### PR TITLE
locales/en: correct validator loading error

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -114,7 +114,7 @@
       "reclaim": "Reclaim"
     },
     "validator": {
-      "loadingError": "Couldn't load transactions. List may be empty or out of date."
+      "loadingError": "Couldn't load validators. List may be empty or out of date."
     }
   },
   "common": {


### PR DESCRIPTION
this is actually coming up a lot, with a problem on the validators API that we use. the error message incorrectly said "transactions" instead of "validators"