### PR TITLE
Configure lint for all files, to match megalinter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,14 @@ const config = {
       files: ['**/*.ts?(x)'],
       rules: { 'prettier/prettier': 'warn' },
     },
+    {
+      files: ['internals/**'],
+      rules: { '@typescript-eslint/no-var-requires': 'off' },
+    },
+    {
+      files: ['**/*.js'],
+      rules: { '@typescript-eslint/no-var-requires': 'off' },
+    },
   ],
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,15 +17,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-.env.development.local
-.env.test.local
-.env.production.local
-
-# boilerplate internals
-generated-cra-app
-.cra-template-rb
-template
-
 # Docker
 node
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 # Don't check auto-generated stuff into git
-.parcel-cache
-.husky
-cypress-coverage
-coverage
-build
-build-ext
-build-dev
-node_modules
+.parcel-cache/
+.husky/
+cypress-coverage/
+coverage/
+build/
+build-ext/
+build-dev/
+node_modules/
 stats.json
 .pnp
 .pnp.js
@@ -18,16 +18,17 @@ yarn-debug.log*
 yarn-error.log*
 
 # Docker
-node
+/node
+/docker/oasis-node/node
 
 # Local debug
 debug*.c
 
 # Cypress
-cypress/screenshots
-cypress/videos
-.nyc_output
-instrumented
+/cypress/screenshots/
+/cypress/videos/
+/.nyc_output/
+/instrumented/
 
 # Megalinter
-report
+/report/

--- a/internals/extractMessages/i18next-scanner.config.js
+++ b/internals/extractMessages/i18next-scanner.config.js
@@ -9,7 +9,7 @@ module.exports = {
     sort: true,
     func: {
       list: ['t'],
-      extensions: ['js', 'jsx'] // We dont want this extension because we manually check on transform function below
+      extensions: ['js', 'jsx'], // We dont want this extension because we manually check on transform function below
     },
     trans: {
       component: 'Trans',
@@ -18,7 +18,7 @@ module.exports = {
       fallbackKey: (ns, value) => {
         return value
       },
-      extensions: ['js', 'jsx']
+      extensions: ['js', 'jsx'],
     },
     lngs: ['en'],
     defaultLng: 'en',
@@ -27,17 +27,17 @@ module.exports = {
       loadPath: 'src/locales/{{lng}}/{{ns}}.json',
       savePath: 'src/locales/{{lng}}/{{ns}}.json',
       jsonIndent: 2,
-      lineEnding: '\n'
+      lineEnding: '\n',
     },
     keySeparator: '.', // char to separate keys
     nsSeparator: ':', // char to split namespace from key
     interpolation: {
       prefix: '{{',
-      suffix: '}}'
-    }
+      suffix: '}}',
+    },
   },
   transform: typescriptTransform({
     extensions: ['.ts', '.tsx'],
-    tsOptions: { jsx: 'preserve', target: 'esnext' }
-  })
+    tsOptions: { jsx: 'preserve', target: 'esnext' },
+  }),
 }

--- a/internals/getCsp.js
+++ b/internals/getCsp.js
@@ -14,7 +14,7 @@ const extensionCsp = {
   `,
   hmrWebsocket: `
     ws://localhost:2222
-  `
+  `,
 }
 
 // Keep synced with deployment

--- a/internals/jest/jest.base-config.js
+++ b/internals/jest/jest.base-config.js
@@ -8,7 +8,7 @@ const config = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: {
     '.*\\.(css|scss|sass)$': '<rootDir>internals/jest/mocks/cssModule.js',
-    '.*\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>internals/jest/mocks/image.js'
+    '.*\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>internals/jest/mocks/image.js',
   },
   modulePaths: ['<rootDir>/src'],
   resetMocks: true,
@@ -16,10 +16,10 @@ const config = {
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.(js|jsx|mjs|cjs|ts|tsx)$': '<rootDir>/internals/jest/babelTransform.js'
+    '^.+\\.(js|jsx|mjs|cjs|ts|tsx)$': '<rootDir>/internals/jest/babelTransform.js',
   },
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$'],
-  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname']
+  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
 }
 
 module.exports = config

--- a/internals/jest/jest.ext-config.js
+++ b/internals/jest/jest.ext-config.js
@@ -8,8 +8,8 @@ const config = {
   displayName: 'Extension Wallet',
   testMatch: [
     '<rootDir>/extension/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
-    '<rootDir>/extension/src/**/*.{spec,test}.{js,jsx,ts,tsx}'
-  ]
+    '<rootDir>/extension/src/**/*.{spec,test}.{js,jsx,ts,tsx}',
+  ],
 }
 
 module.exports = config

