### PR TITLE
Refactor sidebar and make all buttons focusable

### DIFF
--- a/src/app/components/Sidebar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Sidebar/__tests__/__snapshots__/index.test.tsx.snap
@@ -695,13 +695,14 @@ exports[`<Navigation /> should match snapshot 1`] = `
     <div
       class="c6"
     />
-    <div
-      class="c15"
+    <a
+      aria-label="GitHub"
+      href="/https://github.com/oasisprotocol/oasis-wallet-web"
+      rel="noopener"
+      target="_blank"
     >
-      <a
-        href="https://github.com/oasisprotocol/oasis-wallet-web"
-        rel="noopener"
-        target="_blank"
+      <div
+        class="c14"
       >
         <svg
           aria-label="Github"
@@ -714,8 +715,16 @@ exports[`<Navigation /> should match snapshot 1`] = `
             fill-rule="evenodd"
           />
         </svg>
-      </a>
-    </div>
+        <div
+          class="c11"
+        />
+        <span
+          class="c5"
+        >
+          GitHub
+        </span>
+      </div>
+    </a>
   </nav>
 </div>
 `;

--- a/src/app/components/Sidebar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Sidebar/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Navigation /> should match snapshot 1`] = `
-.c12 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`<Navigation /> should match snapshot 1`] = `
   stroke: #666666;
 }
 
