### PR TITLE
Render wallet app in extension popup

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,4 +1,3 @@
 {
-  "extends": "@parcel/config-default",
-  "namers": [ "parcel-namer-rewrite" ]
+  "extends": "@parcel/config-default"
 }

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -4,9 +4,8 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <a href="./popup.html" target="_blank">Open in new tab</a>
-
     <div id="root" style="min-width: 300px; min-height: 300px"></div>
     <script type="module" src="./popup/popup.tsx"></script>
+    <a href="./popup.html" target="_blank">Open in new tab</a>
   </body>
 </html>

--- a/extension/src/popup/popup.tsx
+++ b/extension/src/popup/popup.tsx
@@ -1,1 +1,30 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Provider } from 'react-redux'
+import { HelmetProvider } from 'react-helmet-async'
+
+import { ThemeProvider } from 'styles/theme/ThemeProvider'
+import { configureAppStore } from 'store/configureStore'
+import { App } from 'app'
+
+import 'locales/i18n'
+import 'sanitize.css/sanitize.css'
+import 'styles/main.css'
+
+const store = configureAppStore()
+const MOUNT_NODE = document.getElementById('root') as HTMLElement
+
+ReactDOM.render(
+  <Provider store={store}>
+    <ThemeProvider>
+      <HelmetProvider>
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>
+      </HelmetProvider>
+    </ThemeProvider>
+  </Provider>,
+  MOUNT_NODE,
+)
+
 console.log('popup')

--- a/internals/getCsp.js
+++ b/internals/getCsp.js
@@ -3,11 +3,14 @@
 // - remove 'unsafe-inline' style by precomputing theme hash
 // - add report-uri to gather errors if anything was missed
 
-const cspEnhancement = `
+const extensionFrame = `
   frame-ancestors 
     'self' 
     https: http://localhost:* http://127.0.0.1:*;
   `
+const extensionWebsocket = `
+  ws://localhost:2222
+`
 
 // Keep synced with deployment
 const csp = ({ extension } = {}) =>
@@ -18,23 +21,25 @@ const csp = ({ extension } = {}) =>
       'report-sample';
     style-src
       'self'
-      fonts.googleapis.com
+      https://fonts.googleapis.com
       'unsafe-inline'
       'report-sample';
     font-src
       'self'
-      fonts.gstatic.com;
+      https://fonts.gstatic.com;
     connect-src
       'self'
-      grpc.oasis.dev
-      testnet.grpc.oasis.dev
-      api.oasisscan.com
-      monitor.oasis.dev;
+      https://grpc.oasis.dev
+      https://testnet.grpc.oasis.dev
+      https://api.oasisscan.com
+      https://monitor.oasis.dev
+      ${extension ? extensionWebsocket : ''}
+      ;
     img-src 'self' data: https:;
     prefetch-src 'self';
     base-uri 'self';
     manifest-src 'self';
-    ${extension ? cspEnhancement : ''}
+    ${extension ? extensionFrame : ''}
   `
     .trim()
     .split('\n')

--- a/internals/scripts/serve-prod.js
+++ b/internals/scripts/serve-prod.js
@@ -13,8 +13,8 @@ const server = http.createServer((request, response) => {
     rewrites: [
       {
         source: '**',
-        destination: '/index.html'
-      }
+        destination: '/index.html',
+      },
     ],
     // Disable etag so we don't need to clear cache if we only change CSP.
     etag: false,
@@ -24,11 +24,11 @@ const server = http.createServer((request, response) => {
         headers: [
           {
             key: 'Content-Security-Policy',
-            value: csp
-          }
-        ]
-      }
-    ]
+            value: csp(),
+          },
+        ],
+      },
+    ],
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "start:oasismonitor": "REACT_APP_BACKEND=oasismonitor yarn start",
     "start:oasisscan": "REACT_APP_BACKEND=oasisscan yarn start",
     "clean:ext": "rm -rf build-ext/ .parcel-cache",
-    "start:ext": "EXTENSION_CSP=`yarn --silent print-extension-csp` parcel --host localhost --target ext-dev --dist-dir build-ext --config .parcelrc-ext extension/src/manifest.json",
-    "build:ext": "yarn clean:ext && yarn clean && EXTENSION_CSP=`yarn --silent print-extension-csp` parcel build --target ext-prod --dist-dir build-ext --config .parcelrc-ext extension/src/manifest.json && node ./extension/internals/validate-ext-manifest.js",
+    "start:ext": "HMR_PORT=2222 EXTENSION=true EXTENSION_CSP=`yarn --silent print-extension-csp` parcel --host localhost --target ext-dev --dist-dir build-ext --config .parcelrc-ext extension/src/manifest.json",
+    "build:ext": "yarn clean:ext && yarn clean && EXTENSION=true EXTENSION_CSP=`yarn --silent print-extension-csp` parcel build --target ext-prod --dist-dir build-ext --config .parcelrc-ext extension/src/manifest.json && node ./extension/internals/validate-ext-manifest.js",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "build": "yarn clean && node ./internals/prod-scripts.js",
@@ -170,7 +170,6 @@
     "node-plop": "0.26.3",
     "nodemon": "2.0.15",
     "parcel": "2.3.2",
