### PR TITLE
Clone bounds before sorting (fixes error mutating readonly props)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
   "typescriptHero.imports.insertSemicolons": false,
   "files.exclude": {
     "**/__snapshots__/": true,
+    ".nyc_output/": true,
     "cypress-coverage/": true,
     "build/": true
   }

--- a/src/app/pages/StakingPage/Features/CommissionBounds/index.tsx
+++ b/src/app/pages/StakingPage/Features/CommissionBounds/index.tsx
@@ -56,6 +56,8 @@ export const CommissionBounds = memo((props: Props) => {
 
   if (props.bounds && props.bounds.length > 0) {
     const items = props.bounds
+      // Always clone before sort so it doesn't mutate source
+      .slice()
       .sort((a, b) => a.epochStart - b.epochStart)
       .map((b, i) => <CommissionBound bound={b} key={i} />)
     return <>{items}</>

--- a/src/app/state/staking/saga.ts
+++ b/src/app/state/staking/saga.ts
@@ -96,6 +96,8 @@ function* refreshValidators() {
   const currentEpoch = yield* select(selectEpoch)
 
   const payload: Validator[] = validators
+    // Always clone before sort so it doesn't mutate source
+    .slice()
     .sort((a, b) => b.escrow_balance - a.escrow_balance)
     .map((v, index) => {
       return {
@@ -119,6 +121,8 @@ function computeCurrentRate(currentEpoch: number, rawRates: ValidatorCommissionS
       epochStart: r.start ? Number(r.start) : 0,
       rate: Number(r.rate!) / 100_000,
     }))
+    // Always clone before sort so it doesn't mutate source
+    .slice()
     .sort((a, b) => a.epochStart - b.epochStart)
     // If we have another bound after this one, attach the epochEnd to this one
     .map((b, i, array) => ({
@@ -152,6 +156,8 @@ function* getValidatorDetails({ payload: address }: PayloadAction<string>) {
       lower: b.rate_min ? Number(quantity.toBigInt(b.rate_min)) / 100_000 : 0,
       upper: b.rate_max ? Number(quantity.toBigInt(b.rate_max)) / 100_000 : 0,
     }))
+    // Always clone before sort so it doesn't mutate source
+    .slice()
     .sort((a, b) => a.epochStart - b.epochStart)
     // If we have another bound after this one, attach the epochEnd to this one
     .map((b, i, array) => ({


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-wallet-web/issues/501