### PR TITLE
Restyle confirmation modal to match transaction preview modal

### DIFF
--- a/src/app/components/Modal/index.tsx
+++ b/src/app/components/Modal/index.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useState } from 'react'
 import { Box, Button, Layer, Heading, Paragraph } from 'grommet'
 import { useTranslation } from 'react-i18next'
+import { Alert, Checkmark, Close } from 'grommet-icons/icons'
 
 interface Modal {
   title: string
@@ -34,19 +35,27 @@ const ModalContainer = ({ modal, closeModal }: ModalContainerProps) => {
 
   return (
     <Layer onEsc={closeModal} onClickOutside={closeModal} background="background-front">
-      <Heading margin="medium" size="small">
-        {modal.title}
-      </Heading>
-      <Paragraph margin="medium">{modal.description}</Paragraph>
-      <Box justify="between" margin="medium" direction="row">
-        <Button label={t('common.cancel')} onClick={closeModal} />
-        <Button
-          label={t('common.confirm')}
-          disabled={modal.isDangerous}
-          onClick={confirm}
-          primary={modal.isDangerous}
-          color={modal.isDangerous ? 'status-error' : ''}
-        />
+      <Box margin="medium">
+        <Heading size="small">{modal.title}</Heading>
+        <Paragraph fill>{modal.description}</Paragraph>
+        <Box direction="row" gap="small" alignSelf="end" pad={{ top: 'large' }}>
+          <Button
+            label={t('common.cancel', 'Cancel')}
+            onClick={closeModal}
+            secondary
+            style={{ borderRadius: '4px' }}
+            icon={<Close size="18px" />}
+          />
+          <Button
+            label={t('common.confirm', 'Confirm')}
+            onClick={confirm}
+            disabled={modal.isDangerous}
+            primary={modal.isDangerous}
+            color={modal.isDangerous ? 'status-error' : ''}
+            style={{ borderRadius: '4px' }}
+            icon={modal.isDangerous ? <Alert size="18px" /> : <Checkmark size="18px" />}
+          />
+        </Box>
       </Box>
     </Layer>
   )


### PR DESCRIPTION
| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/3758846/160038208-76cd478e-6f8a-499a-b783-12c4846a5449.png) |  ![image](https://user-images.githubusercontent.com/3758846/160038147-87d1723e-4c60-4e41-b7b5-9a486a26619d.png) | 
| ![image](https://user-images.githubusercontent.com/3758846/160038268-ab171754-64c0-4892-bc66-7fbcb6621b33.png) | ![image](https://user-images.githubusercontent.com/3758846/160038268-ab171754-64c0-4892-bc66-7fbcb6621b33.png) |