### PR TITLE
AccountPage: Use wallet balance from oasis node directly instead of explorer

### DIFF
--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -21,7 +21,7 @@ import { TransitionGroup } from 'react-transition-group'
 import { useAccountSlice } from '../../state/account'
 import { selectAccount } from '../../state/account/selectors'
 import { BalanceDetails } from '../../state/account/types'
-import { selectAddress, selectStatus, selectWallets } from '../../state/wallet/selectors'
+import { selectActiveWallet, selectAddress, selectStatus, selectWallets } from '../../state/wallet/selectors'
 import { ActiveDelegationList } from '../StakingPage/Features/DelegationList/ActiveDelegationList'
 import { DebondingDelegationList } from '../StakingPage/Features/DelegationList/DebondingDelegationList'
 import { ValidatorList } from '../StakingPage/Features/ValidatorList'
@@ -79,15 +79,15 @@ export function AccountPage(props: Props) {
   const selectedNetwork = useSelector(selectSelectedNetwork)
   const { active } = useSelector(selectTransaction)
   const wallets = useSelector(selectWallets)
+  const activeWallet = useSelector(selectActiveWallet)
 
   const balanceDelegations = stake.delegations.reduce((acc, v) => acc + Number(v.amount), 0)
-  const balanceDebondingDelegations = stake.debondingDelegations.reduce((acc, v) => acc + Number(v.amount), 0)
   const balance: BalanceDetails = {
-    available: account.liquid_balance ?? 0,
+    available: parseFloat(activeWallet?.balance.available ?? '') ?? 0,
     delegations: balanceDelegations, //@TODO oasis-explorer : account.debonding_delegations_balance ?? 0,
-    debonding: balanceDebondingDelegations, //@TODO oasis-explorer : account.delegations_balance ?? 0,
-    escrow: account.escrow_balance ?? 0,
-    total: (account.liquid_balance ?? 0) + balanceDelegations + balanceDebondingDelegations,
+    debonding: parseFloat(activeWallet?.balance.debonding ?? '') ?? 0, //@TODO oasis-explorer : account.delegations_balance ?? 0,
+    escrow: parseFloat(activeWallet?.balance.escrow ?? '') ?? 0,
+    total: parseFloat(activeWallet?.balance.total ?? '') ?? 0,
   }
 
   // Reload account balances if address or network changes

--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -82,12 +82,13 @@ export function AccountPage(props: Props) {
   const activeWallet = useSelector(selectActiveWallet)
 
   const balanceDelegations = stake.delegations.reduce((acc, v) => acc + Number(v.amount), 0)
+  const balanceDebondingDelegations = stake.debondingDelegations.reduce((acc, v) => acc + Number(v.amount), 0)
   const balance: BalanceDetails = {
-    available: parseFloat(activeWallet?.balance.available ?? '') ?? 0,
+    available: parseFloat(activeWallet?.balance.available ?? '0'), // Use local oasis-node available balance.
     delegations: balanceDelegations, //@TODO oasis-explorer : account.debonding_delegations_balance ?? 0,
-    debonding: parseFloat(activeWallet?.balance.debonding ?? '') ?? 0, //@TODO oasis-explorer : account.delegations_balance ?? 0,
-    escrow: parseFloat(activeWallet?.balance.escrow ?? '') ?? 0,
-    total: parseFloat(activeWallet?.balance.total ?? '') ?? 0,
+    debonding: balanceDebondingDelegations, //@TODO oasis-explorer : account.delegations_balance ?? 0,
+    escrow: account.escrow_balance ?? 0,
+    total: (account.liquid_balance ?? 0) + balanceDelegations + balanceDebondingDelegations,
   }
 
   // Reload account balances if address or network changes


### PR DESCRIPTION
Related to #403 and #407. Currently, the wallet balance is fetched from the block explorer and if the service went down, the balance was 0. This PR uses the balance reported by the local oasis node only.