### PR TITLE
Update @oasisprotcol/ledger dependency to v0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@ledgerhq/hw-transport-webusb": "6.11.0",
     "@oasisprotocol/client": "0.1.0-alpha7",
-    "@oasisprotocol/ledger": "0.2.0",
+    "@oasisprotocol/ledger": "0.2.1",
     "@reduxjs/toolkit": "1.6.2",
     "base64-arraybuffer": "1.0.1",
     "bech32": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1923,10 +1923,10 @@
     protobufjs "~6.11.2"
     tweetnacl "^1.0.3"
 
-"@oasisprotocol/ledger@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@oasisprotocol/ledger/-/ledger-0.2.0.tgz#f0d0875bcd7c7c0b2369a2f3c2998b377d4bee3f"
-  integrity sha512-5L1LVYyhO2Zne1vEAN854C3qaHfKctyxnjvmq/FRSYzuf4c6YwYuKoCt4OC62T1lWz4toiU7N8QjTM7jI0GuPg==
+"@oasisprotocol/ledger@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@oasisprotocol/ledger/-/ledger-0.2.1.tgz#398a9e126d5c782ef3adc90dfd9128081a717db7"
+  integrity sha512-kisR/b+0qw+zEU7n7dSC2//oQNkiMlxdgID9lOEC8Cxiw6gsMQplHnPmrU6jDCGPP7ugXfM1O0SP7ZfuoimeDA==
   dependencies:
     "@babel/runtime" "^7.9.2"
     "@ledgerhq/hw-transport" "^6.1.0"


### PR DESCRIPTION
This enables support for [Ledger Oasis app](https://github.com/LedgerHQ/app-oasis/) versions 2.x.