### PR TITLE
Send transaction confirmation dialog

### DIFF
--- a/src/app/components/Modal/index.tsx
+++ b/src/app/components/Modal/index.tsx
@@ -1,0 +1,73 @@
+import { createContext, useCallback, useContext, useState } from 'react'
+import { Box, Button, Layer, Heading, Paragraph } from 'grommet'
+import { useTranslation } from 'react-i18next'
+
+interface Modal {
+  handleConfirm: () => void
+  description: string
+  title: string
+  isDangerous: boolean
+}
+
+interface ModalContainerProps {
+  modal: Modal
+  closeModal: () => void
+}
+
+interface ModalContextProps {
+  launchModal: (modal: Modal) => void
+  closeModal: () => void
+}
+
+const ModalContext = createContext<ModalContextProps>({} as ModalContextProps)
+
+const ModalContainer = ({ modal, closeModal }: ModalContainerProps) => {
+  const { t } = useTranslation()
+  const confirm = useCallback(() => {
+    modal.handleConfirm()
+    closeModal()
+  }, [closeModal, modal])
+
+  return (
+    <Layer onEsc={closeModal} onClickOutside={closeModal} background="background-front">
+      <Heading margin="medium" size="small">
+        {modal.title}
+      </Heading>
+      <Paragraph margin="medium">{modal.description}</Paragraph>
+      <Box justify="between" margin="medium" direction="row">
+        <Button label={t('common.cancel')} onClick={closeModal} />
+        <Button
+          label={t('common.confirm')}
+          onClick={confirm}
+          primary={modal.isDangerous}
+          color={modal.isDangerous ? 'status-error' : ''}
+        />
+      </Box>
+    </Layer>
+  )
+}
+
+const ModalProvider = props => {
+  const [modal, setModal] = useState<Modal | null>(null)
+  const closeModal = useCallback(() => {
+    setModal(null)
+  }, [])
+
+  return (
+    <ModalContext.Provider value={{ closeModal, launchModal: setModal }} {...props}>
+      {props.children}
+      {modal && <ModalContainer modal={modal} closeModal={closeModal} />}
+    </ModalContext.Provider>
+  )
+}
+
+const useModal = () => {
+  const context = useContext(ModalContext)
+  if (context === undefined) {
+    throw new Error('useModal must be used within a ModalProvider')
+  }
+
+  return context
+}
+
+export { ModalProvider, useModal }

--- a/src/app/pages/AccountPage/Features/SendTransaction/__tests__/index.test.tsx
+++ b/src/app/pages/AccountPage/Features/SendTransaction/__tests__/index.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { configureAppStore } from 'store/configureStore'
+import { SendTransaction } from '..'
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => {
+    return {
+      t: str => str,
+      i18n: {
+        changeLanguage: () => new Promise(() => {}),
+      },
+    }
+  },
+}))
+
+const renderComponent = store =>
+  render(
+    <Provider store={store}>
+      <SendTransaction />
+    </Provider>,
+  )
+
+describe('<SendTransaction />', () => {
+  let store: ReturnType<typeof configureAppStore>
+
+  beforeEach(() => {
+    store = configureAppStore()
+  })
+
+  it('should dispatch sendTransaction action on submit', () => {
+    const spy = jest.spyOn(store, 'dispatch')
+    renderComponent(store)
+
+    userEvent.type(screen.getByPlaceholderText('account.sendTransaction.enterAddress'), 'walletAddress')
+    userEvent.type(screen.getByPlaceholderText('0'), '10')
+    userEvent.click(screen.getByRole('button'))
+
+    expect(spy).toHaveBeenCalledWith({
+      payload: {
+        amount: 10,
+        to: 'walletAddress',
+        type: 'transfer',
+      },
+      type: 'transaction/sendTransaction',
+    })
+  })
+})

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ import { HelmetProvider } from 'react-helmet-async'
 import { configureAppStore } from 'store/configureStore'
 
 import { ThemeProvider } from 'styles/theme/ThemeProvider'
+import { ModalProvider } from './app/components/Modal'
 
 import reportWebVitals from 'reportWebVitals'
 
@@ -49,7 +50,9 @@ ReactDOM.render(
     <ThemeProvider>
       <HelmetProvider>
         <React.StrictMode>
-          <App />
+          <ModalProvider>
+            <App />
+          </ModalProvider>
         </React.StrictMode>
       </HelmetProvider>
     </ThemeProvider>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -89,6 +89,10 @@
       "designation": "Other address"
     },
     "sendTransaction": {
+      "confirmSendingToValidator": {
+        "description": "This is a validator wallet address. Transfers to this address do not stake your funds with the validator.",
+        "title": "Are you sure you want to continue?"
+      },
       "recipient": "Recipient",
       "enterAddress": "Enter an address",
       "success": "Transaction successfully sent. The transaction might take up to a minute to appear on your account.",
@@ -121,6 +125,7 @@
     "delegator": "Delegator",
     "validator": "Validator",
     "cancel": "Cancel",
+    "confirm": "Confirm",
     "validators": "Validators"
   },
   "errors": {


### PR DESCRIPTION
Targets #567 

- add ability to run dialogs (I hope I did not reinvent a wheel)
- I wasn't able to add proper component tests. I cannot pass anything to store via configureAppStore due to injected reducers pattern (probably). This throws warnings in other places as well, but due to --silent flag it's not visible. Dispatching `updateValidators` did not resolve that issue. I am missing something probably 🤷‍♂️ 

<img width="865" alt="Screenshot 2022-01-11 at 17 03 05" src="https://user-images.githubusercontent.com/891392/148977944-6bf6c0f1-307f-4994-aa66-bb34b0d314d1.png">

