### PR TITLE
OpenWallet: Update link to BitPie FAQ page

### DIFF
--- a/src/app/pages/OpenWalletPage/index.tsx
+++ b/src/app/pages/OpenWalletPage/index.tsx
@@ -79,9 +79,7 @@ export function SelectOpenMethod() {
           i18nKey="openWallet.bitpie.warning"
           t={t}
           defaults="❗ BitPie wallet users: You cannot import the mnemonic phrase directly from your BitPie wallet. <0>Check documentation for details.</0>"
-          components={[
-            <Anchor href="https://docs.oasis.dev/general/manage-tokens/oasis-wallets#how-can-i-transfer-rose-tokens-from-my-bitpie-wallet-to-my-oasis-wallet" />,
-          ]}
+          components={[<Anchor href="https://docs.oasis.dev/general/manage-tokens/faq" />]}
         />
       </Box>
     </Box>


### PR DESCRIPTION
Oasis Web Wallet issues have been moved to a more common FAQ page at https://docs.oasis.dev/general/manage-tokens/faq. This PR updates the link in the BitPie warning.