### PR TITLE
OpenWallet: Make "Ledger" button responsive the same as others

### DIFF
--- a/src/app/pages/OpenWalletPage/index.tsx
+++ b/src/app/pages/OpenWalletPage/index.tsx
@@ -4,7 +4,7 @@
  *
  */
 import { TransitionRoute } from 'app/components/TransitionRoute'
-import { Anchor, Box, Button, Heading } from 'grommet'
+import { Anchor, Box, Button, Heading, Text } from 'grommet'
 import * as React from 'react'
 import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
@@ -47,15 +47,17 @@ export function SelectOpenMethod() {
             primary
           />
         </NavLink>
-        <Button
-          type="submit"
-          label={t('openWallet.method.ledger', 'Ledger')}
-          style={{ borderRadius: '4px' }}
-          onClick={() => {
-            showLedgerModal(true)
-          }}
-          primary
-        />
+        <Text>
+          <Button
+            type="submit"
+            label={t('openWallet.method.ledger', 'Ledger')}
+            style={{ borderRadius: '4px' }}
+            onClick={() => {
+              showLedgerModal(true)
+            }}
+            primary
+          />
+        </Text>
 
         {ledgerModal && (
           <FromLedger


### PR DESCRIPTION
Ledger button was not inlined before so it stretched horizontally on smaller screens. This PR makes it inline using the `Text` grommet component.

| Before | After |
|----------|--------|
| ![image](https://user-images.githubusercontent.com/83672/145394669-815b9325-2ccd-4c06-9dd9-17814d8c76d9.png) | ![image](https://user-images.githubusercontent.com/83672/145394341-0d9f226c-f660-49fe-bf63-425942e1b44b.png) |