### PR TITLE
Use long revision sha in app footer link

### DIFF
--- a/internals/getBuildData.js
+++ b/internals/getBuildData.js
@@ -1,4 +1,4 @@
-const sha = require('child_process').execSync('git rev-parse --short HEAD').toString().trim()
+const sha = require('child_process').execSync('git rev-parse HEAD').toString().trim()
 const buildTime = Date.now()
 
 module.exports = { buildTime, sha }

--- a/src/app/components/Footer/__tests__/index.test.tsx
+++ b/src/app/components/Footer/__tests__/index.test.tsx
@@ -22,7 +22,7 @@ describe('<Footer />', () => {
   it('should render a link with version number', () => {
     render(<Footer />)
 
-    expect(screen.getByRole('link', { name: 'versionNumber' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'version' })).toHaveAttribute(
       'href',
       'https://github.com/oasisprotocol/oasis-wallet-web/commit/versionNumber',
     )

--- a/src/app/components/Footer/index.tsx
+++ b/src/app/components/Footer/index.tsx
@@ -41,7 +41,7 @@ export const Footer = memo(() => {
             components={[
               <Anchor
                 href={`${githubLink}commit/${process.env.REACT_APP_BUILD_VERSION}`}
-                label={process.env.REACT_APP_BUILD_VERSION}
+                label={process.env.REACT_APP_BUILD_VERSION.substring(0, 7)}
               />,
             ]}
             defaults="Version: <0>{{commit}}</0> built at {{buildTime}}"

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -231,6 +231,7 @@
   },
   "footer": {
     "github": "Oasis Wallet est entièrement <0>open source</0> - N'hésitez pas à remonter tout problème !",
-    "terms": "<0>Termes et Conditions</0>"
+    "terms": "<0>Termes et Conditions</0>",
+    "version": "Version: <0>{{commit}}</0> construit à {{buildTime}}"
   }
 }


### PR DESCRIPTION
Use full sha in href, short in label
`https://github.com/oasisprotocol/oasis-wallet-web/commit/454be7b`
vs
`https://github.com/oasisprotocol/oasis-wallet-web/commit/454be7b0a698e32130c2e0e7a5cabcff3d578242`