--- a/internals/jest/jest.web-config.js
+++ b/internals/jest/jest.web-config.js
@@ -8,8 +8,8 @@ const config = {
   displayName: 'Web Wallet',
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
-    '<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}'
-  ]
+    '<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}',
+  ],
 }
 
 module.exports = config

--- a/internals/scripts/serve-prod.js
+++ b/internals/scripts/serve-prod.js
@@ -14,8 +14,8 @@ const server = http.createServer((request, response) => {
     rewrites: [
       {
         source: '**',
-        destination: '/index.html'
-      }
+        destination: '/index.html',
+      },
     ],
     // Disable etag so we don't need to clear cache if we only change CSP.
     etag: false,
@@ -25,11 +25,11 @@ const server = http.createServer((request, response) => {
         headers: [
           {
             key: 'Content-Security-Policy',
-            value: csp
-          }
-        ]
-      }
-    ]
+            value: csp,
+          },
+        ],
+      },
+    ],
   })
 })
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,9 +10,9 @@ const config = {
     '!src/**/*/Loadable.{js,jsx,ts,tsx}',
     '!src/**/*/messages.ts',
     '!src/**/*/types.ts',
-    '!src/index.tsx'
+    '!src/index.tsx',
   ],
-  projects: ['<rootDir>/internals/jest/jest.web-config.js', '<rootDir>/internals/jest/jest.ext-config.js']
+  projects: ['<rootDir>/internals/jest/jest.web-config.js', '<rootDir>/internals/jest/jest.ext-config.js'],
 }
 
 module.exports = config

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:generators": "ts-node --project=./internals/ts-node.tsconfig.json ./internals/testing/generators/test-generators.ts",
     "start:prod": "yarn run build && nodemon --watch ./build ./internals/scripts/serve-prod.js",
     "checkTs": "tsc --noEmit",
-    "lint": "eslint --ext js,ts,tsx ./src ./extension/src",
+    "lint": "eslint --ext js,ts,tsx ./",
     "lint:fix": "yarn run lint --fix",
     "lint:css": "stylelint src/**/*.css",
     "generate": "cross-env TS_NODE_PROJECT='./internals/ts-node.tsconfig.json' plop --plopfile internals/generators/plopfile.ts",

--- a/posthtml.config.js
+++ b/posthtml.config.js
@@ -3,8 +3,8 @@ module.exports = {
   plugins: {
     'posthtml-expressions': {
       locals: {
-        REACT_APP_META_CSP: process.env.REACT_APP_META_CSP
-      }
-    }
-  }
+        REACT_APP_META_CSP: process.env.REACT_APP_META_CSP,
+      },
+    },
+  },
 }

--- a/src/__mocks__/react-i18next.js
+++ b/src/__mocks__/react-i18next.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable react/display-name */
 // https://github.com/i18next/react-i18next/blob/master/example/test-jest/src/__mocks__/react-i18next.js
 
 const React = require('react')
@@ -39,6 +37,7 @@ useMock.i18n = { language: 'en-US' }
 
 module.exports = {
   // this mock makes sure any components using the translate HoC receive the t function as a prop
+  /* eslint-disable-next-line react/display-name */
   withTranslation: () => Component => props => <Component t={k => k} {...props} />,
   Trans: ({ children }) => (Array.isArray(children) ? renderNodes(children) : renderNodes([children])),
   Translation: ({ children }) => children(k => k, { i18n: {} }),


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-wallet-web/issues/774 again. After merging https://github.com/oasisprotocol/oasis-wallet-web/pull/855, megalinter on master checked all files and failed.

This was because:
- `yarn lint` used `.eslintrc.js` rules on only js,ts,tsx files in `./src` and `./extension/src`
- megalinter on a pullrequest used `.eslintrc.js` only on changed js,ts,tsx files
- megalinter on master used `eslintrc.js` on all js,ts,tsx files

After:
- `.eslintignore` is symlinked to `.gitignore`
- `yarn lint` uses `.eslintrc.js` on all js,ts,tsx files, except gitignored ones
- megalinter on a pullrequest still uses `.eslintrc.js` only on changed js,ts,tsx files
- megalinter on master still uses `eslintrc.js` on all js,ts,tsx files