### PR TITLE
Clean up unit tests warnings

### DIFF
--- a/internals/generators/component/index.test.tsx.hbs
+++ b/internals/generators/component/index.test.tsx.hbs
@@ -3,19 +3,6 @@ import { render } from '@testing-library/react';
 
 import { {{ properCase componentName }} } from '..';
 
-{{#if wantTranslations}}
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    };
-  },
-}));
-{{/if}}
-
 describe('<{{ properCase componentName }}  />', () => {
   it('should match snapshot', () => {
     const loadingIndicator = render(<{{ properCase componentName }} />);

--- a/src/__mocks__/react-i18next.js
+++ b/src/__mocks__/react-i18next.js
@@ -1,0 +1,52 @@
+// https://github.com/i18next/react-i18next/blob/master/example/test-jest/src/__mocks__/react-i18next.js
+
+const React = require('react')
+const reactI18next = require('react-i18next')
+
+const hasChildren = node => node && (node.children || (node.props && node.props.children))
+
+const getChildren = node => (node && node.children ? node.children : node.props && node.props.children)
+
+const renderNodes = reactNodes => {
+  if (typeof reactNodes === 'string') {
+    return reactNodes
+  }
+
+  return Object.keys(reactNodes).map((key, i) => {
+    const child = reactNodes[key]
+    const isElement = React.isValidElement(child)
+
+    if (typeof child === 'string') {
+      return child
+    }
+    if (hasChildren(child)) {
+      const inner = renderNodes(getChildren(child))
+      return React.cloneElement(child, { ...child.props, key: i }, inner)
+    }
+    if (typeof child === 'object' && !isElement) {
+      return Object.keys(child).reduce((str, childKey) => `${str}${child[childKey]}`, '')
+    }
+
+    return child
+  })
+}
+
+const useMock = [k => k, {}]
+useMock.t = k => k
+useMock.i18n = { language: 'en-US' }
+
+module.exports = {
+  // this mock makes sure any components using the translate HoC receive the t function as a prop
+  withTranslation: () => Component => props => <Component t={k => k} {...props} />,
+  Trans: ({ children }) => (Array.isArray(children) ? renderNodes(children) : renderNodes([children])),
+  Translation: ({ children }) => children(k => k, { i18n: {} }),
+  useTranslation: () => useMock,
+
+  // mock if needed
+  I18nextProvider: reactI18next.I18nextProvider,
+  initReactI18next: reactI18next.initReactI18next,
+  setDefaults: reactI18next.setDefaults,
+  getDefaults: reactI18next.getDefaults,
+  setI18n: reactI18next.setI18n,
+  getI18n: reactI18next.getI18n,
+}

--- a/src/app/components/AddEscrowForm/__tests__/index.test.tsx
+++ b/src/app/components/AddEscrowForm/__tests__/index.test.tsx
@@ -7,18 +7,6 @@ import { Provider } from 'react-redux'
 import { configureAppStore } from 'store/configureStore'
 
 import { AddEscrowForm } from '..'
-import type { UseTranslationResponse } from 'react-i18next'
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 const renderComponent = (store: any, address: string, validatorStatus: Validator['status']) =>
   render(

--- a/src/app/components/ReclaimEscrowForm/__tests__/index.test.tsx
+++ b/src/app/components/ReclaimEscrowForm/__tests__/index.test.tsx
@@ -5,18 +5,6 @@ import { Provider } from 'react-redux'
 import { configureAppStore } from 'store/configureStore'
 
 import { ReclaimEscrowForm } from '..'
-import type { UseTranslationResponse } from 'react-i18next'
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 const renderComponent = (store: any, address: string, maxAmount: string, shares: string) =>
   render(

--- a/src/app/components/ShortAddress/__tests__/index.test.tsx
+++ b/src/app/components/ShortAddress/__tests__/index.test.tsx
@@ -1,17 +1,6 @@
 import { render, screen } from '@testing-library/react'
 
 import { ShortAddress } from '..'
-import type { UseTranslationResponse, Trans } from 'react-i18next'
-
-type TransType = typeof Trans
-jest.mock('react-i18next', () => ({
-  Trans: (({ i18nKey }) => <>{i18nKey}</>) as TransType,
-  useTranslation: () => {
-    return {
-      t: str => str,
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 describe('<ShortAddress  />', () => {
   it('should render short address', () => {

--- a/src/app/components/Sidebar/__tests__/index.test.tsx
+++ b/src/app/components/Sidebar/__tests__/index.test.tsx
@@ -6,18 +6,6 @@ import { Provider } from 'react-redux'
 import { configureAppStore } from 'store/configureStore'
 
 import { Navigation } from '..'
-import type { UseTranslationResponse } from 'react-i18next'
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 const renderComponent = (store: any) => {
   const history = createBrowserHistory()

--- a/src/app/components/Toolbar/Features/AccountSelector/__tests__/index.test.tsx
+++ b/src/app/components/Toolbar/Features/AccountSelector/__tests__/index.test.tsx
@@ -6,7 +6,6 @@ import { configureAppStore } from 'store/configureStore'
 import { ThemeProvider } from 'styles/theme/ThemeProvider'
 
 import { AccountSelector } from '..'
-import type { UseTranslationResponse } from 'react-i18next'
 
 const renderComponent = (store: any) =>
   render(
@@ -16,17 +15,6 @@ const renderComponent = (store: any) =>
       </ThemeProvider>
     </Provider>,
   )
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 describe('<AccountSelector  />', () => {
   let store: ReturnType<typeof configureAppStore>

--- a/src/app/components/Toolbar/Features/NetworkSelector/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Toolbar/Features/NetworkSelector/__tests__/__snapshots__/index.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`<NetworkSelector  /> should match snapshot 1`] = `
       class="c4"
       data-testid="active-network"
     >
-      Local
+      toolbar.networks.local
     </span>
   </div>
 </button>

--- a/src/app/components/Toolbar/Features/NetworkSelector/__tests__/index.test.tsx
+++ b/src/app/components/Toolbar/Features/NetworkSelector/__tests__/index.test.tsx
@@ -36,11 +36,13 @@ describe('<NetworkSelector  />', () => {
 
   it('should allow switching network', async () => {
     const component = renderComponent(store)
-    expect(component.queryByTestId('active-network')).toContainHTML('Local')
+    expect(component.queryByTestId('active-network')).toContainHTML('toolbar.networks.local')
     userEvent.click(screen.getByTestId('network-selector'))
 
-    await waitFor(() => expect(screen.getByText('Testnet')))
-    screen.getByText('Testnet').click()
-    await waitFor(() => expect(component.queryByTestId('active-network')).toContainHTML('Testnet'))
+    await waitFor(() => expect(screen.getByText('toolbar.networks.testnet')))
+    screen.getByText('toolbar.networks.testnet').click()
+    await waitFor(() =>
+      expect(component.queryByTestId('active-network')).toContainHTML('toolbar.networks.testnet'),
+    )
   })
 })

--- a/src/app/components/Toolbar/Features/SearchAddress/__tests__/index.test.tsx
+++ b/src/app/components/Toolbar/Features/SearchAddress/__tests__/index.test.tsx
@@ -5,18 +5,6 @@ import { SearchAddress } from '..'
 import userEvent from '@testing-library/user-event'
 import { Router } from 'react-router'
 import { createMemoryHistory } from 'history'
-import type { UseTranslationResponse } from 'react-i18next'
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 describe('<SearchAddress  />', () => {
   it('should match snapshot', () => {

--- a/src/app/components/Toolbar/__tests__/index.test.tsx
+++ b/src/app/components/Toolbar/__tests__/index.test.tsx
@@ -4,22 +4,10 @@ import { Provider } from 'react-redux'
 import { configureAppStore } from 'store/configureStore'
 
 import { Toolbar } from '..'
-import type { UseTranslationResponse } from 'react-i18next'
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),
-}))
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
 }))
 
 const renderComponent = (store: any) =>

--- a/src/app/components/TransactionModal/__tests__/index.test.tsx
+++ b/src/app/components/TransactionModal/__tests__/index.test.tsx
@@ -2,18 +2,6 @@ import * as React from 'react'
 import { render } from '@testing-library/react'
 
 import { TransactionModal } from '..'
-import type { UseTranslationResponse } from 'react-i18next'
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 describe('<TransactionModal  />', () => {
   it.skip('should match snapshot', () => {

--- a/src/app/pages/AccountPage/Features/SendTransaction/__tests__/index.test.tsx
+++ b/src/app/pages/AccountPage/Features/SendTransaction/__tests__/index.test.tsx
@@ -4,18 +4,6 @@ import * as React from 'react'
 import { Provider } from 'react-redux'
 import { configureAppStore } from 'store/configureStore'
 import { SendTransaction } from '..'
-import type { UseTranslationResponse } from 'react-i18next'
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 const renderComponent = (store: any) =>
   render(

--- a/src/app/pages/CreateWalletPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/CreateWalletPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -1457,7 +1457,11 @@ exports[`<CreateWalletPage  /> should match snapshot 1`] = `
         <span
           class="c17"
         >
-          createWallet.instruction
+          Save your keyphrase 
+          <strong>
+            in the right order
+          </strong>
+           in a secure location, you will need it to open your wallet.
         </span>
       </div>
       <div

--- a/src/app/pages/CreateWalletPage/__tests__/index.test.tsx
+++ b/src/app/pages/CreateWalletPage/__tests__/index.test.tsx
@@ -7,23 +7,8 @@ import { ThemeProvider } from 'styles/theme/ThemeProvider'
 import { Provider } from 'react-redux'
 import { hdkey } from '@oasisprotocol/client'
 import * as bip39 from 'bip39'
-import type { UseTranslationResponse, Trans } from 'react-i18next'
 
 const HDKey = hdkey.HDKey
-
-type TransType = typeof Trans
-jest.mock('react-i18next', () => ({
-  Trans: (({ i18nKey }) => <>{i18nKey}</>) as TransType,
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
-
 const renderPage = (store: any) =>
   render(
     <Provider store={store}>

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/__tests__/__snapshots__/index.test.tsx.snap
@@ -376,7 +376,7 @@ Object {
                   class="c6"
                   size="1"
                 >
-                  Select the wallets to open
+                  openWallet.ledger.selectWallets
                 </h1>
                 <div
                   class="c7"
@@ -387,7 +387,7 @@ Object {
                     style="border-radius: 4px;"
                     type="button"
                   >
-                    Cancel
+                    openWallet.ledger.cancel
                   </button>
                   <div
                     class="c9"
@@ -399,7 +399,7 @@ Object {
                     style="border-radius: 4px;"
                     type="button"
                   >
-                    Open
+                    openWallet.ledger.openWallets
                   </button>
                 </div>
               </div>

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/__tests__/index.test.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/__tests__/index.test.tsx
@@ -9,18 +9,9 @@ import { configureAppStore } from 'store/configureStore'
 import { ThemeProvider } from 'styles/theme/ThemeProvider'
 
 import { FromLedgerModal } from '..'
-import type { UseTranslationResponse } from 'react-i18next'
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
   useDispatch: jest.fn(),
 }))
 

--- a/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/index.test.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/index.test.tsx
@@ -6,18 +6,6 @@ import { configureAppStore } from 'store/configureStore'
 import { Provider } from 'react-redux'
 import { ThemeProvider } from 'styles/theme/ThemeProvider'
 import { FromMnemonic } from '..'
-import type { UseTranslationResponse } from 'react-i18next'
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 const renderPage = (store: any) =>
   render(

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -443,7 +443,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
       <h1
         class="c2"
       >
-        Enter your private key
+        openWallet.privateKey.header
       </h1>
       <p
         class="c3"
@@ -451,7 +451,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
         <label
           for="privatekey"
         >
-          Enter your private key in Base64 format.
+          openWallet.privateKey.instruction
         </label>
       </p>
       <div
@@ -471,7 +471,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
                 class="c8"
                 data-testid="privatekey"
                 id="privatekey"
-                placeholder="Enter your private key here"
+                placeholder="openWallet.privateKey.enterPrivateKeyHere"
                 type="password"
                 value=""
               />
@@ -507,7 +507,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
             style="border-radius: 4px;"
             type="submit"
           >
-            Open my wallet
+            openWallet.mnemonic.open
           </button>
         </div>
       </div>

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/index.test.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/index.test.tsx
@@ -30,11 +30,11 @@ describe('<FromPrivateKey  />', () => {
 
   it('should display an error on invalid private key', () => {
     renderPage(store)
-    const textbox = screen.getByLabelText(/Enter your private key/)
-    const button = screen.getByRole('button', { name: /Open my wallet/ })
+    const textbox = screen.getByPlaceholderText('openWallet.privateKey.enterPrivateKeyHere')
+    const button = screen.getByRole('button', { name: 'openWallet.mnemonic.open' })
     userEvent.type(textbox, 'hello')
     userEvent.click(button)
-    const errorElem = screen.getByText(/Invalid private key/)
+    const errorElem = screen.getByText('openWallet.privateKey.error')
     expect(errorElem).toBeInTheDocument()
 
     // A valid phrase should remove the error
@@ -49,8 +49,8 @@ describe('<FromPrivateKey  />', () => {
 
   it('should allow multiline private keys with envelope', async () => {
     renderPage(store)
-    const textbox = screen.getByLabelText(/Enter your private key/)
-    const button = screen.getByRole('button', { name: /Open my wallet/ })
+    const textbox = screen.getByPlaceholderText('openWallet.privateKey.enterPrivateKeyHere')
+    const button = screen.getByRole('button', { name: 'openWallet.mnemonic.open' })
     userEvent.type(
       textbox,
       `

--- a/src/app/pages/StakingPage/Features/CommissionBounds/__tests__/index.test.tsx
+++ b/src/app/pages/StakingPage/Features/CommissionBounds/__tests__/index.test.tsx
@@ -8,6 +8,8 @@ import { configureAppStore } from 'store/configureStore'
 
 import { CommissionBounds } from '..'
 
+jest.unmock('react-i18next')
+
 const renderComponent = (store: any, bounds?: ICommissionBounds[]) =>
   render(
     <Provider store={store}>

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/ActiveDelegationList.test.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/ActiveDelegationList.test.tsx
@@ -5,18 +5,6 @@ import { Provider } from 'react-redux'
 import { ActiveDelegationList } from '../ActiveDelegationList'
 import { configureAppStore } from 'store/configureStore'
 import { stakingActions } from 'app/state/staking'
-import type { UseTranslationResponse } from 'react-i18next'
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 const renderComponent = (store: any) =>
   render(

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/DebondingDelegationList.test.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/DebondingDelegationList.test.tsx
@@ -7,18 +7,6 @@ import { Provider } from 'react-redux'
 import { DebondingDelegationList } from '../DebondingDelegationList'
 import { configureAppStore } from 'store/configureStore'
 import { stakingActions } from 'app/state/staking'
-import type { UseTranslationResponse } from 'react-i18next'
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 const renderComponent = (store: any) =>
   render(

--- a/src/app/pages/StakingPage/Features/ValidatorList/__tests__/index.test.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/__tests__/index.test.tsx
@@ -5,7 +5,6 @@ import { Validator } from 'app/state/staking/types'
 import * as React from 'react'
 import { Provider } from 'react-redux'
 import { configureAppStore } from 'store/configureStore'
-import type { UseTranslationResponse } from 'react-i18next'
 
 import { ValidatorList } from '..'
 
@@ -44,17 +43,6 @@ const unknownValidator: Validator = {
   name: 'test-validator3',
   media: activeValidator.media,
 }
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: str => str,
-      i18n: {
-        changeLanguage: () => new Promise(() => {}),
-      },
-    } as UseTranslationResponse<'translation'>
-  },
-}))
 
 const renderComponent = (store: any) =>
   render(

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -18,3 +18,5 @@ window.TextEncoder = global.TextEncoder
 
 global.fetch = require('portable-fetch')
 window.fetch = require('portable-fetch')
+
+global.window.scrollTo = () => {}


### PR DESCRIPTION
PR removes two types of warnings that are thrown when unit tests are running

- `Warning: React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined.`
- `Not implemented: window.scrollTo`

I've copied mock from `react-i18next` repo.  It fixes issue with `undefined` in all places where `Trans` component is used. Instead of adding mock in all places let's add it globally. We can always override it in each test file when needed (`CommissionBounds` is an example where test relies on interpolation/real implementation).

