### PR TITLE
Fix validator logos reloading on expand

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
   "jest.showCoverageOnLoad": true,
   "typescriptHero.imports.insertSemicolons": false,
   "files.exclude": {
+    "**/__snapshots__/": true,
     "cypress-coverage/": true,
     "build/": true
   }

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
@@ -520,9 +520,9 @@ Object {
                   >
                     <img
                       alt=""
-                      height="16px"
+                      class="logotype-small"
+                      loading="lazy"
                       src="/logo192.png"
-                      width="16px"
                     />
                   </div>
                   <div
@@ -721,9 +721,9 @@ Object {
                 >
                   <img
                     alt=""
-                    height="16px"
+                    class="logotype-small"
+                    loading="lazy"
                     src="/logo192.png"
-                    width="16px"
                   />
                 </div>
                 <div

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
@@ -509,13 +509,13 @@ Object {
               >
                 <div
                   class="c14 rdt_TableRow"
-                  id="row-0"
+                  id="row-test-validator"
                   role="row"
                 >
                   <div
                     class="c15 c8 c16 rdt_TableCell"
                     data-tag="allowRowEvents"
-                    id="cell-icon-undefined"
+                    id="cell-icon-test-validator"
                     role="gridcell"
                   >
                     <img
@@ -528,7 +528,7 @@ Object {
                   <div
                     class="c15 c8 c16 rdt_TableCell"
                     data-tag="allowRowEvents"
-                    id="cell-status-undefined"
+                    id="cell-status-test-validator"
                     role="gridcell"
                   >
                     <svg
@@ -547,7 +547,7 @@ Object {
                   <div
                     class="c15 c9 c16 rdt_TableCell"
                     data-tag="allowRowEvents"
-                    id="cell-name-undefined"
+                    id="cell-name-test-validator"
                     role="gridcell"
                   >
                     test-validator
@@ -555,7 +555,7 @@ Object {
                   <div
                     class="c15 c9 c16 rdt_TableCell"
                     data-tag="allowRowEvents"
-                    id="cell-amount-undefined"
+                    id="cell-amount-test-validator"
                     role="gridcell"
                   >
                     0.0
@@ -565,7 +565,7 @@ Object {
                   <div
                     class="c15 c12 c16 rdt_TableCell"
                     data-tag="allowRowEvents"
-                    id="cell-fee-undefined"
+                    id="cell-fee-test-validator"
                     role="gridcell"
                   >
                     7.000000000000001%
@@ -710,13 +710,13 @@ Object {
             >
               <div
                 class="sc-jrAFXE XoGWB rdt_TableRow"
-                id="row-0"
+                id="row-test-validator"
                 role="row"
               >
                 <div
                   class="sc-hKgJUU sc-eCstlR sc-jSgvzq iFEPIi eceSDa gSqEps rdt_TableCell"
                   data-tag="allowRowEvents"
-                  id="cell-icon-undefined"
+                  id="cell-icon-test-validator"
                   role="gridcell"
                 >
                   <img
@@ -729,7 +729,7 @@ Object {
                 <div
                   class="sc-hKgJUU sc-eCstlR sc-jSgvzq iFEPIi eceSDa gSqEps rdt_TableCell"
                   data-tag="allowRowEvents"
-                  id="cell-status-undefined"
+                  id="cell-status-test-validator"
                   role="gridcell"
                 >
                   <svg
@@ -748,7 +748,7 @@ Object {
                 <div
                   class="sc-hKgJUU sc-eCstlR sc-jSgvzq iFEPIi iurrS gSqEps rdt_TableCell"
                   data-tag="allowRowEvents"
-                  id="cell-name-undefined"
+                  id="cell-name-test-validator"
                   role="gridcell"
                 >
                   test-validator
@@ -756,7 +756,7 @@ Object {
                 <div
                   class="sc-hKgJUU sc-eCstlR sc-jSgvzq iFEPIi iurrS gSqEps rdt_TableCell"
                   data-tag="allowRowEvents"
-                  id="cell-amount-undefined"
+                  id="cell-amount-test-validator"
                   role="gridcell"
                 >
                   0.0
@@ -766,7 +766,7 @@ Object {
                 <div
                   class="sc-hKgJUU sc-eCstlR sc-jSgvzq iFEPIi hSZcZi gSqEps rdt_TableCell"
                   data-tag="allowRowEvents"
-                  id="cell-fee-undefined"
+                  id="cell-fee-test-validator"
                   role="gridcell"
                 >
                   7.000000000000001%

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
@@ -465,13 +465,13 @@ Object {
               >
                 <div
                   class="c13 rdt_TableRow"
-                  id="row-0"
+                  id="row-test-validator"
                   role="row"
                 >
                   <div
                     class="c14 c8 c15 rdt_TableCell"
                     data-tag="allowRowEvents"
-                    id="cell-icon-undefined"
+                    id="cell-icon-test-validator"
                     role="gridcell"
                   >
                     <img
@@ -484,7 +484,7 @@ Object {
                   <div
                     class="c14 c9 c15 rdt_TableCell"
                     data-tag="allowRowEvents"
-                    id="cell-name-undefined"
+                    id="cell-name-test-validator"
                     role="gridcell"
                   >
                     test-validator
@@ -492,7 +492,7 @@ Object {
                   <div
                     class="c14 c9 c15 rdt_TableCell"
                     data-tag="allowRowEvents"
-                    id="cell-amount-undefined"
+                    id="cell-amount-test-validator"
                     role="gridcell"
                   >
                     0.0
@@ -502,7 +502,7 @@ Object {
                   <div
                     class="c14 c9 c16 rdt_TableCell"
                     data-tag="allowRowEvents"
-                    id="cell-epoch-undefined"
+                    id="cell-epoch-test-validator"
                     role="gridcell"
                   >
                     <div
@@ -648,13 +648,13 @@ Object {
             >
               <div
                 class="sc-jrAFXE XoGWB rdt_TableRow"
-                id="row-0"
+                id="row-test-validator"
                 role="row"
               >
                 <div
                   class="sc-hKgJUU sc-eCstlR sc-jSgvzq iFEPIi eceSDa gSqEps rdt_TableCell"
                   data-tag="allowRowEvents"
-                  id="cell-icon-undefined"
+                  id="cell-icon-test-validator"
                   role="gridcell"
                 >
                   <img
@@ -667,7 +667,7 @@ Object {
                 <div
                   class="sc-hKgJUU sc-eCstlR sc-jSgvzq iFEPIi iurrS gSqEps rdt_TableCell"
                   data-tag="allowRowEvents"
-                  id="cell-name-undefined"
+                  id="cell-name-test-validator"
                   role="gridcell"
                 >
                   test-validator
@@ -675,7 +675,7 @@ Object {
                 <div
                   class="sc-hKgJUU sc-eCstlR sc-jSgvzq iFEPIi iurrS gSqEps rdt_TableCell"
                   data-tag="allowRowEvents"
-                  id="cell-amount-undefined"
+                  id="cell-amount-test-validator"
                   role="gridcell"
                 >
                   0.0
@@ -685,7 +685,7 @@ Object {
                 <div
                   class="sc-hKgJUU sc-eCstlR sc-jSgvzq iFEPIi iurrS iCHCMz rdt_TableCell"
                   data-tag="allowRowEvents"
-                  id="cell-epoch-undefined"
+                  id="cell-epoch-test-validator"
                   role="gridcell"
                 >
                   <div

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
@@ -476,9 +476,9 @@ Object {
                   >
                     <img
                       alt=""
-                      height="16px"
+                      class="logotype-small"
+                      loading="lazy"
                       src="/logo192.png"
-                      width="16px"
                     />
                   </div>
                   <div
@@ -659,9 +659,9 @@ Object {
                 >
                   <img
                     alt=""
-                    height="16px"
+                    class="logotype-small"
+                    loading="lazy"
                     src="/logo192.png"
-                    width="16px"
                   />
                 </div>
                 <div

--- a/src/app/pages/StakingPage/Features/DelegationList/index.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/index.tsx
@@ -136,6 +136,7 @@ export const DelegationList = memo((props: Props) => {
       noHeader={true}
       columns={columns}
       data={delegations}
+      keyField="validatorAddress"
       style={{}}
       customStyles={dataTableStyles}
       expandableRowsHideExpander

--- a/src/app/pages/StakingPage/Features/DelegationList/index.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/index.tsx
@@ -13,10 +13,10 @@ import { selectActiveWallet } from 'app/state/wallet/selectors'
 import { Text } from 'grommet'
 import { Down, StatusCritical, StatusGood } from 'grommet-icons'
 import React, { memo } from 'react'
-import DataTable, { IDataTableColumn } from 'react-data-table-component'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { dataTableStyles } from 'styles/theme/ThemeProvider'
+import { TypeSafeDataTable, ITypeSafeDataTableColumn } from 'types/TypeSafeDataTable'
 
 import { DelegationItem } from './DelegationItem'
 
@@ -54,7 +54,7 @@ export const DelegationList = memo((props: Props) => {
   // All possible columns
   const columnTypes: Record<
     'icon' | 'status' | 'name' | 'amount' | 'fee' | 'epoch',
-    IDataTableColumn<Delegation>
+    ITypeSafeDataTableColumn<Delegation>
   > = {
     icon: {
       name: '',
@@ -132,7 +132,7 @@ export const DelegationList = memo((props: Props) => {
       : [columnTypes.icon, columnTypes.name, columnTypes.amount, columnTypes.epoch]
 
   return (
-    <DataTable
+    <TypeSafeDataTable
       noHeader={true}
       columns={columns}
       data={delegations}

--- a/src/app/pages/StakingPage/Features/DelegationList/index.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/index.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { dataTableStyles } from 'styles/theme/ThemeProvider'
 import { TypeSafeDataTable, ITypeSafeDataTableColumn } from 'types/TypeSafeDataTable'
+import { isWebUri } from 'valid-url'
 
 import { DelegationItem } from './DelegationItem'
 
@@ -59,7 +60,18 @@ export const DelegationList = memo((props: Props) => {
     icon: {
       name: '',
       id: 'icon',
-      cell: datum => <img src={process.env.PUBLIC_URL + '/logo192.png'} height="16px" width="16px" alt="" />,
+      cell: datum => (
+        <img
+          src={
+            datum.validator?.media?.logotype && isWebUri(datum.validator?.media.logotype)
+              ? datum.validator?.media.logotype
+              : process.env.PUBLIC_URL + '/logo192.png'
+          }
+          loading="lazy"
+          className={'logotype-small'}
+          alt=""
+        />
+      ),
       width: '34px',
     },
     status: {

--- a/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
@@ -52,6 +52,7 @@ export const ValidatorList = memo((props: Props) => {
   const columns: IDataTableColumn<Validator>[] = [
     {
       name: '',
+      id: 'icon',
       cell: datum => (
         <img
           src={
@@ -68,6 +69,7 @@ export const ValidatorList = memo((props: Props) => {
     },
     {
       name: '',
+      id: 'status',
       cell: datum =>
         datum.status === 'active' ? (
           <StatusGood color="status-ok" />
@@ -78,6 +80,7 @@ export const ValidatorList = memo((props: Props) => {
     },
     {
       name: t('validator.name', 'Name'),
+      id: 'name',
       selector: 'name',
       cell: datum =>
         datum.name ?? (
@@ -90,6 +93,7 @@ export const ValidatorList = memo((props: Props) => {
     },
     {
       name: t('validator.escrow', 'Escrow'),
+      id: 'escrow',
       selector: 'escrow',
       hide: 'sm',
       cell: datum =>
@@ -101,6 +105,7 @@ export const ValidatorList = memo((props: Props) => {
     },
     {
       name: t('validator.fee', 'Fee'),
+      id: 'fee',
       selector: 'fee',
       sortable: true,
       width: '110px',
@@ -123,6 +128,7 @@ export const ValidatorList = memo((props: Props) => {
         noHeader={true}
         columns={columns}
         data={validators}
+        keyField="address"
         style={{}}
         customStyles={dataTableStyles}
         expandableRowsHideExpander

--- a/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
@@ -59,6 +59,7 @@ export const ValidatorList = memo((props: Props) => {
               ? datum.media.logotype
               : process.env.PUBLIC_URL + '/logo192.png'
           }
+          loading="lazy"
           className={'logotype-small'}
           alt=""
         />

--- a/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
@@ -18,10 +18,10 @@ import { selectStatus } from 'app/state/wallet/selectors'
 import { Box, Text } from 'grommet'
 import { Down, StatusCritical, StatusGood } from 'grommet-icons/icons'
 import React, { memo } from 'react'
-import DataTable, { IDataTableColumn } from 'react-data-table-component'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { dataTableStyles } from 'styles/theme/ThemeProvider'
+import { TypeSafeDataTable, ITypeSafeDataTableColumn } from 'types/TypeSafeDataTable'
 import { isWebUri } from 'valid-url'
 
 import { ValidatorItem } from './ValidatorItem'
@@ -49,7 +49,7 @@ export const ValidatorList = memo((props: Props) => {
     }
   }
 
-  const columns: IDataTableColumn<Validator>[] = [
+  const columns: ITypeSafeDataTableColumn<Validator>[] = [
     {
       name: '',
       id: 'icon',
@@ -124,7 +124,7 @@ export const ValidatorList = memo((props: Props) => {
           {updateValidatorsError}
         </p>
       )}
-      <DataTable
+      <TypeSafeDataTable
         noHeader={true}
         columns={columns}
         data={validators}

--- a/src/types/TypeSafeDataTable.tsx
+++ b/src/types/TypeSafeDataTable.tsx
@@ -1,0 +1,18 @@
+import DataTable, { IDataTableColumn, IDataTableProps } from 'react-data-table-component'
+
+export interface ITypeSafeDataTableColumn<T> extends IDataTableColumn<T> {
+  id: string
+}
+export interface ITypeSafeDataTableProps<T> extends Omit<IDataTableProps<T>, 'keyField'> {
+  keyField: keyof T
+  columns: ITypeSafeDataTableColumn<T>[]
+}
+
+/**
+ * Overrides DataTable type to ensure:
+ * - `keyField` on rows is not missing and is valid
+ * - `id` on cols is not missing
+ */
+export function TypeSafeDataTable<T = any>(props: ITypeSafeDataTableProps<T>): React.ReactElement {
+  return <DataTable {...(props as IDataTableProps<T>)} />
+}


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-wallet-web/issues/544
Related https://github.com/oasisprotocol/oasis-wallet-web/pull/457

- Added native lazy loading to logos
- All validator rows were destroyed and recreated because `keyField` on rows and `id` on cols were missing
- Show validator logos in DelegationList
