### PR TITLE
Add backend name in the app footer

### DIFF
--- a/src/app/components/Footer/__tests__/index.test.tsx
+++ b/src/app/components/Footer/__tests__/index.test.tsx
@@ -3,6 +3,13 @@ import * as React from 'react'
 
 import { Footer } from '..'
 
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: key => key,
+  }),
+  Trans: ({ components }: { components: React.ReactNode }) => components,
+}))
+
 describe('<Footer />', () => {
   const originalEnvs = process.env
 
@@ -12,6 +19,7 @@ describe('<Footer />', () => {
       ...originalEnvs,
       REACT_APP_BUILD_TIME: '1645464110349',
       REACT_APP_BUILD_VERSION: 'versionNumber',
+      REACT_APP_BACKEND: 'oasisscan',
     }
   })
 
@@ -26,5 +34,11 @@ describe('<Footer />', () => {
       'href',
       'https://github.com/oasisprotocol/oasis-wallet-web/commit/versionNumber',
     )
+  })
+
+  it('should render backend label', () => {
+    render(<Footer />)
+
+    expect(screen.getByText('footer.poweredBy.oasisscan')).toBeInTheDocument()
   })
 })

--- a/src/app/components/Footer/index.tsx
+++ b/src/app/components/Footer/index.tsx
@@ -2,10 +2,16 @@ import { Anchor, Box, Text } from 'grommet'
 import React, { memo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { dateFormat } from '../DateFormatter'
+import { BackendAPIs } from 'vendors/backend'
+
 const githubLink = 'https://github.com/oasisprotocol/oasis-wallet-web/'
 
 export const Footer = memo(() => {
   const { t } = useTranslation()
+  const poweredByLabel =
+    process.env.REACT_APP_BACKEND === BackendAPIs.OasisMonitor
+      ? t('footer.poweredBy.oasismonitor')
+      : t('footer.poweredBy.oasisscan')
 
   return (
     <Box
@@ -50,6 +56,7 @@ export const Footer = memo(() => {
               commit: process.env.REACT_APP_WALLET_VERSION,
             }}
           />
+          {process.env.REACT_APP_BACKEND && <Box align="center">{poweredByLabel}</Box>}
         </Text>
       )}
     </Box>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -248,6 +248,10 @@
   },
   "footer": {
     "github": "Oasis Wallet is fully <0>open source</0> - Feedback and issues are appreciated!",
+    "poweredBy": {
+      "oasisscan": "Powered by Oasis Scan",
+      "oasismonitor": "Powered by Oasis Monitor API & SimplyVC’s gRPC"
+    },
     "terms": "<0>Terms and Conditions</0>",
     "version": "Version: <0>{{commit}}</0> built at {{buildTime}}"
   }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -231,6 +231,10 @@
   },
   "footer": {
     "github": "Oasis Wallet est entièrement <0>open source</0> - N'hésitez pas à remonter tout problème !",
+    "poweredBy": {
+      "oasisscan": "Alimenté par Oasis Scan",
+      "oasismonitor": "Alimenté par Oasis Monitor API & SimplyVC’s gRPC"
+    },
     "terms": "<0>Termes et Conditions</0>",
     "version": "Version: <0>{{commit}}</0> construit à {{buildTime}}"
   }


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/oasis-wallet-web/issues/724


Added a task to an internal board to mock react-i18next globally, because it looks like mocking translations in tests is pattern we  want to follow in this repo.

<img width="648" alt="Screenshot 2022-03-16 at 22 58 04" src="https://user-images.githubusercontent.com/891392/158698570-5155d21c-0fdc-48d9-bedc-e42e16b11c5f.png">
<img width="650" alt="Screenshot 2022-03-16 at 22 59 08" src="https://user-images.githubusercontent.com/891392/158698572-a8b9bc8c-6ceb-42c4-bcb4-199d66b7e349.png">

