### PR TITLE
hotfix: Return empty list of validators, if oasismonitor.com is down

### DIFF
--- a/src/vendors/explorer/README.md
+++ b/src/vendors/explorer/README.md
@@ -16,3 +16,8 @@ To update the bindings:
     npx @openapitools/openapi-generator-cli generate -i swagger.yml -g typescript-fetch -o . --additional-properties=modelPropertyNaming=snake_case,typescriptThreePlus=true
     ```
 
+3. Reapply hotfix (commit generated changes first):
+
+    ```sh
+    git cherry-pick 'HEAD^{/^hotfix: Return empty list of validators, if oasismonitor\.com is down}'
+    ```

--- a/src/vendors/explorer/apis/AccountsApi.ts
+++ b/src/vendors/explorer/apis/AccountsApi.ts
@@ -557,10 +557,14 @@ export class AccountsApi extends runtime.BaseAPI {
     /**
      */
     async getValidatorsList(requestParameters: GetValidatorsListRequest): Promise<Array<ValidatorRow>> {
+      try {
         const response = await this.getValidatorsListRaw(requestParameters);
         return await response.value();
+      } catch (e) {
+        // TODO: Properly handle this error - should show a warning or so! See #403
+        return [];
+      }
     }
-
 }
 
 /**


### PR DESCRIPTION
need to reapply from #406 following #426 when we regenerated the API stubs