-.c12 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c12 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c12 *[stroke*="#"],
-.c12 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c12 *[fill-rule],
-.c12 *[FILL-RULE],
-.c12 *[fill*="#"],
-.c12 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -171,37 +171,19 @@ exports[`<Navigation /> should match snapshot 1`] = `
   background: background-oasis-blue;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
   padding-top: 12px;
   padding-bottom: 12px;
   padding-left: 24px;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c14 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -218,7 +200,7 @@ exports[`<Navigation /> should match snapshot 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -227,15 +209,19 @@ exports[`<Navigation /> should match snapshot 1`] = `
   max-width: 100%;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
   padding-top: 12px;
   padding-bottom: 12px;
   padding-left: 24px;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -254,7 +240,7 @@ exports[`<Navigation /> should match snapshot 1`] = `
   padding: 12px;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -270,7 +256,7 @@ exports[`<Navigation /> should match snapshot 1`] = `
   border-radius: 4px;
 }
 
-.c19 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -285,7 +271,7 @@ exports[`<Navigation /> should match snapshot 1`] = `
   padding: 12px;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -323,7 +309,7 @@ exports[`<Navigation /> should match snapshot 1`] = `
   height: 12px;
 }
 
-.c13 {
+.c11 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -338,48 +324,7 @@ exports[`<Navigation /> should match snapshot 1`] = `
   line-height: 24px;
 }
 
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: start;
-  align-self: flex-start;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c17 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -395,45 +340,104 @@ exports[`<Navigation /> should match snapshot 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  width: 100%;
 }
 
-.c17:focus {
+.c13:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c13:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c16 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c16:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus > circle,
+.c16:focus > ellipse,
+.c16:focus > line,
+.c16:focus > path,
+.c16:focus > polygon,
+.c16:focus > polyline,
+.c16:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c16:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c16:focus:not(:focus-visible) > circle,
+.c16:focus:not(:focus-visible) > ellipse,
+.c16:focus:not(:focus-visible) > line,
+.c16:focus:not(:focus-visible) > path,
+.c16:focus:not(:focus-visible) > polygon,
+.c16:focus:not(:focus-visible) > polyline,
+.c16:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c16:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -481,25 +485,25 @@ exports[`<Navigation /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c15 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c18 {
+  .c17 {
     border: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c19 {
+  .c18 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c20 {
+  .c19 {
     padding: 6px;
   }
 }
@@ -553,39 +557,34 @@ exports[`<Navigation /> should match snapshot 1`] = `
     >
       <a
         aria-current="page"
+        aria-label="menu.home"
         class="active"
+        data-testid="nav-home"
         href="/"
       >
         <div
           class="c9"
         >
-          <button
-            aria-label="menu.home"
+          <svg
+            aria-label="Home"
             class="c10"
-            data-testid="nav-home"
-            type="button"
+            viewBox="0 0 24 24"
           >
-            <div
-              class="c11"
-            >
-              <svg
-                aria-label="Home"
-                class="c12"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m1 11 11-9 11 9m-8 12v-8H9v8m-5 0V9m16 14V9"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-              <div
-                class="c13"
-              />
-              menu.home
-            </div>
-          </button>
+            <path
+              d="m1 11 11-9 11 9m-8 12v-8H9v8m-5 0V9m16 14V9"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+          <div
+            class="c11"
+          />
+          <span
+            class="c5"
+          >
+            menu.home
+          </span>
         </div>
       </a>
       <div
@@ -600,61 +599,61 @@ exports[`<Navigation /> should match snapshot 1`] = `
     class="c6"
   />
   <nav
-    class="c14"
+    class="c12"
   >
+    <button
+      aria-label="theme.darkMode"
+      class="c13"
+      type="button"
+    >
+      <div
+        class="c14"
+      >
+        <svg
+          aria-label="Moon"
+          class="c10"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M9.874 5.008c2.728-1.68 6.604-1.014 8.25.197-2.955.84-5.11 3.267-5.242 6.415-.18 4.28 3.006 6.588 5.24 7.152-1.964 1.343-4.36 1.293-5.235 1.172-3.568-.492-6.902-3.433-7.007-7.711-.106-4.278 2.573-6.35 3.994-7.225z"
+            stroke="#000"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+        <div
+          class="c11"
+        />
+        <span
+          class="c5"
+        >
+          theme.darkMode
+        </span>
+      </div>
+    </button>
+    <div
+      class="c6"
+    />
+    <div
+      class="c6"
+    />
     <div
       class="c15"
     >
       <button
-        aria-label="theme.darkMode"
-        class="c10"
-        type="button"
-      >
-        <div
-          class="c11"
-        >
-          <svg
-            aria-label="Moon"
-            class="c12"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M9.874 5.008c2.728-1.68 6.604-1.014 8.25.197-2.955.84-5.11 3.267-5.242 6.415-.18 4.28 3.006 6.588 5.24 7.152-1.964 1.343-4.36 1.293-5.235 1.172-3.568-.492-6.902-3.433-7.007-7.711-.106-4.278 2.573-6.35 3.994-7.225z"
-              stroke="#000"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-          <div
-            class="c13"
-          />
-          theme.darkMode
-        </div>
-      </button>
-    </div>
-    <div
-      class="c6"
-    />
-    <div
-      class="c6"
-    />
-    <div
-      class="c16"
-    >
-      <button
         aria-label="Open Menu"
-        class="c17"
+        class="c16"
         type="button"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c19"
+            class="c18"
           >
             <svg
               aria-label="Language"
-              class="c12"
+              class="c10"
               viewBox="0 0 24 24"
             >
               <path
@@ -666,7 +665,7 @@ exports[`<Navigation /> should match snapshot 1`] = `
             </svg>
           </div>
           <div
-            class="c20"
+            class="c19"
           >
             <span
               class="c5"
@@ -675,11 +674,11 @@ exports[`<Navigation /> should match snapshot 1`] = `
             </span>
           </div>
           <div
-            class="c19"
+            class="c18"
           >
             <svg
               aria-label="FormDown"
-              class="c12"
+              class="c10"
               viewBox="0 0 24 24"
             >
               <path
@@ -697,7 +696,7 @@ exports[`<Navigation /> should match snapshot 1`] = `
       class="c6"
     />
     <div
-      class="c16"
+      class="c15"
     >
       <a
         href="https://github.com/oasisprotocol/oasis-wallet-web"
@@ -706,7 +705,7 @@ exports[`<Navigation /> should match snapshot 1`] = `
       >
         <svg
           aria-label="Github"
-          class="c12"
+          class="c10"
           viewBox="0 0 24 24"
         >
           <path

--- a/src/app/components/Sidebar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Sidebar/__tests__/__snapshots__/index.test.tsx.snap
@@ -228,10 +228,10 @@ exports[`<Navigation /> should match snapshot 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -247,13 +247,11 @@ exports[`<Navigation /> should match snapshot 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  border-radius: 4px;
 }
 
 .c18 {
@@ -487,12 +485,6 @@ exports[`<Navigation /> should match snapshot 1`] = `
 @media only screen and (max-width:768px) {
   .c15 {
     padding: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c17 {
-    border: solid 1px rgba(0,0,0,0.33);
   }
 }
 

--- a/src/app/components/Sidebar/index.tsx
+++ b/src/app/components/Sidebar/index.tsx
@@ -1,10 +1,9 @@
 import { walletActions } from 'app/state/wallet'
-import { selectAddress, selectStatus } from 'app/state/wallet/selectors'
+import { selectAddress, selectIsOpen } from 'app/state/wallet/selectors'
 import {
   Avatar,
   Box,
   Button,
-  ButtonExtendedProps,
   Layer,
   Menu,
   Nav,
@@ -32,20 +31,36 @@ import { ThemeSwitcher } from '../ThemeSwitcher'
 import logotype from '../../../../public/logo192.png'
 import { languageLabels } from '../../../locales/i18n'
 
-interface SidebarButtonProps extends ButtonExtendedProps {
-  secure?: boolean
-  route?: string
+interface SidebarButtonBaseProps {
+  needsWalletOpen?: boolean
+  icon: JSX.Element
   label: string
 }
 
-export const SidebarButton = ({ secure, icon, label, route, ...rest }: SidebarButtonProps) => {
-  const status = useSelector(selectStatus)
+type SidebarButtonProps = SidebarButtonBaseProps &
+  (
+    | { route: string; onClick?: undefined }
+    | {
+        route?: undefined
+        onClick: React.MouseEventHandler<HTMLButtonElement> & React.MouseEventHandler<HTMLAnchorElement>
+      }
+  )
+
+export const SidebarButton = ({
+  needsWalletOpen,
+  icon,
+  label,
+  route,
+  onClick,
+  ...rest
+}: SidebarButtonProps) => {
+  const isWalletOpen = useSelector(selectIsOpen)
   const size = useContext(ResponsiveContext)
   const location = useLocation()
-  const isActive = route && route === location.pathname
+  const isActive = route ? route === location.pathname : false
   const isMediumSize = size === 'medium'
 
-  if (!status && secure) {
+  if (!isWalletOpen && needsWalletOpen) {
     return null
   }
 
@@ -75,6 +90,7 @@ export const SidebarButton = ({ secure, icon, label, route, ...rest }: SidebarBu
           plain
           icon={icon}
           label={!isMediumSize ? label : undefined}
+          onClick={onClick}
           {...rest}
         />
       </Box>
@@ -144,7 +160,7 @@ const SidebarFooter = (props: SidebarFooterProps) => {
       <SidebarButton
         icon={<Logout />}
         label={t('menu.closeWallet', 'Close wallet')}
-        secure={true}
+        needsWalletOpen={true}
         onClick={() => logout()}
       />
       <Box pad="small" align="center">
@@ -189,7 +205,7 @@ function SidebarMenuItems() {
       <SidebarButton
         icon={<Money />}
         label={t('menu.wallet', 'Wallet')}
-        secure={true}
+        needsWalletOpen={true}
         route={`/account/${address}`}
         data-testid="nav-myaccount"
       />
@@ -198,7 +214,7 @@ function SidebarMenuItems() {
       <SidebarButton
         icon={<LineChart />}
         label={t('menu.stake', 'Stake')}
-        secure={true}
+        needsWalletOpen={true}
         route={`/account/${address}/stake`}
         data-testid="nav-stake"
       />

--- a/src/app/components/Sidebar/index.tsx
+++ b/src/app/components/Sidebar/index.tsx
@@ -75,33 +75,43 @@ export const SidebarButton = ({
     </Box>
   )
 
-  const component = (
+  const SidebarTooltip = (props: { children: React.ReactNode }) => (
     <Tip content={isMediumSize ? tooltip : undefined} dropProps={{ align: { left: 'right' } }} plain={true}>
-      <Box
-        pad={{ vertical: 'small', left: isMediumSize ? 'none' : 'medium' }}
-        background={isActive ? 'background-oasis-blue' : undefined}
-        responsive={false}
-      >
-        <Button
-          a11yTitle={label}
-          gap="medium"
-          alignSelf={isMediumSize ? 'center' : 'start'}
-          focusIndicator={false}
-          plain
-          icon={icon}
-          label={!isMediumSize ? label : undefined}
-          onClick={onClick}
-          {...rest}
-        />
-      </Box>
+      {props.children}
     </Tip>
   )
 
-  if (route) {
-    return <NavLink to={route}>{component}</NavLink>
-  }
+  const component = (
+    <Box
+      pad={{ vertical: 'small', left: isMediumSize ? 'none' : 'medium' }}
+      background={isActive ? 'background-oasis-blue' : undefined}
+      responsive={false}
+      direction="row"
+      gap="medium"
+      justify={isMediumSize ? 'center' : 'start'}
+    >
+      {icon}
+      {!isMediumSize && <Text>{label}</Text>}
+    </Box>
+  )
 
-  return component
+  if (route) {
+    return (
+      <SidebarTooltip>
+        <NavLink aria-label={label} to={route} {...rest}>
+          {component}
+        </NavLink>
+      </SidebarTooltip>
+    )
+  } else {
+    return (
+      <SidebarTooltip>
+        <Button a11yTitle={label} fill="horizontal" onClick={onClick} {...rest}>
+          {component}
+        </Button>
+      </SidebarTooltip>
+    )
+  }
 }
 
 type Size = 'small' | 'medium' | 'large'

--- a/src/app/components/Sidebar/index.tsx
+++ b/src/app/components/Sidebar/index.tsx
@@ -31,6 +31,26 @@ import { ThemeSwitcher } from '../ThemeSwitcher'
 import logotype from '../../../../public/logo192.png'
 import { languageLabels } from '../../../locales/i18n'
 
+const SidebarTooltip = (props: { children: React.ReactNode; isActive: boolean; label: string }) => {
+  const size = useContext(ResponsiveContext)
+  const isMediumSize = size === 'medium'
+  const tooltip = (
+    <Box
+      pad={{ vertical: 'small', right: 'medium' }}
+      margin="none"
+      background={props.isActive ? 'background-oasis-blue' : 'component-sidebar'}
+      round={{ size: 'medium', corner: 'right' }}
+    >
+      {props.label}
+    </Box>
+  )
+  return (
+    <Tip content={isMediumSize ? tooltip : undefined} dropProps={{ align: { left: 'right' } }} plain={true}>
+      {props.children}
+    </Tip>
+  )
+}
+
 interface SidebarButtonBaseProps {
   needsWalletOpen?: boolean
   icon: JSX.Element
@@ -39,9 +59,10 @@ interface SidebarButtonBaseProps {
 
 type SidebarButtonProps = SidebarButtonBaseProps &
   (
-    | { route: string; onClick?: undefined }
+    | { route: string; newTab?: boolean; onClick?: undefined }
     | {
         route?: undefined
+        newTab?: undefined
         onClick: React.MouseEventHandler<HTMLButtonElement> & React.MouseEventHandler<HTMLAnchorElement>
       }
   )
@@ -51,6 +72,7 @@ export const SidebarButton = ({
   icon,
   label,
   route,
+  newTab,
   onClick,
   ...rest
 }: SidebarButtonProps) => {
@@ -63,23 +85,6 @@ export const SidebarButton = ({
   if (!isWalletOpen && needsWalletOpen) {
     return null
   }
-
-  const tooltip = (
-    <Box
-      pad={{ vertical: 'small', right: 'medium' }}
-      margin="none"
-      background={isActive ? 'background-oasis-blue' : 'component-sidebar'}
-      round={{ size: 'medium', corner: 'right' }}
-    >
-      {label}
-    </Box>
-  )
-
-  const SidebarTooltip = (props: { children: React.ReactNode }) => (
-    <Tip content={isMediumSize ? tooltip : undefined} dropProps={{ align: { left: 'right' } }} plain={true}>
-      {props.children}
-    </Tip>
-  )
 
   const component = (
     <Box
@@ -97,15 +102,20 @@ export const SidebarButton = ({
 
   if (route) {
     return (
-      <SidebarTooltip>
-        <NavLink aria-label={label} to={route} {...rest}>
+      <SidebarTooltip label={label} isActive={isActive}>
+        <NavLink
+          aria-label={label}
+          to={route}
+          {...(newTab ? { target: '_blank', rel: 'noopener' } : {})}
+          {...rest}
+        >
           {component}
         </NavLink>
       </SidebarTooltip>
     )
   } else {
     return (
-      <SidebarTooltip>
+      <SidebarTooltip label={label} isActive={isActive}>
         <Button a11yTitle={label} fill="horizontal" onClick={onClick} {...rest}>
           {component}
         </Button>
@@ -173,34 +183,38 @@ const SidebarFooter = (props: SidebarFooterProps) => {
         needsWalletOpen={true}
         onClick={() => logout()}
       />
-      <Box pad="small" align="center">
-        <Menu
-          hoverIndicator={false}
-          dropProps={{ align: { bottom: 'bottom', left: 'left' } }}
-          items={languageLabels.map(([key, label]) => ({ label: label, onClick: () => setLanguage(key) }))}
-        >
-          <Box direction="row" round="4px" border={{ size: '1px' }}>
-            <Box pad="small">
-              <Language />
+
+      <SidebarTooltip label="Language" isActive={false}>
+        <Box pad="small" align="center">
+          <Menu
+            hoverIndicator={false}
+            dropProps={{ align: { bottom: 'bottom', left: 'left' } }}
+            items={languageLabels.map(([key, label]) => ({ label: label, onClick: () => setLanguage(key) }))}
+          >
+            <Box direction="row" round="4px" border={{ size: '1px' }}>
+              <Box pad="small">
+                <Language />
+              </Box>
+              {size !== 'medium' && (
+                <>
+                  <Box pad="small" flex="grow">
+                    <Text>Language</Text>
+                  </Box>
+                  <Box pad="small">
+                    <FormDown />
+                  </Box>
+                </>
+              )}
             </Box>
-            {size !== 'medium' && (
-              <>
-                <Box pad="small" flex="grow">
-                  <Text>Language</Text>
-                </Box>
-                <Box pad="small">
-                  <FormDown />
-                </Box>
-              </>
-            )}
-          </Box>
-        </Menu>
-      </Box>
-      <Box align="center" pad="small">
-        <a href="https://github.com/oasisprotocol/oasis-wallet-web" target="_blank" rel="noopener">
-          <Github />
-        </a>
-      </Box>
+          </Menu>
+        </Box>
+      </SidebarTooltip>
+      <SidebarButton
+        icon={<Github />}
+        label="GitHub"
+        route="https://github.com/oasisprotocol/oasis-wallet-web"
+        newTab
+      ></SidebarButton>
     </Nav>
   )
 }

--- a/src/app/components/Sidebar/index.tsx
+++ b/src/app/components/Sidebar/index.tsx
@@ -185,13 +185,13 @@ const SidebarFooter = (props: SidebarFooterProps) => {
       />
 
       <SidebarTooltip label="Language" isActive={false}>
-        <Box pad="small" align="center">
+        <Box pad="small" align={size === 'medium' ? 'center' : 'start'}>
           <Menu
             hoverIndicator={false}
             dropProps={{ align: { bottom: 'bottom', left: 'left' } }}
             items={languageLabels.map(([key, label]) => ({ label: label, onClick: () => setLanguage(key) }))}
           >
-            <Box direction="row" round="4px" border={{ size: '1px' }}>
+            <Box direction="row">
               <Box pad="small">
                 <Language />
               </Box>

--- a/src/app/components/Toolbar/index.tsx
+++ b/src/app/components/Toolbar/index.tsx
@@ -3,7 +3,7 @@
  * Toolbar
  *
  */
-import { selectStatus } from 'app/state/wallet/selectors'
+import { selectIsOpen } from 'app/state/wallet/selectors'
 import { Box } from 'grommet'
 import * as React from 'react'
 import { useSelector } from 'react-redux'
@@ -15,7 +15,7 @@ import { SearchAddress } from './Features/SearchAddress'
 interface Props {}
 
 export function Toolbar(props: Props) {
-  const isOpen = useSelector(selectStatus)
+  const isOpen = useSelector(selectIsOpen)
 
   return (
     <Box

--- a/src/app/pages/AccountPage/Features/AccountDetails/index.tsx
+++ b/src/app/pages/AccountPage/Features/AccountDetails/index.tsx
@@ -3,7 +3,7 @@
  * AccountDetails
  *
  */
-import { selectStatus } from 'app/state/wallet/selectors'
+import { selectIsOpen } from 'app/state/wallet/selectors'
 import { Box } from 'grommet'
 import React, { memo } from 'react'
 import { useSelector } from 'react-redux'
@@ -13,7 +13,7 @@ import { TransactionHistory } from '../TransactionHistory'
 interface Props {}
 
 export const AccountDetails = memo((props: Props) => {
-  const walletIsOpen = useSelector(selectStatus)
+  const walletIsOpen = useSelector(selectIsOpen)
 
   return (
     <Box direction="row-responsive" gap="small">

--- a/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
+++ b/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
@@ -34,7 +34,7 @@ export function AccountSummary(props: AccountSummaryProps) {
         <Box>
           <AddressBox address={address} />
           <Grid
-            columns={['auto', 'auto']}
+            columns={['max-content', 'auto']}
             gap={{ column: 'medium' }}
             pad={{ top: 'small' }}
             responsive={false}

--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -21,7 +21,7 @@ import { TransitionGroup } from 'react-transition-group'
 import { accountActions } from '../../state/account'
 import { selectAccount } from '../../state/account/selectors'
 import { BalanceDetails } from '../../state/account/types'
-import { selectAddress, selectStatus, selectWallets } from '../../state/wallet/selectors'
+import { selectAddress, selectIsOpen, selectWallets } from '../../state/wallet/selectors'
 import { ActiveDelegationList } from '../StakingPage/Features/DelegationList/ActiveDelegationList'
 import { DebondingDelegationList } from '../StakingPage/Features/DelegationList/DebondingDelegationList'
 import { ValidatorList } from '../StakingPage/Features/ValidatorList'
@@ -72,7 +72,7 @@ export function AccountPage(props: Props) {
   const account = useSelector(selectAccount)
   const stake = useSelector(selectStaking)
 
-  const walletIsOpen = useSelector(selectStatus)
+  const walletIsOpen = useSelector(selectIsOpen)
   const walletAddress = useSelector(selectAddress)
   const selectedNetwork = useSelector(selectSelectedNetwork)
   const { active } = useSelector(selectTransaction)

--- a/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
@@ -15,7 +15,7 @@ import {
   selectValidatorsTimestamp,
 } from 'app/state/staking/selectors'
 import { Validator } from 'app/state/staking/types'
-import { selectStatus } from 'app/state/wallet/selectors'
+import { selectIsOpen } from 'app/state/wallet/selectors'
 import { Box, Text } from 'grommet'
 import { Down } from 'grommet-icons/icons'
 import React, { memo } from 'react'
@@ -35,7 +35,7 @@ export const ValidatorList = memo((props: Props) => {
   const validators = useSelector(selectValidators)
   const validatorsTimestamp = useSelector(selectValidatorsTimestamp)
   const updateValidatorsError = useSelector(selectUpdateValidatorsError)
-  const walletIsOpen = useSelector(selectStatus)
+  const walletIsOpen = useSelector(selectIsOpen)
   const selectedAddress = useSelector(selectSelectedAddress)
   const validatorDetails = useSelector(selectValidatorDetails)
 

--- a/src/app/state/wallet/selectors.ts
+++ b/src/app/state/wallet/selectors.ts
@@ -17,4 +17,4 @@ export const selectWallets = createSelector([selectSlice], state => state.wallet
 export const selectAddress = createSelector([selectActiveWallet], wallet => wallet?.address ?? '')
 export const selectPublicKey = createSelector([selectActiveWallet], wallet => wallet?.publicKey ?? '')
 export const selectBalance = createSelector([selectActiveWallet], wallet => wallet?.balance)
-export const selectStatus = createSelector([selectSlice], wallet => wallet.isOpen)
+export const selectIsOpen = createSelector([selectSlice], wallet => wallet.isOpen)


### PR DESCRIPTION
I suggest reviewing differences commit by commit, and ignoring whitespace changes

| Tabbing through sidebar buttons before | After |
| --- | --- |
|  ![before](https://user-images.githubusercontent.com/3758846/166311836-d3dbd143-8f29-457a-9e58-87a3b3cb14b5.gif) | ![after](https://user-images.githubusercontent.com/3758846/166311832-07122d34-6a63-4e24-9a60-c7586b94dd41.gif)  |
