### PR TITLE
Allow double spaces and newlines in mnemonic

### DIFF
--- a/src/app/components/MnemonicGrid/index.tsx
+++ b/src/app/components/MnemonicGrid/index.tsx
@@ -67,12 +67,10 @@ export function MnemonicGrid({ mnemonic, highlightedIndex: hilightedIndex, hidde
     large: ['1fr', '1fr', '1fr', '1fr'],
   }
 
-  const words = mnemonic!.map(word => word.trim()).filter(word => word !== '')
-
   return (
     <NoTranslate>
       <Grid columns={columns[size]} data-testid="mnemonic-grid">
-        {words.map((word, index) => (
+        {mnemonic.map((word, index) => (
           <MnemonicWord
             key={index + 1}
             id={index + 1}

--- a/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/__snapshots__/index.test.tsx.snap
@@ -133,6 +133,44 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   flex-direction: column;
 }
 
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 6px;
+  background: #11111108;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 6px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-right: 12px;
+}
+
+.c17 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c12 {
   display: inline-block;
   box-sizing: border-box;
@@ -375,6 +413,30 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+  .c15 {
+    margin: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    padding: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c16 {
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
   .c4 {
     margin: 0;
   }
@@ -467,7 +529,35 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
           <div
             class="c14"
             data-testid="mnemonic-grid"
-          />
+          >
+            <div
+              class="c15"
+            >
+              <div
+                class="c16"
+              >
+                <span
+                  class="c17"
+                  style="user-select: none;"
+                >
+                  1
+                  .
+                </span>
+              </div>
+              <div
+                class="c6"
+              >
+                <span
+                  class="notranslate"
+                  translate="no"
+                >
+                  <strong
+                    style="white-space: pre;"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
         </span>
       </div>
     </div>

--- a/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/index.test.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/index.test.tsx
@@ -55,4 +55,14 @@ describe('<FromMnemonic/>', () => {
     userEvent.click(button)
     expect(errorElem).not.toBeInTheDocument()
   })
+
+  it('newlines in mnemonic should be valid', () => {
+    renderPage(store)
+    const textbox = screen.getByRole('textbox')
+    const button = screen.getByRole('button')
+    userEvent.type(textbox, 'echo\ntoward hold   roast\n rather reduce cute civil equal whale wait conduct')
+    userEvent.click(button)
+    const errorElem = screen.queryByText('openWallet.mnemonic.error')
+    expect(errorElem).toBeNull()
+  })
 })

--- a/src/app/pages/OpenWalletPage/Features/FromMnemonic/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromMnemonic/index.tsx
@@ -13,19 +13,19 @@ export function FromMnemonic(props: Props) {
   const walletActions = useWalletSlice().actions
   const dispatch = useDispatch()
 
-  const [mnemonic, setMnemonic] = React.useState('')
+  const [rawMnemonic, setRawMnemonic] = React.useState('')
   const [mnemonicIsValid, setMnemonicIsValid] = React.useState(true)
 
+  const mnemonic = rawMnemonic.trim().replace(/[ \n]+/g, ' ')
   const onChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setMnemonic(event.target.value)
+    setRawMnemonic(event.target.value)
   }
   const onSubmit = () => {
-    const trimmedMnemonic = mnemonic.trim()
-    const isValid = validateMnemonic(trimmedMnemonic)
+    const isValid = validateMnemonic(mnemonic)
     setMnemonicIsValid(isValid)
 
     if (isValid === true) {
-      dispatch(walletActions.openWalletFromMnemonic(trimmedMnemonic))
+      dispatch(walletActions.openWalletFromMnemonic(mnemonic))
     }
   }
 
@@ -65,7 +65,7 @@ export function FromMnemonic(props: Props) {
                     data-testid="mnemonic"
                     placeholder={t('openWallet.mnemonic.enterPhraseHere', 'Enter your keyphrase here')}
                     size="medium"
-                    value={mnemonic}
+                    value={rawMnemonic}
                     onChange={onChange}
                     fill
                   />


### PR DESCRIPTION
Revisits / related to https://github.com/oasisprotocol/oasis-wallet-web/issues/326, https://github.com/oasisprotocol/oasis-wallet-web/pull/331, https://github.com/oasisprotocol/oasis-wallet-web/pull/333.

- This is a stricter version of [#331](https://github.com/oasisprotocol/oasis-wallet-web/pull/331) `/\s/` == `\f\n\r\t\v\u00A0\u2028\u2029`
- I don't like that double-spaces are invalid. Meanwhile, MnemonicGrid was already showing double-space as if it was valid, but submitting it failed.
- And writing whole mnemonic with newlines should have a meaningful validation warning, but converting it just seems easier.
