### PR TITLE
i18n: Fix wrong usage of "wallet" in contrast to "account"

### DIFF
--- a/cypress/integration/create-wallet.ts
+++ b/cypress/integration/create-wallet.ts
@@ -17,12 +17,12 @@ describe('Create wallet', () => {
   })
 
   it('should not be able to submit without confirmation', () => {
-    cy.findByRole('button', { name: /Open my wallet/ }).should('be.disabled')
+    cy.findByRole('button', { name: /Import my wallet/ }).should('be.disabled')
   })
 
   it('Should open mnemonic confirmation', () => {
     cy.findByLabelText(/saved/).click({ force: true })
-    cy.findByRole('button', { name: /Open my wallet/ })
+    cy.findByRole('button', { name: /Import my wallet/ })
       .should('be.enabled')
       .click()
   })
@@ -34,15 +34,15 @@ describe('Create wallet', () => {
       'abuse gown claw final toddler wedding sister parade useful typical spatial skate decrease bulk student manual cloth shove fat car little swamp tag ginger',
       { delay: 0 },
     )
-    cy.findByRole('button', { name: /Open my wallet/ }).click()
+    cy.findByRole('button', { name: /Import my wallet/ }).click()
     cy.contains('mnemonic does not match').should('exist')
   })
 
   it('Should confirm mnemonic', () => {
     cy.findByRole('button', { name: /Send/ }).should('not.exist')
-    cy.findByRole('button', { name: /Open my wallet/ }).click()
+    cy.findByRole('button', { name: /Import my wallet/ }).click()
     cy.findByTestId('mnemonic').type(generatedMnemonic, { delay: 0 })
-    cy.findByRole('button', { name: /Open my wallet/ }).click()
+    cy.findByRole('button', { name: /Import my wallet/ }).click()
     cy.contains('mnemonic does not match').should('not.exist')
     cy.findByRole('button', { name: /Send/ }).should('exist')
   })

--- a/cypress/integration/open-wallet.ts
+++ b/cypress/integration/open-wallet.ts
@@ -26,7 +26,7 @@ describe('Open wallet', () => {
 
     it('Should reject invalid mnemonics', () => {
       cy.findByTestId('mnemonic').type('this is an invalid mnemonic')
-      cy.findByRole('button', { name: /Open my wallet/ }).click()
+      cy.findByRole('button', { name: /Import my wallet/ }).click()
       cy.findByText(/Invalid keyphrase/).should('be.visible')
     })
 
@@ -35,7 +35,7 @@ describe('Open wallet', () => {
         'planet believe session regular rib kiss police deposit prison hundred apart tongue',
         { delay: 1 },
       )
-      cy.findByRole('button', { name: /Open my wallet/ }).click()
+      cy.findByRole('button', { name: /Import my wallet/ }).click()
       cy.findByText(/Invalid keyphrase/).should('not.exist')
       cy.url().should('include', 'oasis1qqca0gplrfn63ljg9c833te7em36lkz0cv8djffh')
     })
@@ -48,7 +48,7 @@ describe('Open wallet', () => {
 
     it('Should reject invalid keys', () => {
       cy.findByTestId('privatekey').type('this is an invalid key')
-      cy.findByRole('button', { name: /Open my wallet/ }).click()
+      cy.findByRole('button', { name: /Import my wallet/ }).click()
       cy.findByText(/Invalid private key/).should('be.visible')
     })
 
@@ -57,30 +57,30 @@ describe('Open wallet', () => {
         'X0jlpvskP1q8E6rHxWRJr7yTvpCuOPEKBGW8gtuVTxfnViTI0s2fBizgMxNzo75Q7w7MxdJXtOLeqDoFUGxxMg==',
         { delay: 1 },
       )
-      cy.findByRole('button', { name: /Open my wallet/ }).click()
+      cy.findByRole('button', { name: /Import my wallet/ }).click()
       cy.findByText(/Invalid private key/).should('not.exist')
       cy.url().should('include', '/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk')
     })
   })
 
   // it('should not be able to submit without confirmation', () => {
-  //   cy.findByRole('button', { name: /Open my wallet/ }).should('be.disabled')
+  //   cy.findByRole('button', { name: /Import my wallet/ }).should('be.disabled')
   // });
 
   // it('should be able to submit with confirmation', () => {
   //   cy.findByLabelText(/saved/).click({ force: true })
-  //   cy.findByRole('button', { name: /Open my wallet/ }).should('be.enabled')
+  //   cy.findByRole('button', { name: /Import my wallet/ }).should('be.enabled')
   // });
 
   // it('Should open wallet', () => {
   //   cy.findByLabelText(/saved/).click({ force: true })
