### PR TITLE
Fix waiting in async tests (wait for expect.resolves / rejects)

### DIFF
--- a/src/app/lib/ledger.test.ts
+++ b/src/app/lib/ledger.test.ts
@@ -49,7 +49,7 @@ describe('Ledger Library', () => {
     it('Should catch Cannot open Oasis app', async () => {
       mockAppIsOpen('Oasis')
       const pubKey: jest.Mock<any> = OasisApp.prototype.publicKey
-      pubKey.mockResolvedValueOnce({ return_code: 26628 })
+      pubKey.mockResolvedValueOnce({ return_code: 0x6804 })
 
       const accounts = Ledger.enumerateAccounts({})
       expect(accounts).rejects.toThrowError(WalletError)
@@ -59,7 +59,7 @@ describe('Ledger Library', () => {
     it('Should catch App version not supported', async () => {
       mockAppIsOpen('Oasis')
       const pubKey: jest.Mock<any> = OasisApp.prototype.publicKey
-      pubKey.mockResolvedValueOnce({ return_code: 25600 })
+      pubKey.mockResolvedValueOnce({ return_code: 0x6400 })
 
       const accounts = Ledger.enumerateAccounts({})
       expect(accounts).rejects.toThrowError(WalletError)
@@ -120,7 +120,7 @@ describe('Ledger Library', () => {
 
     it('Should throw if the transaction was rejected', () => {
       const sign: jest.Mock<any> = OasisApp.prototype.sign
-      sign.mockResolvedValueOnce({ return_code: 27014 })
+      sign.mockResolvedValueOnce({ return_code: 0x6986 })
 
       const signer = new LedgerSigner({
         type: WalletType.Ledger,

--- a/src/app/lib/ledger.test.ts
+++ b/src/app/lib/ledger.test.ts
@@ -52,8 +52,8 @@ describe('Ledger Library', () => {
       pubKey.mockResolvedValueOnce({ return_code: 0x6804 })
 
       const accounts = Ledger.enumerateAccounts({})
-      expect(accounts).rejects.toThrowError(WalletError)
-      expect(accounts).rejects.toHaveProperty('type', WalletErrors.LedgerCannotOpenOasisApp)
+      await expect(accounts).rejects.toThrowError(WalletError)
+      await expect(accounts).rejects.toHaveProperty('type', WalletErrors.LedgerCannotOpenOasisApp)
     })
 
     it('Should catch App version not supported', async () => {
@@ -62,8 +62,8 @@ describe('Ledger Library', () => {
       pubKey.mockResolvedValueOnce({ return_code: 0x6400 })
 
       const accounts = Ledger.enumerateAccounts({})
-      expect(accounts).rejects.toThrowError(WalletError)
-      expect(accounts).rejects.toHaveProperty('type', WalletErrors.LedgerAppVersionNotSupported)
+      await expect(accounts).rejects.toThrowError(WalletError)
+      await expect(accounts).rejects.toHaveProperty('type', WalletErrors.LedgerAppVersionNotSupported)
     })
 
     it('Should catch ledger unknown errors', async () => {
@@ -72,9 +72,9 @@ describe('Ledger Library', () => {
       pubKey.mockResolvedValueOnce({ return_code: -1, error_message: 'unknown dummy error' })
 
       const accounts = Ledger.enumerateAccounts({})
-      expect(accounts).rejects.toThrowError(WalletError)
-      expect(accounts).rejects.toThrow(/unknown dummy error/)
-      expect(accounts).rejects.toHaveProperty('type', WalletErrors.LedgerUnknownError)
+      await expect(accounts).rejects.toThrowError(WalletError)
+      await expect(accounts).rejects.toThrow(/unknown dummy error/)
+      await expect(accounts).rejects.toHaveProperty('type', WalletErrors.LedgerUnknownError)
     })
   })
 
@@ -118,7 +118,7 @@ describe('Ledger Library', () => {
       expect(signer.public()).toEqual(new Uint8Array([170, 187, 204]))
     })
 
-    it('Should throw if the transaction was rejected', () => {
+    it('Should throw if the transaction was rejected', async () => {
       const sign: jest.Mock<any> = OasisApp.prototype.sign
       sign.mockResolvedValueOnce({ return_code: 0x6986 })
 
@@ -130,11 +130,11 @@ describe('Ledger Library', () => {
 
       signer.setTransport({})
       const result = signer.sign('', new Uint8Array())
-      expect(result).rejects.toThrowError(WalletError)
-      expect(result).rejects.toHaveProperty('type', WalletErrors.LedgerTransactionRejected)
+      await expect(result).rejects.toThrowError(WalletError)
+      await expect(result).rejects.toHaveProperty('type', WalletErrors.LedgerTransactionRejected)
     })
 
-    it('Should return the signature', () => {
+    it('Should return the signature', async () => {
       const sign: jest.Mock<any> = OasisApp.prototype.sign
       sign.mockResolvedValueOnce({ return_code: 0x9000, signature: Buffer.from(new Uint8Array([1, 2, 3])) })
 
@@ -145,7 +145,7 @@ describe('Ledger Library', () => {
       } as Wallet)
 
       signer.setTransport({})
-      expect(signer.sign('', new Uint8Array())).resolves.toEqual(new Uint8Array([1, 2, 3]))
+      await expect(signer.sign('', new Uint8Array())).resolves.toEqual(new Uint8Array([1, 2, 3]))
     })
   })
 })

--- a/src/app/lib/ledger.ts
+++ b/src/app/lib/ledger.ts
@@ -19,11 +19,11 @@ interface LedgerAccount {
 const successOrThrow = (response: Response, message: string) => {
   if (response.return_code !== 0x9000) {
     switch (response.return_code) {
-      case 25600:
+      case 0x6400:
         throw new WalletError(WalletErrors.LedgerAppVersionNotSupported, response.error_message)
-      case 27014:
+      case 0x6986:
         throw new WalletError(WalletErrors.LedgerTransactionRejected, response.error_message)
-      case 26628:
+      case 0x6804:
         throw new WalletError(WalletErrors.LedgerCannotOpenOasisApp, response.error_message)
 
       default:

--- a/src/app/lib/transaction.spec.ts
+++ b/src/app/lib/transaction.spec.ts
@@ -110,7 +110,7 @@ describe('OasisTransaction', () => {
       spy.mockRejectedValueOnce({ metadata: { 'grpc-message': 'transaction: invalid nonce' } })
 
       const call = OasisTransaction.submit(nic, tw)
-      expect(call).rejects.toThrow(/Invalid nonce/)
+      await expect(call).rejects.toThrow(/Invalid nonce/)
     })
   })
 })


### PR DESCRIPTION
Previously mistakes in these tests would still pass and just print UnhandledPromiseRejectionWarning, Expected value, Received value