-    "parcel-namer-rewrite": "2.0.0-rc.2",
     "plop": "2.7.6",
     "posthtml-expressions": "1.9.0",
     "redux-saga-test-plan": "4.0.4",
@@ -190,6 +189,7 @@
     }
   },
   "alias": {
+    "locales": "./src/locales",
     "utils": "./src/utils",
     "app": "./src/app",
     "types": "./src/types",
@@ -214,12 +214,5 @@
     "ext-prod": {
       "distDir": "./build-ext"
     }
-  },
-  "parcel-namer-rewrite": {
-    "developmentHashing": true,
-    "rules": {
-      "(.*).png": "$1.png"
-    },
-    "silent": true
   }
 }

--- a/src/app/components/Sidebar/index.tsx
+++ b/src/app/components/Sidebar/index.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link, NavLink, useHistory, useLocation } from 'react-router-dom'
 import { ThemeSwitcher } from '../ThemeSwitcher'
+import logotype from '../../../logo192.png'
 
 interface SidebarButtonProps extends ButtonExtendedProps {
   secure?: boolean
@@ -104,7 +105,7 @@ const SidebarHeader = (props: SidebarHeaderProps) => {
     >
       <Link to="/">
         <Box align="center" direction="row" gap="small">
-          <Avatar src="/logo192.png" size={sizeLogo[size]} />
+          <Avatar src={logotype} size={sizeLogo[size]} />
           {size !== 'medium' && <Text>Oasis Wallet</Text>}
         </Box>
       </Link>

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -4,10 +4,10 @@
 
 import { combineReducers } from '@reduxjs/toolkit'
 import { InjectedReducersType } from 'utils/types/injector-typings'
-import { createBrowserHistory } from 'history'
+import { createHashHistory, createBrowserHistory } from 'history'
 import { connectRouter } from 'connected-react-router'
 
-export const history = createBrowserHistory()
+export const history = process.env.EXTENSION ? createHashHistory() : createBrowserHistory()
 
 /**
  * Merges the main reducer with the router state and dynamically injected reducers

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -2,5 +2,6 @@ declare namespace NodeJS {
   export interface ProcessEnv {
     REACT_APP_BACKEND: 'oasismonitor' | 'oasisscan'
     REACT_APP_BYPASS_LOCAL: '1' | undefined
+    EXTENSION: 'true' | undefined
   }
 }

--- a/src/types/images.d.ts
+++ b/src/types/images.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+  const content: string
+  export default content
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "jsx": "react-jsx",
     "baseUrl": "./src"
   },
-  "include": ["src", "vendors", "internals/startingTemplate/**/*"]
+  "include": ["src", "extension/src", "vendors", "internals/startingTemplate/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,7 +2937,7 @@
     detect-libc "^1.0.3"
     xxhash-wasm "^0.4.2"
 
-"@parcel/logger@2.3.2", "@parcel/logger@^2.0.0-rc.0":
+"@parcel/logger@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@parcel/logger/-/logger-2.3.2.tgz#b5fc7a9c1664ee0286d0f67641c7c81c8fec1561"
   integrity sha512-jIWd8TXDQf+EnNWSa7Q10lSQ6C1LSH8OZkTlaINrfVIw7s+3tVxO3I4pjp7/ARw7RX2gdNPlw6fH4Gn/HvvYbw==
@@ -2952,7 +2952,7 @@
   dependencies:
     chalk "^4.1.0"
 
-"@parcel/namer-default@2.3.2", "@parcel/namer-default@^2.0.0-rc.0":
+"@parcel/namer-default@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@parcel/namer-default/-/namer-default-2.3.2.tgz#84e17abfc84fd293b23b3f405280ed2e279c75d8"
   integrity sha512-3QUMC0+5+3KMKfoAxYAbpZtuRqTgyZKsGDWzOpuqwemqp6P8ahAvNPwSCi6QSkGcTmvtYwBu9/NHPSONxIFOfg==
@@ -3024,7 +3024,7 @@
     nullthrows "^1.1.1"
     terser "^5.2.0"
 
-"@parcel/package-manager@2.3.2", "@parcel/package-manager@^2.0.0-rc.0":
+"@parcel/package-manager@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@parcel/package-manager/-/package-manager-2.3.2.tgz#380f0741c9d0c79c170c437efae02506484df315"
   integrity sha512-pAQfywKVORY8Ee+NHAyKzzQrKbnz8otWRejps7urwhDaTVLfAd5C/1ZV64ATZ9ALYP9jyoQ8bTaxVd4opcSuwg==
@@ -3096,7 +3096,7 @@
     "@parcel/utils" "2.3.2"
     posthtml "^0.16.4"
 
-"@parcel/plugin@2.3.2", "@parcel/plugin@^2.0.0-rc.0":
+"@parcel/plugin@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@parcel/plugin/-/plugin-2.3.2.tgz#7701c40567d2eddd5d5b2b6298949cd03a2a22fa"
   integrity sha512-SaLZAJX4KH+mrAmqmcy9KJN+V7L+6YNTlgyqYmfKlNiHu7aIjLL+3prX8QRcgGtjAYziCxvPj0cl1CCJssaiGg==
@@ -3324,7 +3324,7 @@
     "@parcel/utils" "2.3.2"
     json-source-map "^0.6.1"
 
-"@parcel/types@2.3.2", "@parcel/types@^2.0.0-rc.0":
+"@parcel/types@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@parcel/types/-/types-2.3.2.tgz#7eb6925bc852a518dd75b742419e51292418769f"
   integrity sha512-C77Ct1xNM7LWjPTfe/dQ/9rq1efdsX5VJu2o8/TVi6qoFh64Wp/c5/vCHwKInOTBZUTchVO6z4PGJNIZoUVJuA==
@@ -4669,16 +4669,6 @@ assert@^1.4.0:
   dependencies:
     object-assign "^4.1.1"
     util "0.10.3"
-
-assert@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
-  integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
-  dependencies:
-    es6-object-assign "^1.1.0"
-    is-nan "^1.2.1"
-    object-is "^1.0.1"
-    util "^0.12.0"
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -7146,11 +7136,6 @@ es6-error@^4.0.1:
   resolved "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-es6-object-assign@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
-  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
-
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
@@ -9212,14 +9197,6 @@ is-lower-case@^1.1.0:
   integrity sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=
   dependencies:
     lower-case "^1.1.0"
-
-is-nan@^1.2.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
-  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
 
 is-negated-glob@^1.0.0:
   version "1.0.0"
@@ -11668,14 +11645,6 @@ object-inspect@^1.9.0:
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz"
   integrity sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==
 
-object-is@^1.0.1:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz"
-  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz"
@@ -12027,18 +11996,6 @@ param-case@^2.1.0:
   integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
   dependencies:
     no-case "^2.2.0"
-
-parcel-namer-rewrite@2.0.0-rc.2:
-  version "2.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/parcel-namer-rewrite/-/parcel-namer-rewrite-2.0.0-rc.2.tgz#d6d0738ee5f8cc6a675ce99ca8bf1f62f948250e"
-  integrity sha512-yGLCrZOoR26zPidaXEv+q+mqy5sMKPCA5nPTxqBKdeoF8CntRUwPgK261Gc9a0TzfJWsfeiGgiogL7HTZUa2Gg==
-  dependencies:
-    "@parcel/logger" "^2.0.0-rc.0"
-    "@parcel/namer-default" "^2.0.0-rc.0"
-    "@parcel/package-manager" "^2.0.0-rc.0"
-    "@parcel/plugin" "^2.0.0-rc.0"
-    "@parcel/types" "^2.0.0-rc.0"
-    assert "^2.0.0"
 
 parcel-transformer-env-variables-injection@0.1.0:
   version "0.1.0"
@@ -15372,7 +15329,7 @@ util@^0.10.3, util@~0.10.1:
   dependencies:
     inherits "2.0.3"
 
-util@^0.12.0, util@~0.12.0:
+util@~0.12.0:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
   integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==


### PR DESCRIPTION
PR fixes small issues around extension dev build and allows to render current stuff in popup 
![Screenshot 2022-03-28 at 15 34 20](https://user-images.githubusercontent.com/891392/160412477-944f553d-d234-43c0-9589-cc8b250e15a0.png)

- fixes aliases and adds one missing alias
- fixes CSP, extension requires protocols. added web sockets as well which is required by runtime or hmr (to be determined)
- support for browser routing in extension (at least for now, there is additional ENV, but it really depends on routing strategy)

Questions:
1) How we want to handle routing in extension? Current ext use old hash router, do we want to switch to browser router? Do we want to have exact the same routes in web and ext or routes are define individually in each app?
2) Does anyone build redux-injectors and webext-redux combo? I am not sure proxy store will work
3) Are we aiming for 1:1 implementation, so reducers configuration is in one place etc?

Other stuff that I will extract into tickets
- with self hosted google fonts #526 we will need to adjust ext build again
- resolve issue with static assets. Mainly usage of `<Avatar />` which requires a string url prop. Stuff like https://parceljs.org/recipes/image/#javascript won't work in extension. We may add a copy task before starting a ext build, or just add support for inline svgs and get rid of Avatar usage in logotype in app header, or it may be handled by manifest somehow
- add webext-redux
