### PR TITLE
Oasisscan: add guards around short address creation

### DIFF
--- a/src/app/components/ShortAddress/__tests__/index.test.tsx
+++ b/src/app/components/ShortAddress/__tests__/index.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+
+import { ShortAddress } from '..'
+
+jest.mock('react-i18next', () => ({
+  Trans: ({ i18nKey }) => <>{i18nKey}</>,
+  useTranslation: () => {
+    return {
+      t: str => str,
+    }
+  },
+}))
+
+describe('<ShortAddress  />', () => {
+  it('should render short address', () => {
+    render(<ShortAddress address="qwertyuiopasdfghjkl" />)
+    expect(screen.getByText('qwertyuiop...sdfghjkl')).toBeInTheDocument()
+  })
+
+  it('should fallback to unavailable label when short address cannot be created', () => {
+    render(<ShortAddress address="" />)
+    expect(screen.getByText('common.unavailable')).toBeInTheDocument()
+  })
+})

--- a/src/app/components/ShortAddress/index.tsx
+++ b/src/app/components/ShortAddress/index.tsx
@@ -4,13 +4,16 @@
  *
  */
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   address: string
 }
 
 export function ShortAddress(props: Props) {
+  const { t } = useTranslation()
+
   const a = props.address
-  const short = `${a.slice(0, 10)}...${a.slice(-8)}`
+  const short = props.address ? `${a.slice(0, 10)}...${a.slice(-8)}` : t('common.unavailable', 'Unavailable')
   return <>{short}</>
 }

--- a/src/app/components/Transaction/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Transaction/__tests__/__snapshots__/index.test.tsx.snap
@@ -518,6 +518,7 @@ exports[`<Transaction  /> should handle unknown transaction types gracefully 1`]
         </div>
       </div>
       <a
+        data-testid="external-wallet-address"
         href="/account/source"
       >
         <div
@@ -1151,6 +1152,7 @@ exports[`<Transaction  /> should match snapshot 1`] = `
         </div>
       </div>
       <a
+        data-testid="external-wallet-address"
         href="/account/source"
       >
         <div

--- a/src/app/components/Transaction/__tests__/index.test.tsx
+++ b/src/app/components/Transaction/__tests__/index.test.tsx
@@ -94,4 +94,18 @@ describe('<Transaction  />', () => {
     })
     expect(component.container.firstChild).toMatchSnapshot()
   })
+
+  it('should not render a link when address is undefined', () => {
+    renderComponent(store, 'sourceAddr', {
+      amount: 1000000,
+      timestamp: 1618018255,
+      from: 'sourceAddr',
+      to: undefined,
+      type: 'anyType',
+      hash: 'ff1234',
+    })
+
+    expect(screen.queryByTestId('external-wallet-address')).not.toBeInTheDocument()
+    expect(screen.getByText('common.unavailable')).toBeInTheDocument()
+  })
 })

--- a/src/app/components/Transaction/index.tsx
+++ b/src/app/components/Transaction/index.tsx
@@ -220,13 +220,22 @@ export function Transaction(props: TransactionProps) {
       <CardBody pad={{ horizontal: 'none', vertical: 'none' }}>
         <Grid columns={{ count: 'fit', size: 'xsmall' }} gap="none">
           <InfoBox icon={<Money color="brand" />} label={t('common.amount', 'Amount')} value={amount} />
-          <NavLink to={`/account/${otherAddress}`}>
+          {otherAddress && (
+            <NavLink data-testid="external-wallet-address" to={`/account/${otherAddress}`}>
+              <InfoBox
+                icon={<ContactInfo color="brand" />}
+                label={designation}
+                value={<ShortAddress address={otherAddress} />}
+              />
+            </NavLink>
+          )}
+          {!otherAddress && (
             <InfoBox
               icon={<ContactInfo color="brand" />}
               label={designation}
-              value={<ShortAddress address={otherAddress} />}
+              value={t('common.unavailable', 'Unavailable')}
             />
-          </NavLink>
+          )}
           <InfoBox
             icon={<Cube color="brand" />}
             label={t('common.block', 'Block')}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -129,6 +129,7 @@
     "validator": "Validator",
     "cancel": "Cancel",
     "confirm": "Confirm",
+    "unavailable": "Unavailable",
     "validators": "Validators"
   },
   "errors": {


### PR DESCRIPTION
This is causing app crash. oasisscan for types like `ExecutorCommit`, `PVSSCommit`  (and more) can return `to: null`  in payload 

https://api.oasisscan.com/mainnet/chain/transactions?size=20&address=oasis1qz5eut7wc0q4ch8ufe8jlrh2qr5n00arc5y7ywht&runtime=false

Needed for #704 