### PR TITLE
i18n: Add missing full stop, base-64 -> Base64

### DIFF
--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -335,7 +335,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
       <p
         class="c3"
       >
-        Enter your base-64 encoded private key
+        Enter your private key in Base64 format.
       </p>
       <div
         class="c4 "

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
@@ -53,7 +53,7 @@ export function FromPrivateKey(props: Props) {
       <Form>
         <Heading margin="0">{t('openWallet.privateKey.header', 'Enter your private key')}</Heading>
         <Paragraph>
-          {t('openWallet.privateKey.instruction', 'Enter your base-64 encoded private key')}
+          {t('openWallet.privateKey.instruction', 'Enter your private key in Base64 format.')}
         </Paragraph>
         <FormField
           htmlFor="privateKey"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -33,7 +33,7 @@
     },
     "privateKey": {
       "header": "Enter your private key",
-      "instruction": "Enter your base-64 encoded private key",
+      "instruction": "Enter your private key in Base64 format.",
       "error": "Invalid private key",
       "enterPrivateKeyHere": "Enter your private key here"
     },


### PR DESCRIPTION
This PR fixes the import base64-encoded private key term in the original English translation.