-  //   cy.findByRole('button', { name: /Open my wallet/ }).should('be.enabled').click()
+  //   cy.findByRole('button', { name: /Import my wallet/ }).should('be.enabled').click()
   //   cy.url().should('include', '/wallet')
   // })
 
   // it('Should be able to close the wallet once opened', () => {
   //   cy.findByLabelText(/saved/).click({ force: true })
-  //   cy.findByRole('button', { name: /Open my wallet/i }).click()
+  //   cy.findByRole('button', { name: /Import my wallet/i }).click()
   //   cy.url().should('include', '/wallet')
   //   cy.get('button[aria-label="Close Wallet"]').click()
 

--- a/cypress/integration/scenario-account-switcher.ts
+++ b/cypress/integration/scenario-account-switcher.ts
@@ -9,7 +9,7 @@ describe('Scenario : multiple accounts', () => {
       'abuse gown claw final toddler wedding sister parade useful typical spatial skate decrease bulk student manual cloth shove fat car little swamp tag ginger',
       { delay: 0 },
     )
-    cy.findByRole('button', { name: /Open my wallet/ }).click()
+    cy.findByRole('button', { name: /Import my wallet/ }).click()
     cy.url().should('include', '/account/oasis1qq5t7f2gecsjsdxmp5zxtwgck6pzpjmkvc657z6l')
 
     cy.findByTestId('nav-home').click()
@@ -21,7 +21,7 @@ describe('Scenario : multiple accounts', () => {
       'X0jlpvskP1q8E6rHxWRJr7yTvpCuOPEKBGW8gtuVTxfnViTI0s2fBizgMxNzo75Q7w7MxdJXtOLeqDoFUGxxMg==',
       { delay: 0 },
     )
-    cy.findByRole('button', { name: /Open my wallet/ }).click()
+    cy.findByRole('button', { name: /Import my wallet/ }).click()
     cy.url().should('include', '/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk')
   })
 

--- a/cypress/integration/scenario-transaction.ts
+++ b/cypress/integration/scenario-transaction.ts
@@ -28,7 +28,7 @@ describe('Scenario : from mnemonic', () => {
       'abuse gown claw final toddler wedding sister parade useful typical spatial skate decrease bulk student manual cloth shove fat car little swamp tag ginger',
       { delay: 1 },
     )
-    cy.findByRole('button', { name: /Open my wallet/ }).click()
+    cy.findByRole('button', { name: /Import my wallet/ }).click()
     cy.url().should('include', '/account/oasis1qq5t7f2gecsjsdxmp5zxtwgck6pzpjmkvc657z6l')
   })
 
