### PR TITLE
Combine packages into groups in Renovate to reduce PR clutter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "groupName": "eslint",
+      "matchPackagePatterns": ["eslint", "prettier", "stylelint"]
+    },
+    {
+      "groupName": "tests",
+      "matchPackagePatterns": ["jest", "cypress", "testing-library", "istanbul"]
+    },
+    {
+      "groupName": "react",
+      "matchPackagePatterns": ["react"]
+    },
+    {
+      "groupName": "redux",
+      "matchPackagePatterns": ["redux"]
+    },
+    {
+      "groupName": "i18n",
+      "matchPackagePatterns": ["i18n"]
+    }
+  ]
 }


### PR DESCRIPTION
Whenever we merge a Renovate PR, all others get rebased and spam CI. So waiting for CI and merging one by one is slow. We can group some of these PRs by package name, and be happier until an update breaks things https://docs.renovatebot.com/noise-reduction/#package-grouping