### PR TITLE
hotfix: Return empty list of validators, if oasismonitor.com is down

### DIFF
--- a/src/vendors/explorer/apis/AccountsApi.ts
+++ b/src/vendors/explorer/apis/AccountsApi.ts
@@ -381,10 +381,14 @@ export class AccountsApi extends runtime.BaseAPI {
     /**
     */
     async getValidatorsList(requestParameters: GetValidatorsListRequest): Promise<Array<ValidatorRow>> {
+      try {
         const response = await this.getValidatorsListRaw(requestParameters);
         return await response.value();
+      } catch (e) {
+        // TODO: Properly handle this error - should show a warning or so! See #403
+        return [];
+      }
     }
-
 }
 
 /**


### PR DESCRIPTION
Temporary fix for #403.