### PR TITLE
Speedup caching in CI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -7,7 +7,21 @@ on:
     branches: [stable, master]
 
 jobs:
+  yarn_cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: yarn-cache
+        uses: c-hive/gha-yarn-cache@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+
   build:
+    needs: [yarn_cache]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,7 +36,7 @@ jobs:
       - run: yarn build
 
   jest:
-    needs: [build]
+    needs: [yarn_cache]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +55,7 @@ jobs:
           retention-days: 5
 
   cypress:
-    needs: [build]
+    needs: [yarn_cache]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`jest` and `cypress` steps didn't really need to wait for `build`. But if they didn't wait, then `gha-yarn-cache` would save cache three times.

`yarn_cache` should only save cache once and speed up CI by 2min when cache is hit and 40sec when missed
