### PR TITLE
Only show SendTransaction on your accounts

### DIFF
--- a/src/app/pages/AccountPage/Features/AccountDetails/index.tsx
+++ b/src/app/pages/AccountPage/Features/AccountDetails/index.tsx
@@ -3,23 +3,27 @@
  * AccountDetails
  *
  */
-import { selectIsOpen } from 'app/state/wallet/selectors'
+import { selectAddress, selectIsOpen } from 'app/state/wallet/selectors'
 import { Box } from 'grommet'
 import React, { memo } from 'react'
 import { useSelector } from 'react-redux'
 import { SendTransaction } from '../SendTransaction'
 import { TransactionHistory } from '../TransactionHistory'
+import { selectAccountAddress } from 'app/state/account/selectors'
 
 interface Props {}
 
 export const AccountDetails = memo((props: Props) => {
   const walletIsOpen = useSelector(selectIsOpen)
+  const walletAddress = useSelector(selectAddress)
+  const address = useSelector(selectAccountAddress)
+  const isAddressInWallet = walletIsOpen && walletAddress === address
 
   return (
     <Box direction="row-responsive" gap="small">
-      {walletIsOpen && (
+      {isAddressInWallet && (
         <Box flex basis="1/4" width={{ min: '300px' }}>
-          <SendTransaction />
+          <SendTransaction isAddressInWallet={isAddressInWallet} />
         </Box>
       )}
       <Box flex basis="3/4">

--- a/src/app/pages/AccountPage/Features/SendTransaction/__tests__/index.test.tsx
+++ b/src/app/pages/AccountPage/Features/SendTransaction/__tests__/index.test.tsx
@@ -8,7 +8,7 @@ import { SendTransaction } from '..'
 const renderComponent = (store: any) =>
   render(
     <Provider store={store}>
-      <SendTransaction />
+      <SendTransaction isAddressInWallet />
     </Provider>,
   )
 

--- a/src/app/pages/AccountPage/Features/SendTransaction/index.tsx
+++ b/src/app/pages/AccountPage/Features/SendTransaction/index.tsx
@@ -9,7 +9,15 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
-export function SendTransaction() {
+export interface SendTransactionProps {
+  isAddressInWallet: boolean
+}
+
+export function SendTransaction(props: SendTransactionProps) {
+  if (!props.isAddressInWallet) {
+    throw new Error('SendTransaction component should only appear on your accounts')
+  }
+
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const { launchModal } = useModal()


### PR DESCRIPTION
Before: 
- user imports `oasis1qqug..hsu8` to wallet
- search `oasis1qr9t..gxfl`
- see SendTransaction component to transfer from `oasis1qqug..hsu8` to any _Recipient_
  ![oasis1qquga66n9mzypsayerxnkp8p343g5ufwny4dhsu8_to_oasis1qr9tkn7cg2rg95ps7td0ar3ghqru8y225s4tgxfl](https://user-images.githubusercontent.com/3758846/174208995-45fcce5e-3e32-428d-84f9-548ab3140017.png)