### PR TITLE
Fix handling wrapped RPC errors

### DIFF
--- a/src/app/components/ErrorFormatter/index.tsx
+++ b/src/app/components/ErrorFormatter/index.tsx
@@ -18,9 +18,8 @@ export function ErrorFormatter(props: Props) {
   const message = props.message
 
   const errorMap: { [code in WalletErrors]: string | React.ReactElement } = {
-    [WalletErrors.UnknownError]: t('errors.unknown', {
-      message,
-    }),
+    [WalletErrors.UnknownError]: t('errors.unknown', { message }),
+    [WalletErrors.UnknownGrpcError]: t('errors.unknownGrpc', { message }),
     [WalletErrors.InvalidAddress]: t('errors.invalidAddress'),
     [WalletErrors.InvalidPrivateKey]: t('errors.invalidPrivateKey'),
     [WalletErrors.InsufficientBalance]: t('errors.insufficientBalance'),

--- a/src/app/lib/transaction.spec.ts
+++ b/src/app/lib/transaction.spec.ts
@@ -124,6 +124,8 @@ describe('OasisTransaction', () => {
       spy.mockRejectedValueOnce(wrapRpcError('submit', 'transaction: invalid nonce'))
       await expect(OasisTransaction.submit(nic, tw)).rejects.toThrow(/Invalid nonce/)
 
+      spy.mockRejectedValueOnce(wrapRpcError('submit', 'unhandled err'))
+      await expect(OasisTransaction.submit(nic, tw)).rejects.toThrow(/unhandled err/)
     })
   })
 })

--- a/src/app/lib/transaction.ts
+++ b/src/app/lib/transaction.ts
@@ -98,7 +98,7 @@ export class OasisTransaction {
     try {
       await tw.submit(nic)
     } catch (e: any) {
-      const grpcError = e?.metadata?.['grpc-message']
+      const grpcError = e?.cause?.metadata?.['grpc-message']
 
       if (!grpcError) {
         throw new WalletError(WalletErrors.UnknownError, 'Unknown error', e)

--- a/src/app/lib/transaction.ts
+++ b/src/app/lib/transaction.ts
@@ -98,10 +98,10 @@ export class OasisTransaction {
     try {
       await tw.submit(nic)
     } catch (e: any) {
-      const grpcError = e?.cause?.metadata?.['grpc-message']
+      const grpcError = e?.cause?.metadata?.['grpc-message'] || e.message
 
       if (!grpcError) {
-        throw new WalletError(WalletErrors.UnknownError, 'Unknown error', e)
+        throw new WalletError(WalletErrors.UnknownError, grpcError, e)
       }
 
       switch (grpcError) {
@@ -110,7 +110,7 @@ export class OasisTransaction {
         case 'consensus: duplicate transaction':
           throw new WalletError(WalletErrors.DuplicateTransaction, 'Duplicate transaction')
         default:
-          throw new WalletError(WalletErrors.UnknownError, 'Unknown gRPC Error', e)
+          throw new WalletError(WalletErrors.UnknownGrpcError, grpcError, e)
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -134,6 +134,7 @@
   },
   "errors": {
     "unknown": "Unknown error: {{message}}",
+    "unknownGrpc": "Unknown gRPC error: {{message}}",
     "invalidPrivateKey": "Invalid private key",
     "cannotSendToSelf": "Cannot send to yourself",
     "invalidNonce": "Invalid nonce (transaction number)",

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -6,6 +6,7 @@ export class WalletError extends Error {
 
 export enum WalletErrors {
   UnknownError = 'unknown',
+  UnknownGrpcError = 'unknown_grpc',
   InvalidAddress = 'invalid_address',
   InvalidPrivateKey = 'invalid_private_key',
   InsufficientBalance = 'insufficient_balance',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8276,9 +8276,9 @@ grommet@2.21.0:
     prop-types "^15.8.1"
 
 grpc-web@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/grpc-web/-/grpc-web-1.3.0.tgz#4c36d97e7a7b6102a7df463e7822cd86d4f65ed8"
-  integrity sha512-nePImtnrnkZLErFq00Sr1H6AqaRrRptOJEhjUnlTB6RiJgs8ULYvRI9cX2hDwMvyYgakmO3H/wThYvS+Ibdreg==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/grpc-web/-/grpc-web-1.3.1.tgz#6d8affe75a103790b7ad570824e765a1d6a418e4"
+  integrity sha512-VxyYEAGsatecAFY3xieRDzsuhm92yQBsJD7fd5Z3MY150hZWPwkrUWetzJ0QK5W0uym4+VedPQrei38wk0eIjQ==
 
 gulp-sort@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Since https://github.com/oasisprotocol/oasis-sdk/pull/676 all RPC resulted in `Unknown error: Unknown error`