@@ -81,7 +81,7 @@ describe('Scenario : from private key', () => {
       'X0jlpvskP1q8E6rHxWRJr7yTvpCuOPEKBGW8gtuVTxfnViTI0s2fBizgMxNzo75Q7w7MxdJXtOLeqDoFUGxxMg==',
       { delay: 1 },
     )
-    cy.findByRole('button', { name: /Open my wallet/ }).click()
+    cy.findByRole('button', { name: /Import my wallet/ }).click()
   })
 
   it('Should send a transaction', () => {

--- a/src/app/components/FatalErrorHandler/index.tsx
+++ b/src/app/components/FatalErrorHandler/index.tsx
@@ -45,7 +45,7 @@ export function FatalErrorHandler(props: Props) {
           <Text>
             <Trans
               i18nKey="fatalError.instruction"
-              defaults="A fatal error has occurred and Oasis Wallet must stop. Try refreshing the page and reopening your wallets to see if the issue persists. If the issue persists, please contact our support team via <0>wallet@oasisprotocol.org</0> email and attach the report below."
+              defaults="A fatal error has occurred and Oasis Wallet must stop. Try refreshing the page and reopening your wallet to see if the issue persists. If the issue persists, please contact our support team via <0>wallet@oasisprotocol.org</0> email and attach the report below."
               t={t}
               components={[<Anchor href="mailto:wallet@oasisprotocol.org" />]}
             />

--- a/src/app/components/MnemonicValidation/index.tsx
+++ b/src/app/components/MnemonicValidation/index.tsx
@@ -78,7 +78,7 @@ export function MnemonicValidation(props: Props) {
             <Box direction="row" gap="small" margin={{ top: 'medium' }}>
               <Button
                 type="submit"
-                label={t('openWallet.mnemonic.open', 'Open my wallet')}
+                label={t('openWallet.mnemonic.import', 'Import my wallet')}
                 style={{ borderRadius: '4px' }}
                 primary
                 onClick={onSubmit}

--- a/src/app/components/Toolbar/Features/AccountSelector/index.tsx
+++ b/src/app/components/Toolbar/Features/AccountSelector/index.tsx
@@ -120,7 +120,7 @@ export const AccountSelector = memo((props: Props) => {
     >
       <Box pad={{ vertical: 'small' }} margin="medium" width={size === 'small' ? 'auto' : '700px'}>
         <Heading size="1" margin={{ vertical: 'small' }}>
-          {t('toolbar.wallets.switchOtherWallet', 'Switch to another wallet')}
+          {t('toolbar.wallets.switchOtherWallet', 'Switch to another account')}
         </Heading>
         <Box
           gap="small"

--- a/src/app/pages/AccountPage/Features/SendTransaction/index.tsx
+++ b/src/app/pages/AccountPage/Features/SendTransaction/index.tsx
@@ -35,7 +35,7 @@ export function SendTransaction() {
         ),
         description: t(
           'account.sendTransaction.confirmSendingToValidator.description',
-          'This is a validator wallet address. Transfers to this address do not stake your funds with the validator.',
+          'This is a validator address. Transfers to this address do not stake your funds with the validator.',
         ),
         handleConfirm: sendTransaction,
         isDangerous: true,

--- a/src/app/pages/CreateWalletPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/CreateWalletPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -1504,7 +1504,7 @@ exports[`<CreateWalletPage  /> should match snapshot 1`] = `
             style="border-radius: 4px;"
             type="submit"
           >
-            openWallet.mnemonic.open
+            openWallet.mnemonic.import
           </button>
         </div>
       </div>

--- a/src/app/pages/CreateWalletPage/index.tsx
+++ b/src/app/pages/CreateWalletPage/index.tsx
@@ -157,7 +157,7 @@ export function CreateWalletPage(props: CreateWalletProps) {
             <Box direction="row" justify="between" margin={{ top: 'medium' }}>
               <Button
                 type="submit"
-                label={t('openWallet.mnemonic.open', 'Open my wallet')}
+                label={t('openWallet.mnemonic.import', 'Import my wallet')}
                 style={{ borderRadius: '4px' }}
                 primary
                 disabled={!checked}

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -20,7 +20,7 @@ export function HomePage() {
           <Paragraph>
             {t(
               'home.existing.description',
-              'Open your existing wallet using Ledger, a private key, or your mnemonic phrase.',
+              'Open your existing wallet stored on Ledger, import a private key or a mnemonic phrase.',
             )}
           </Paragraph>
           <Box direction="row" justify="between" margin={{ top: 'medium' }}>

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
@@ -74,7 +74,7 @@ export function FromLedger(props: FromLedgerProps) {
       <Box direction="row" margin={{ top: 'medium' }}>
         <Button
           type="submit"
-          label={t('openWallet.ledger.selectWallets', 'Select the wallets to open')}
+          label={t('openWallet.ledger.selectWallets', 'Select accounts to open')}
           style={{ borderRadius: '4px' }}
           onClick={() => {
             showLedgerModal(true)
@@ -123,7 +123,7 @@ export function FromLedgerModal(props: FromLedgerModalProps) {
     <ResponsiveLayer position="center" modal>
       <Box width="750px" pad="medium" background="background-front">
         <Heading size="1" margin={{ bottom: 'medium', top: 'none' }}>
-          {t('openWallet.ledger.selectWallets', 'Select the wallets to open')}
+          {t('openWallet.ledger.selectWallets', 'Select accounts to open')}
         </Heading>
         {ledger.step && ledger.step !== LedgerStep.Done && (
           <Box direction="row" gap="medium" alignContent="center">

--- a/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/__snapshots__/index.test.tsx.snap
@@ -488,7 +488,7 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
               style="border-radius: 4px;"
               type="submit"
             >
-              openWallet.mnemonic.open
+              openWallet.mnemonic.import
             </button>
           </div>
         </form>

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -507,7 +507,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
             style="border-radius: 4px;"
             type="submit"
           >
-            openWallet.mnemonic.open
+            openWallet.mnemonic.import
           </button>
         </div>
       </div>

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/index.test.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/index.test.tsx
@@ -31,7 +31,7 @@ describe('<FromPrivateKey  />', () => {
   it('should display an error on invalid private key', () => {
     renderPage(store)
     const textbox = screen.getByPlaceholderText('openWallet.privateKey.enterPrivateKeyHere')
-    const button = screen.getByRole('button', { name: 'openWallet.mnemonic.open' })
+    const button = screen.getByRole('button', { name: 'openWallet.mnemonic.import' })
     userEvent.type(textbox, 'hello')
     userEvent.click(button)
     const errorElem = screen.getByText('openWallet.privateKey.error')
@@ -50,7 +50,7 @@ describe('<FromPrivateKey  />', () => {
   it('should allow multiline private keys with envelope', async () => {
     renderPage(store)
     const textbox = screen.getByPlaceholderText('openWallet.privateKey.enterPrivateKeyHere')
-    const button = screen.getByRole('button', { name: 'openWallet.mnemonic.open' })
+    const button = screen.getByRole('button', { name: 'openWallet.mnemonic.import' })
     userEvent.type(
       textbox,
       `

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
@@ -95,7 +95,7 @@ export function FromPrivateKey(props: Props) {
           <Box direction="row" justify="between" margin={{ top: 'medium' }}>
             <Button
               type="submit"
-              label={t('openWallet.mnemonic.open', 'Open my wallet')}
+              label={t('openWallet.mnemonic.import', 'Import my account')}
               style={{ borderRadius: '4px' }}
               primary
               onClick={onSubmit}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -18,7 +18,7 @@
     },
     "sendTransaction": {
       "confirmSendingToValidator": {
-        "description": "This is a validator wallet address. Transfers to this address do not stake your funds with the validator.",
+        "description": "This is a validator address. Transfers to this address do not stake your funds with the validator.",
         "title": "Are you sure you want to continue?"
       },
       "enterAddress": "Enter an address",
@@ -117,7 +117,7 @@
     "copied": "Error copied to clipboard",
     "copy": "Copy error to clipboard",
     "heading": "A fatal error occurred",
-    "instruction": "A fatal error has occurred and Oasis Wallet must stop. Try refreshing the page and reopening your wallets to see if the issue persists. If the issue persists, please contact our support team via <0>wallet@oasisprotocol.org</0> email and attach the report below."
+    "instruction": "A fatal error has occurred and Oasis Wallet must stop. Try refreshing the page and reopening your wallet to see if the issue persists. If the issue persists, please contact our support team via <0>wallet@oasisprotocol.org</0> email and attach the report below."
   },
   "footer": {
     "github": "Oasis Wallet is fully <0>open source</0> - Feedback and issues are appreciated!",
@@ -136,7 +136,7 @@
     },
     "existing": {
       "button": "Open wallet",
-      "description": "Open your existing wallet using Ledger, a private key, or your mnemonic phrase.",
+      "description": "Open your existing wallet stored on Ledger, import a private key or a mnemonic phrase.",
       "header": "Access existing wallet"
     }
   },
@@ -170,7 +170,7 @@
       "cancel": "Cancel",
       "header": "Open from Ledger device",
       "openWallets": "Open",
-      "selectWallets": "Select the wallets to open"
+      "selectWallets": "Select accounts to open"
     },
     "method": {
       "ledger": "Ledger",
@@ -181,8 +181,8 @@
       "enterPhraseHere": "Enter your keyphrase here",
       "error": "Invalid keyphrase. Please make sure to input the words in the right order, all lowercase.",
       "header": "Enter your keyphrase",
-      "instruction": "Enter all your keyphrase words below separated by spaces. Most keyphrases are made of either 24 or 12 words.",
-      "open": "Open my wallet"
+      "import": "Import my wallet",
+      "instruction": "Enter all your keyphrase words below separated by spaces. Most keyphrases are made of either 24 or 12 words."
     },
     "privateKey": {
       "enterPrivateKeyHere": "Enter your private key here",
@@ -208,7 +208,7 @@
     },
     "wallets": {
       "close": "Close",
-      "switchOtherWallet": "Switch to another wallet",
+      "switchOtherWallet": "Switch to another account",
       "type": {
         "ledger": "Ledger",
         "mnemonic": "Mnemonic",


### PR DESCRIPTION
Term "account" denotes a keypair corresponding to a single oasis address. The term wallet denotes one or more accounts stored in a file, browser, Ledger, as a mnemonic etc.

Term "open" corresponds to an action where you open something stored in a file or a Ledger device. Term "import" corresponds to an action where you need to type in mnemonics or a private key again in order to access it.

This PR fixes the usage of account/wallet and open/import terms.

Fixes https://github.com/oasisprotocol/oasis-wallet-web/issues/812