### PR TITLE
Ensure block explorer link goes to the correct block explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "replace-in-file": "6.3.2",
     "rimraf": "3.0.2",
     "styled-components": "5.3.1",
+    "ts-jest": "27.1.3",
     "tweetnacl": "1.0.3",
     "typed-redux-saga": "1.3.1",
     "typescript": "4.5.4",

--- a/src/app/components/Transaction/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Transaction/__tests__/__snapshots__/index.test.tsx.snap
@@ -612,7 +612,8 @@ exports[`<Transaction  /> should handle unknown transaction types gracefully 1`]
     >
       <a
         class="c16"
-        href="https://www.oasisscan.com/transactions/ff1234"
+        data-testid="explorer-link"
+        href="https://oasisscan.com/transactions/ff1234"
         rel="noopener"
         target="_blank"
       >
@@ -1246,7 +1247,8 @@ exports[`<Transaction  /> should match snapshot 1`] = `
     >
       <a
         class="c16"
-        href="https://www.oasisscan.com/transactions/ff1234"
+        data-testid="explorer-link"
+        href="https://oasisscan.com/transactions/ff1234"
         rel="noopener"
         target="_blank"
       >

--- a/src/app/components/Transaction/index.tsx
+++ b/src/app/components/Transaction/index.tsx
@@ -23,6 +23,9 @@ import { DateFormatter } from '../DateFormatter'
 import { ShortAddress } from '../ShortAddress'
 import { InfoBox } from './InfoBox'
 import * as transactionTypes from 'app/state/transaction/types'
+import { NetworkType } from 'app/state/network/types'
+import { config } from 'config'
+import { backend } from 'vendors/backend'
 
 export enum TransactionSide {
   Sent = 'sent',
@@ -42,6 +45,7 @@ type TransactionDictionary = {
 interface TransactionProps {
   referenceAddress: string
   transaction: transactionTypes.Transaction
+  network: NetworkType
 }
 
 export function Transaction(props: TransactionProps) {
@@ -208,6 +212,7 @@ export function Transaction(props: TransactionProps) {
   const icon = matchingConfiguration.icon()
   const header = matchingConfiguration.header()
   const designation = matchingConfiguration.designation
+  const blockExplorerLink = config[props.network][backend()]?.blockExplorer
 
   return (
     <Card round="small" background="background-front" gap="none" elevation="xsmall">
@@ -251,9 +256,10 @@ export function Transaction(props: TransactionProps) {
           <Button
             icon={<CircleInformation color="dark-3" />}
             hoverIndicator
-            href={'https://www.oasisscan.com/transactions/' + encodeURIComponent(transaction.hash)}
+            href={blockExplorerLink.replace('{{txHash}}', encodeURIComponent(transaction.hash))}
             target="_blank"
             rel="noopener"
+            data-testid="explorer-link"
           />
         </Box>
       </CardFooter>

--- a/src/app/pages/AccountPage/Features/TransactionHistory/index.tsx
+++ b/src/app/pages/AccountPage/Features/TransactionHistory/index.tsx
@@ -14,6 +14,7 @@ import {
   selectTransactions,
   selectTransactionsError,
 } from '../../../../state/account/selectors'
+import { selectSelectedNetwork } from 'app/state/network/selectors'
 
 interface Props {}
 
@@ -25,8 +26,9 @@ export function TransactionHistory(props: Props) {
   const allTransactions = useSelector(selectTransactions)
   const transactionsError = useSelector(selectTransactionsError)
   const address = useSelector(selectAccountAddress)
+  const network = useSelector(selectSelectedNetwork)
   const transactionComponents = allTransactions.map((t, i) => (
-    <Transaction key={i} transaction={t} referenceAddress={address} />
+    <Transaction key={i} transaction={t} referenceAddress={address} network={network} />
   ))
 
   return (

--- a/src/app/state/network/saga.ts
+++ b/src/app/state/network/saga.ts
@@ -26,7 +26,7 @@ export function* getOasisNic(network?: NetworkType) {
  */
 export function* getExplorerAPIs(network?: NetworkType) {
   const selectedNetwork = yield* select(selectSelectedNetwork)
-  const url = config[selectedNetwork][backend].explorer
+  const url = config[selectedNetwork][backend()].explorer
   return backendApi(url)
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,9 +4,11 @@ export const config = {
   mainnet: {
     [BackendAPIs.OasisMonitor]: {
       explorer: 'https://monitor.oasis.dev',
+      blockExplorer: 'https://oasismonitor.com/operation/{{txHash}}',
     },
     [BackendAPIs.OasisScan]: {
       explorer: 'https://api.oasisscan.com/mainnet',
+      blockExplorer: 'https://oasisscan.com/transactions/{{txHash}}',
     },
     grpc: 'https://grpc.oasis.dev',
   },
@@ -14,18 +16,22 @@ export const config = {
     grpc: 'https://testnet.grpc.oasis.dev',
     [BackendAPIs.OasisMonitor]: {
       explorer: 'https://monitor.oasis.dev/api/testnet',
+      blockExplorer: 'https://testnet.oasismonitor.com/operation/{{txHash}}',
     },
     [BackendAPIs.OasisScan]: {
       explorer: 'https://api.oasisscan.com/testnet',
+      blockExplorer: 'https://testnet.oasisscan.com/transactions/{{txHash}}',
     },
   },
   local: {
     grpc: 'http://localhost:42280',
     [BackendAPIs.OasisMonitor]: {
       explorer: 'http://localhost:9001',
+      blockExplorer: 'http://localhost:9001/data/transactions?operation_id={{txHash}}',
     },
     [BackendAPIs.OasisScan]: {
       explorer: 'http://localhost:9001',
+      blockExplorer: 'http://localhost:9001/data/transactions?operation_id={{txHash}}',
     },
   },
 }

--- a/src/vendors/backend.ts
+++ b/src/vendors/backend.ts
@@ -6,5 +6,5 @@ export enum BackendAPIs {
   OasisScan = 'oasisscan',
 }
 
-export const backend = process.env.REACT_APP_BACKEND || BackendAPIs.OasisMonitor
-export const backendApi = backend === BackendAPIs.OasisScan ? getOasisscanAPIs : getMonitorAPIs
+export const backend = () => process.env.REACT_APP_BACKEND || BackendAPIs.OasisMonitor
+export const backendApi = backend() === BackendAPIs.OasisScan ? getOasisscanAPIs : getMonitorAPIs

--- a/yarn.lock
+++ b/yarn.lock
@@ -2441,6 +2441,17 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.5.1":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.5.1.tgz#3c79ec4a8ba61c170bf937bcf9e98a9df175ec80"
+  integrity sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@ledgerhq/devices@^6.20.0":
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-6.20.0.tgz#4280aaa5dc16f821ecab9ee8ae882299411ba5b7"
@@ -5435,6 +5446,13 @@ browserslist@^4.17.5, browserslist@^4.19.1:
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz"
@@ -5905,6 +5923,11 @@ ci-info@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.1.1.tgz"
   integrity sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==
+
+ci-info@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
+  integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
 
 cidr-regex@^3.1.1:
   version "3.1.1"
@@ -8428,7 +8451,7 @@ fast-glob@^3.2.7:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -9185,6 +9208,11 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   version "4.2.6"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graceful-fs@^4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
 grommet-icons@4.7.0, grommet-icons@^4.7.0:
   version "4.7.0"
@@ -11125,6 +11153,18 @@ jest-util@^26.6.0, jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
+jest-util@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.5.1.tgz#3ba9771e8e31a0b85da48fe0b0891fb86c01c2f9"
+  integrity sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==
+  dependencies:
+    "@jest/types" "^27.5.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
 jest-validate@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz"
@@ -11321,19 +11361,19 @@ json3@^3.3.3:
   resolved "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
+json5@2.x, json5@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
-
-json5@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -11849,7 +11889,7 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
-lodash.memoize@^4.1.2:
+lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
@@ -12021,7 +12061,7 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1.1.1:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -16193,17 +16233,17 @@ semver@7.3.2:
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.x, semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 send@0.17.1:
   version "0.17.1"
@@ -17699,6 +17739,20 @@ tryer@^1.0.1:
   resolved "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
+ts-jest@27.1.3:
+  version "27.1.3"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.3.tgz#1f723e7e74027c4da92c0ffbd73287e8af2b2957"
+  integrity sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==
+  dependencies:
+    bs-logger "0.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^27.0.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
 ts-node@10.4.0:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
@@ -18972,6 +19026,11 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yargs-parser@20.x:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/oasis-wallet-web/issues/747

- handle block explorer links correctly for mainnet and testnet

- added ts-jest dependency to handle mock types nicely. I will create ticket on our board to remove this after Parcel migration. Currently due to old `react-scripts` we are using old Jest version. In the new one mocked function was moved from ts-test/utils into Jest. 