### PR TITLE
Hide private key by default when importing wallet

### DIFF
--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<FromPrivateKey  /> should match snapshot 1`] = `
+.c10 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c10 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c10 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -29,11 +63,14 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   margin-bottom: 12px;
+  border: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  width: 768px;
+  border-radius: 12px;
 }
 
 .c5 {
@@ -60,12 +97,13 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   max-width: 100%;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  border-radius: 12px;
 }
 
-.c8 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -81,7 +119,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   padding-bottom: 24px;
 }
 
-.c9 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -100,7 +138,67 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c10 {
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -129,47 +227,47 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   font-weight: bold;
 }
 
-.c10:hover {
+.c13:hover {
   box-shadow: 0px 0px 0px 2px #0092f6;
 }
 
-.c10:focus {
+.c13:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c13:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -179,6 +277,75 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   line-height: 56px;
   max-width: 1200px;
   font-weight: 600;
+}
+
+.c8 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  outline: none;
+  border: none;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c8::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c8:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c8::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c8::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
+  opacity: 1;
+}
+
+.c7 {
+  position: relative;
+  width: 100%;
 }
 
 .c0 {
@@ -198,68 +365,6 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
-  color: #AAAAAA;
-}
-
-.c7::-moz-placeholder {
-  color: #AAAAAA;
-}
-
-.c7:-ms-input-placeholder {
-  color: #AAAAAA;
-}
-
-.c7::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-.c7::-moz-focus-inner {
-  border: none;
-  outline: none;
-}
-
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
-  opacity: 1;
 }
 
 @media only screen and (max-width:768px) {
@@ -287,20 +392,38 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+  .c4 {
+    border: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    border-radius: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
   .c5 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c6 {
+    border-radius: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
     padding-top: 12px;
     padding-bottom: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c12 {
     margin-top: 12px;
   }
 }
@@ -335,7 +458,11 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
       <p
         class="c3"
       >
-        Enter your private key in Base64 format.
+        <label
+          for="privatekey"
+        >
+          Enter your private key in Base64 format.
+        </label>
       </p>
       <div
         class="c4 "
@@ -346,23 +473,47 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
           <div
             class="c6"
           >
-            <textarea
+            <div
               class="c7"
-              data-testid="privatekey"
-              id="privatekey"
-              placeholder="Enter your private key here"
-            />
+            >
+              <input
+                autocomplete="off"
+                class="c8"
+                data-testid="privatekey"
+                id="privatekey"
+                placeholder="Enter your private key here"
+                type="password"
+                value=""
+              />
+            </div>
+            <button
+              class="c9"
+              type="button"
+            >
+              <svg
+                aria-label="Hide"
+                class="c10"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 17c-2.727 0-6-2.778-6-5s3.273-5 6-5 6 2.778 6 5-3.273 5-6 5zm-1-5a1 1 0 1 0 2 0 1 1 0 0 0-2 0zm9-7L4 19"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
           </div>
         </div>
       </div>
       <div
-        class="c8"
+        class="c11"
       >
         <div
-          class="c9"
+          class="c12"
         >
           <button
-            class="c10"
+            class="c13"
             style="border-radius: 4px;"
             type="submit"
           >

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  width: 768px;
+  width: 1152px;
   border-radius: 12px;
 }
 
@@ -95,12 +95,15 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  border-radius: 12px;
 }
 
 .c11 {
@@ -406,12 +409,6 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
 @media only screen and (max-width:768px) {
   .c5 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    border-radius: 6px;
   }
 }
 

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -80,7 +80,6 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -403,12 +402,6 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
 @media only screen and (max-width:768px) {
   .c4 {
     border-radius: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/index.test.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/index.test.tsx
@@ -30,8 +30,8 @@ describe('<FromPrivateKey  />', () => {
 
   it('should display an error on invalid private key', () => {
     renderPage(store)
-    const textbox = screen.getByRole('textbox')
-    const button = screen.getByRole('button')
+    const textbox = screen.getByLabelText(/Enter your private key/)
+    const button = screen.getByRole('button', { name: /Open my wallet/ })
     userEvent.type(textbox, 'hello')
     userEvent.click(button)
     const errorElem = screen.getByText(/Invalid private key/)

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/index.test.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/index.test.tsx
@@ -38,12 +38,29 @@ describe('<FromPrivateKey  />', () => {
     expect(errorElem).toBeInTheDocument()
 
     // A valid phrase should remove the error
-    textbox.setSelectionRange(0, 5)
+    userEvent.clear(textbox)
     userEvent.type(
       textbox,
       'X0jlpvskP1q8E6rHxWRJr7yTvpCuOPEKBGW8gtuVTxfnViTI0s2fBizgMxNzo75Q7w7MxdJXtOLeqDoFUGxxMg==',
     )
     userEvent.click(button)
+    expect(errorElem).not.toBeInTheDocument()
+  })
+
+  it('should allow multiline private keys with envelope', async () => {
+    renderPage(store)
+    const textbox = screen.getByLabelText(/Enter your private key/)
+    const button = screen.getByRole('button', { name: /Open my wallet/ })
+    userEvent.type(
+      textbox,
+      `
+      -----BEGIN ED25519 PRIVATE KEY-----
+      ZqtrV0QtEY/JemfTPbOl9hgk3UxHXfZO42G4sG+XKHThZTM+GvRiqsAgc7magKNN
+      4MEkyO0pi7lJeunILQKiZA==
+      -----END ED25519 PRIVATE KEY-----`,
+    )
+    userEvent.click(button)
+    const errorElem = screen.queryByText(/Invalid private key/)
     expect(errorElem).not.toBeInTheDocument()
   })
 })

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
@@ -1,5 +1,6 @@
 import { useWalletSlice } from 'app/state/wallet'
-import { Box, Form, Heading, Paragraph, FormField, TextArea, Button } from 'grommet'
+import { Box, Form, Heading, Paragraph, FormField, Button, TextInput, Tip } from 'grommet'
+import { View, Hide } from 'grommet-icons'
 import { decode } from 'base64-arraybuffer'
 import * as React from 'react'
 import { useDispatch } from 'react-redux'
@@ -12,9 +13,10 @@ interface Props {}
 const parseKey = (key: string) => {
   try {
     const keyWithoutEnvelope = key
-      .replace(/^-----.*$\n?/gm, '')
       .replace(/\n/gm, '')
       .replace(/ /g, '')
+      .replace(/^-----.*?-----/, '')
+      .replace(/-----.*?-----$/, '')
 
     const key_bytes = decode(keyWithoutEnvelope)
     return OasisKey.fromPrivateKey(new Uint8Array(key_bytes))
@@ -30,6 +32,7 @@ export function FromPrivateKey(props: Props) {
 
   const [privateKey, setPrivateKey] = React.useState('')
   const [privateKeyIsValid, setPrivateKeyIsValid] = React.useState(true)
+  const [privateKeyIsVisible, setPrivateKeyIsVisible] = React.useState(false)
 
   const onChange = event => setPrivateKey(event.target.value)
   const onSubmit = () => {
@@ -53,20 +56,39 @@ export function FromPrivateKey(props: Props) {
       <Form>
         <Heading margin="0">{t('openWallet.privateKey.header', 'Enter your private key')}</Heading>
         <Paragraph>
-          {t('openWallet.privateKey.instruction', 'Enter your private key in Base64 format.')}
+          <label htmlFor="privatekey">
+            {t('openWallet.privateKey.instruction', 'Enter your private key in Base64 format.')}
+          </label>
         </Paragraph>
         <FormField
           htmlFor="privateKey"
           error={privateKeyIsValid === false ? t('openWallet.privateKey.error', 'Invalid private key') : ''}
+          border
+          round="small"
+          width="large"
         >
-          <Box border={false}>
-            <TextArea
+          <Box border={false} direction="row" round="small">
+            <TextInput
               id="privatekey"
               data-testid="privatekey"
               placeholder={t('openWallet.privateKey.enterPrivateKeyHere', 'Enter your private key here')}
               value={privateKey}
               onChange={onChange}
+              type={privateKeyIsVisible ? 'text' : 'password'}
+              plain
             />
+            <Tip
+              content={
+                privateKeyIsVisible
+                  ? t('openWallet.privateKey.hidePrivateKey', 'Hide private key')
+                  : t('openWallet.privateKey.showPrivateKey', 'Show private key')
+              }
+            >
+              <Button
+                onClick={() => setPrivateKeyIsVisible(!privateKeyIsVisible)}
+                icon={privateKeyIsVisible ? <View /> : <Hide />}
+              />
+            </Tip>
           </Box>
         </FormField>
         <Box pad={{ vertical: 'medium' }}>

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
@@ -65,9 +65,9 @@ export function FromPrivateKey(props: Props) {
           error={privateKeyIsValid === false ? t('openWallet.privateKey.error', 'Invalid private key') : ''}
           border
           round="small"
-          width="large"
+          width="xlarge"
         >
-          <Box border={false} direction="row" round="small">
+          <Box direction="row" align="center">
             <TextInput
               id="privatekey"
               data-testid="privatekey"

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
@@ -64,6 +64,7 @@ export function FromPrivateKey(props: Props) {
           htmlFor="privateKey"
           error={privateKeyIsValid === false ? t('openWallet.privateKey.error', 'Invalid private key') : ''}
           border
+          contentProps={{ border: privateKeyIsValid ? false : 'bottom' }}
           round="small"
           width="xlarge"
         >

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -35,7 +35,9 @@
       "header": "Enter your private key",
       "instruction": "Enter your private key in Base64 format.",
       "error": "Invalid private key",
-      "enterPrivateKeyHere": "Enter your private key here"
+      "enterPrivateKeyHere": "Enter your private key here",
+      "hidePrivateKey": "Hide private key",
+      "showPrivateKey": "Show private key"
     },
     "ledger": {
       "selectWallets": "Select the wallets to open",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -35,7 +35,9 @@
       "header": "Entrez votre clé privée",
       "instruction": "Entrez votre clé privée au format base64 ci-dessous.",
       "error": "Clé privée invalide",
-      "enterPrivateKeyHere": "Entrez votre clé privée ici"
+      "enterPrivateKeyHere": "Entrez votre clé privée ici",
+      "hidePrivateKey": "Masquer la clé privée",
+      "showPrivateKey": "Montrer la clé privée"
     },
     "ledger": {
       "selectWallets": "Sélectionnez les portefeuilles à ouvrir",


### PR DESCRIPTION
# Motivation
When accessing the web wallet, the user has to re-authenticate often by either inputting the mnemonic, or private key. Since private keys are especially sensitive and often copied from a password manager (where they are hidden), I found myself wanting to keep the private key hidden during import into the web wallet as well. 

# Previous Behaviour
The private key was entered into a text area which displayed the private key to the user.

# New Behaviour
The private key is entered into a text input which hides the private key by default. The user can choose to show the private key by clicking a button beside the text input.

# Changes
- Changed `TextArea` to `TextInput` to allow input to be classified as a password and hidden
- Added a hide/show private key toggle to the `TextInput`
- Updated jest snapshot to reflect changes
- Updated English and French localization (please verify, French is not my first language!)

# Screenshots
Before:
![image](https://user-images.githubusercontent.com/71935095/148041624-51adc72f-aa3f-4bfe-9c60-43f16e22be04.png)
After: 
![image](https://user-images.githubusercontent.com/71935095/148041679-96313853-cac0-4714-b2cc-55d964be4dda.png)
![image](https://user-images.githubusercontent.com/71935095/148041730-5021b67a-817e-442c-8eeb-edee325430d1.png)

# Additional comments
This can potentially be extended to include hiding the mnemonic input too, as entering the mnemonic may take longer than the private key, leaving it exposed for longer, if the user chooses to input it by hand. 