### PR TITLE
Survive fetching delegations failures

### DIFF
--- a/src/app/components/AlertBox/index.tsx
+++ b/src/app/components/AlertBox/index.tsx
@@ -1,0 +1,26 @@
+import { Box, Text } from 'grommet'
+import * as React from 'react'
+
+interface Props {
+  color: 'status-error' | 'status-warning' | 'status-ok'
+  children: React.ReactNode
+}
+
+export function AlertBox(props: Props) {
+  return (
+    <Box
+      border={{
+        color: props.color,
+        side: 'left',
+        size: '3px',
+      }}
+      background={{
+        color: props.color,
+        opacity: 'weak',
+      }}
+      pad={{ horizontal: 'small', vertical: 'xsmall' }}
+    >
+      <Text weight="bold">{props.children}</Text>
+    </Box>
+  )
+}

--- a/src/app/components/ErrorFormatter/index.tsx
+++ b/src/app/components/ErrorFormatter/index.tsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { Anchor } from 'grommet'
 import { WalletErrors } from 'types/errors'
+import { backend, BackendAPIs } from 'vendors/backend'
 
 interface Props {
   code: WalletErrors
@@ -16,6 +17,11 @@ interface Props {
 export function ErrorFormatter(props: Props) {
   const { t } = useTranslation()
   const message = props.message
+
+  const backendToLabel = {
+    [BackendAPIs.OasisMonitor]: t('backends.oasismonitor', 'Oasis Monitor API'),
+    [BackendAPIs.OasisScan]: t('backends.oasisscan', 'Oasis Scan API'),
+  }
 
   const errorMap: { [code in WalletErrors]: string | React.ReactElement } = {
     [WalletErrors.UnknownError]: t('errors.unknown', 'Unknown error: {{message}}', { message }),
@@ -68,6 +74,13 @@ export function ErrorFormatter(props: Props) {
     [WalletErrors.LedgerUnknownError]: t('errors.unknownLedgerError', 'Unknown ledger error: {{message}}', {
       message,
     }),
+    [WalletErrors.IndexerAPIError]: t(
+      'errors.indexerAPIError',
+      '{{indexerName}} appears to be down, some information may be missing or out of date. Please, come back later.',
+      {
+        indexerName: backendToLabel[backend()],
+      },
+    ),
   }
 
   const error = errorMap[props.code]

--- a/src/app/components/ErrorFormatter/index.tsx
+++ b/src/app/components/ErrorFormatter/index.tsx
@@ -81,6 +81,7 @@ export function ErrorFormatter(props: Props) {
         indexerName: backendToLabel[backend()],
       },
     ),
+    [WalletErrors.DisconnectedError]: t('errors.disconnectedError', 'Lost connection.'),
   }
 
   const error = errorMap[props.code]

--- a/src/app/components/FatalErrorHandler/index.tsx
+++ b/src/app/components/FatalErrorHandler/index.tsx
@@ -3,6 +3,7 @@
  * FatalError
  *
  */
+import { AlertBox } from 'app/components/AlertBox'
 import { selectFatalError } from 'app/state/fatalerror/selectors'
 import copy from 'copy-to-clipboard'
 import { Anchor, Box, Button, Heading, Text } from 'grommet'
@@ -49,20 +50,11 @@ export function FatalErrorHandler(props: Props) {
             />
           </Text>
         </Box>
-        <Box
-          border={{
-            color: 'status-error',
-            side: 'left',
-            size: '3px',
-          }}
-          background={{
-            color: 'status-error',
-            opacity: 'weak',
-          }}
-          pad={{ horizontal: 'small', vertical: 'xsmall' }}
-        >
-          <pre data-testid="fatalerror-stacktrace">{combinedStacktrace}</pre>
-        </Box>
+        <AlertBox color="status-error">
+          <Text weight="normal">
+            <pre data-testid="fatalerror-stacktrace">{combinedStacktrace}</pre>
+          </Text>
+        </AlertBox>
         <Box align="end" pad={{ vertical: 'medium' }}>
           <Button
             onClick={() => copyError()}

--- a/src/app/components/TransactionModal/index.tsx
+++ b/src/app/components/TransactionModal/index.tsx
@@ -1,3 +1,4 @@
+import { AlertBox } from 'app/components/AlertBox'
 import { selectChainContext } from 'app/state/network/selectors'
 import { transactionActions } from 'app/state/transaction'
 import { selectTransaction } from 'app/state/transaction/selectors'
@@ -51,25 +52,13 @@ export function TransactionModal() {
           <Heading level="2" margin="none">
             {t('transaction.step.preview', 'Preview transaction')}
           </Heading>
-          <Box
-            border={{
-              color: 'status-warning',
-              side: 'left',
-              size: '3px',
-            }}
-            background={{
-              color: 'status-warning',
-              opacity: 'weak',
-            }}
-            margin={{ vertical: 'small' }}
-            pad="xsmall"
-          >
-            <Text>
+          <Box margin={{ vertical: 'small' }}>
+            <AlertBox color="status-warning">
               {t(
                 'transaction.preview.warning',
                 'Once you confirm this transaction you will not be able to cancel it. Carefully review it, and confirm once you are sure that you want to send it.',
               )}
-            </Text>
+            </AlertBox>
           </Box>
           {preview && (
             <TransactionPreview chainContext={chainContext} preview={preview} walletAddress={walletAddress} />

--- a/src/app/components/TransactionStatus/index.tsx
+++ b/src/app/components/TransactionStatus/index.tsx
@@ -3,7 +3,7 @@
  * TransactionStatus
  *
  */
-import { Box, Text } from 'grommet'
+import { AlertBox } from 'app/components/AlertBox'
 import React, { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ErrorPayload } from 'types/errors'
@@ -21,43 +21,17 @@ export const TransactionStatus = memo((props: Props) => {
   return (
     <>
       {error && (
-        <Box
-          border={{
-            color: 'status-error',
-            side: 'left',
-            size: '3px',
-          }}
-          background={{
-            color: 'status-error',
-            opacity: 'weak',
-          }}
-          pad={{ horizontal: 'small', vertical: 'xsmall' }}
-        >
-          <Text weight="bold">
-            <ErrorFormatter code={error.code} message={error.message} />
-          </Text>
-        </Box>
+        <AlertBox color="status-error">
+          <ErrorFormatter code={error.code} message={error.message} />
+        </AlertBox>
       )}
       {success && (
-        <Box
-          border={{
-            color: 'status-ok',
-            side: 'left',
-            size: '3px',
-          }}
-          background={{
-            color: 'status-ok',
-            opacity: 'weak',
-          }}
-          pad={{ horizontal: 'small', vertical: 'xsmall' }}
-        >
-          <Text weight="bold">
-            {t(
-              'account.sendTransaction.success',
-              'Transaction successfully sent. The transaction might take up to a minute to appear on your account.',
-            )}
-          </Text>
-        </Box>
+        <AlertBox color="status-ok">
+          {t(
+            'account.sendTransaction.success',
+            'Transaction successfully sent. The transaction might take up to a minute to appear on your account.',
+          )}
+        </AlertBox>
       )}
     </>
   )

--- a/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
+++ b/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
@@ -1,4 +1,5 @@
 import { AddressBox } from 'app/components/AddressBox'
+import { AlertBox } from 'app/components/AlertBox'
 import { AmountFormatter } from 'app/components/AmountFormatter'
 import { AnchorLink } from 'app/components/AnchorLink'
 import { Box, Grid, ResponsiveContext, Text } from 'grommet'
@@ -79,59 +80,22 @@ export function AccountSummary(props: AccountSummaryProps) {
         )}
       </Box>
       {walletIsOpen && walletAddress === address && (
-        <Box
-          border={{
-            color: 'status-ok',
-            side: 'left',
-            size: '3px',
-          }}
-          background={{
-            color: 'status-ok',
-            opacity: 'weak',
-          }}
-          pad={{ horizontal: 'small', vertical: 'xsmall' }}
-        >
-          <Text weight="bold">{t('account.summary.yourAccount', 'This is your account.')}</Text>
-        </Box>
+        <AlertBox color="status-ok">{t('account.summary.yourAccount', 'This is your account.')}</AlertBox>
       )}
       {walletIsOpen && walletAddress !== address && (
-        <Box
-          border={{
-            color: 'status-warning',
-            side: 'left',
-            size: '3px',
-          }}
-          background={{
-            color: 'status-warning',
-            opacity: 'weak',
-          }}
-          pad={{ horizontal: 'small', vertical: 'xsmall' }}
-        >
-          <Text weight="bold">{t('account.summary.notYourAccount', 'This is not your account.')}</Text>
-        </Box>
+        <AlertBox color="status-warning">
+          {t('account.summary.notYourAccount', 'This is not your account.')}
+        </AlertBox>
       )}
       {!walletIsOpen && (
-        <Box
-          border={{
-            color: 'status-warning',
-            side: 'left',
-            size: '3px',
-          }}
-          background={{
-            color: 'status-warning',
-            opacity: 'weak',
-          }}
-          pad={{ horizontal: 'small', vertical: 'xsmall' }}
-        >
-          <Text weight="bold">
-            <Trans
-              i18nKey="account.summary.noWalletIsOpen"
-              t={t}
-              components={[<AnchorLink to="/" />]}
-              defaults="To send, receive, stake and swap ROSE tokens, <0>open your wallet!</0>"
-            />
-          </Text>
-        </Box>
+        <AlertBox color="status-warning">
+          <Trans
+            i18nKey="account.summary.noWalletIsOpen"
+            t={t}
+            components={[<AnchorLink to="/" />]}
+            defaults="To send, receive, stake and swap ROSE tokens, <0>open your wallet!</0>"
+          />
+        </AlertBox>
       )}
     </Box>
   )

--- a/src/app/pages/AccountPage/Features/TransactionHistory/index.tsx
+++ b/src/app/pages/AccountPage/Features/TransactionHistory/index.tsx
@@ -15,6 +15,7 @@ import {
   selectTransactionsError,
 } from '../../../../state/account/selectors'
 import { selectSelectedNetwork } from 'app/state/network/selectors'
+import { ErrorFormatter } from 'app/components/ErrorFormatter'
 
 interface Props {}
 
@@ -35,11 +36,8 @@ export function TransactionHistory(props: Props) {
     <Box gap="small" margin="none">
       {transactionsError && (
         <p>
-          {t(
-            'account.transaction.loadingError',
-            "Couldn't load transactions. List may be empty or out of date.",
-          )}{' '}
-          {transactionsError}
+          {t('account.transaction.loadingError', "Couldn't load transactions.")}{' '}
+          <ErrorFormatter code={transactionsError.code} message={transactionsError.message} />
         </p>
       )}
       {allTransactions.length ? (

--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -3,6 +3,7 @@
  * AccountPage
  *
  */
+import { ErrorFormatter } from 'app/components/ErrorFormatter'
 import { TransactionModal } from 'app/components/TransactionModal'
 import { TransitionRoute } from 'app/components/TransitionRoute'
 import { selectSelectedNetwork } from 'app/state/network/selectors'
@@ -118,6 +119,15 @@ export function AccountPage(props: Props) {
         <p>
           {t('account.loadingError', "Couldn't load account. Information may be missing or out of date.")}{' '}
           {account.accountError}
+        </p>
+      )}
+      {stake.updateDelegationsError && (
+        <p>
+          {t('delegations.loadingError', "Couldn't load delegations.")}{' '}
+          <ErrorFormatter
+            code={stake.updateDelegationsError.code}
+            message={stake.updateDelegationsError.message}
+          />
         </p>
       )}
       {address && address !== '' && (

--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -3,6 +3,7 @@
  * AccountPage
  *
  */
+import { AlertBox } from 'app/components/AlertBox'
 import { ErrorFormatter } from 'app/components/ErrorFormatter'
 import { TransactionModal } from 'app/components/TransactionModal'
 import { TransitionRoute } from 'app/components/TransitionRoute'
@@ -116,19 +117,19 @@ export function AccountPage(props: Props) {
         </Layer>
       )}
       {account.accountError && (
-        <p>
-          {t('account.loadingError', "Couldn't load account. Information may be missing or out of date.")}{' '}
-          {account.accountError}
-        </p>
+        <AlertBox color="status-error">
+          {t('account.loadingError', "Couldn't load account.")}{' '}
+          <ErrorFormatter code={account.accountError.code} message={account.accountError.message} />
+        </AlertBox>
       )}
       {stake.updateDelegationsError && (
-        <p>
+        <AlertBox color="status-error">
           {t('delegations.loadingError', "Couldn't load delegations.")}{' '}
           <ErrorFormatter
             code={stake.updateDelegationsError.code}
             message={stake.updateDelegationsError.message}
           />
-        </p>
+        </AlertBox>
       )}
       {address && address !== '' && (
         <>

--- a/src/app/pages/CreateWalletPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/CreateWalletPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -165,7 +165,10 @@ exports[`<CreateWalletPage  /> should match snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  padding: 6px;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 .c20 {
@@ -604,7 +607,15 @@ exports[`<CreateWalletPage  /> should match snapshot 1`] = `
 
 @media only screen and (max-width:768px) {
   .c18 {
-    padding: 3px;
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c18 {
+    padding-top: 3px;
+    padding-bottom: 3px;
   }
 }
 

--- a/src/app/pages/CreateWalletPage/index.tsx
+++ b/src/app/pages/CreateWalletPage/index.tsx
@@ -3,6 +3,7 @@
  * CreateWalletPage
  *
  */
+import { AlertBox } from 'app/components/AlertBox'
 import { MnemonicGrid } from 'app/components/MnemonicGrid'
 import { MnemonicValidation } from 'app/components/MnemonicValidation'
 import { NoTranslate } from 'app/components/NoTranslate'
@@ -60,20 +61,9 @@ export function CreateWalletPage(props: CreateWalletProps) {
   return (
     <>
       {showMnemonicMismatch && (
-        <Box
-          pad="small"
-          border={{
-            color: 'status-error',
-            side: 'left',
-            size: '3px',
-          }}
-          background={{
-            color: 'status-error',
-            opacity: 'weak',
-          }}
-        >
-          <Text weight="bold">{t('createWallet.mnemonicMismatch', 'Entered mnemonic does not match.')}</Text>
-        </Box>
+        <AlertBox color="status-error">
+          {t('createWallet.mnemonicMismatch', 'Entered mnemonic does not match.')}
+        </AlertBox>
       )}
       {showConfirmation && (
         <Layer
@@ -134,25 +124,12 @@ export function CreateWalletPage(props: CreateWalletProps) {
               </Trans>
             </Text>
           </Box>
-          <Box
-            pad="xsmall"
-            border={{
-              color: 'status-warning',
-              side: 'left',
-              size: '3px',
-            }}
-            background={{
-              color: 'status-warning',
-              opacity: 'weak',
-            }}
-          >
-            <Text weight="bold">
-              {t(
-                'createWallet.doNotShare',
-                'Never share your keyphrase, anyone with your keyphrase can access your wallet and your tokens.',
-              )}
-            </Text>
-          </Box>
+          <AlertBox color="status-warning">
+            {t(
+              'createWallet.doNotShare',
+              'Never share your keyphrase, anyone with your keyphrase can access your wallet and your tokens.',
+            )}
+          </AlertBox>
           <Box pad={{ vertical: 'medium' }}>
             <CheckBox
               label={t('createWallet.confirmSaved', 'I saved my keyphrase')}

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
@@ -3,6 +3,7 @@
  * FromLedger
  *
  */
+import { AlertBox } from 'app/components/AlertBox'
 import { ErrorFormatter } from 'app/components/ErrorFormatter'
 import { LedgerStepFormatter } from 'app/components/LedgerStepFormatter'
 import { ResponsiveLayer } from 'app/components/ResponsiveLayer'
@@ -139,22 +140,9 @@ export function FromLedgerModal(props: FromLedgerModalProps) {
           </Box>
         )}
         {error && (
-          <Box
-            border={{
-              color: 'status-error',
-              side: 'left',
-              size: '3px',
-            }}
-            background={{
-              color: 'status-error',
-              opacity: 'weak',
-            }}
-            pad={{ horizontal: 'small', vertical: 'xsmall' }}
-          >
-            <Text weight="bold">
-              <ErrorFormatter code={error.code} message={error.message} />
-            </Text>
-          </Box>
+          <AlertBox color="status-error">
+            <ErrorFormatter code={error.code} message={error.message} />
+          </AlertBox>
         )}
         <Box direction="row" gap="small" alignSelf="end" pad={{ top: 'large' }}>
           <Button

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/ActiveDelegationList.test.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/ActiveDelegationList.test.tsx
@@ -23,21 +23,24 @@ describe('<ActiveDelegationList  />', () => {
   it('should match snapshot', () => {
     const component = renderComponent(store)
     store.dispatch(
-      stakingActions.updateDelegations([
-        {
-          amount: '100',
-          shares: '100',
-          validatorAddress: 'test-validator',
-          validator: {
-            current_rate: 0.07,
-            address: 'test-validator',
-            rank: 1,
-            status: 'active',
-            name: 'test-validator',
-            nodeAddress: 'oasis1qq7pgk9v8l3hu2aenjtflezy5vajc2cz3y4d96rj',
+      stakingActions.updateDelegations({
+        delegations: [
+          {
+            amount: '100',
+            shares: '100',
+            validatorAddress: 'test-validator',
+            validator: {
+              current_rate: 0.07,
+              address: 'test-validator',
+              rank: 1,
+              status: 'active',
+              name: 'test-validator',
+              nodeAddress: 'oasis1qq7pgk9v8l3hu2aenjtflezy5vajc2cz3y4d96rj',
+            },
           },
-        },
-      ]),
+        ],
+        debondingDelegations: [],
+      }),
     )
 
     expect(component).toMatchSnapshot()
@@ -50,21 +53,24 @@ describe('<ActiveDelegationList  />', () => {
   it('should expand and display the delegation on click', async () => {
     renderComponent(store)
     store.dispatch(
-      stakingActions.updateDelegations([
-        {
-          amount: '100',
-          shares: '100',
-          validatorAddress: 'oasis1qqv25adrld8jjquzxzg769689lgf9jxvwgjs8tha',
-          validator: {
-            address: 'oasis1qqv25adrld8jjquzxzg769689lgf9jxvwgjs8tha',
-            rank: 1,
-            status: 'active',
-            name: 'test-validator1',
-            nodeAddress: 'oasis1qq7pgk9v8l3hu2aenjtflezy5vajc2cz3y4d96rj',
+      stakingActions.updateDelegations({
+        delegations: [
+          {
+            amount: '100',
+            shares: '100',
+            validatorAddress: 'oasis1qqv25adrld8jjquzxzg769689lgf9jxvwgjs8tha',
+            validator: {
+              address: 'oasis1qqv25adrld8jjquzxzg769689lgf9jxvwgjs8tha',
+              rank: 1,
+              status: 'active',
+              name: 'test-validator1',
+              nodeAddress: 'oasis1qq7pgk9v8l3hu2aenjtflezy5vajc2cz3y4d96rj',
+            },
           },
-        },
-        { amount: '50', shares: '50', validatorAddress: 'oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4' },
-      ]),
+          { amount: '50', shares: '50', validatorAddress: 'oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4' },
+        ],
+        debondingDelegations: [],
+      }),
     )
 
     let row = screen.getByText(/test-validator1/)

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/DebondingDelegationList.test.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/DebondingDelegationList.test.tsx
@@ -25,22 +25,25 @@ describe('<DebondingDelegationList  />', () => {
   it('should match snapshot', () => {
     const component = renderComponent(store)
     store.dispatch(
-      stakingActions.updateDebondingDelegations([
-        {
-          epoch: 100,
-          amount: '100',
-          shares: '100',
-          validatorAddress: 'test-validator',
-          validator: {
-            current_rate: 0.1,
-            address: 'test-validator',
-            rank: 1,
-            status: 'active',
-            name: 'test-validator',
-            nodeAddress: 'oasis1qq7pgk9v8l3hu2aenjtflezy5vajc2cz3y4d96rj',
+      stakingActions.updateDelegations({
+        delegations: [],
+        debondingDelegations: [
+          {
+            epoch: 100,
+            amount: '100',
+            shares: '100',
+            validatorAddress: 'test-validator',
+            validator: {
+              current_rate: 0.1,
+              address: 'test-validator',
+              rank: 1,
+              status: 'active',
+              name: 'test-validator',
+              nodeAddress: 'oasis1qq7pgk9v8l3hu2aenjtflezy5vajc2cz3y4d96rj',
+            },
           },
-        },
-      ]),
+        ],
+      }),
     )
 
     expect(component).toMatchSnapshot()
@@ -49,28 +52,31 @@ describe('<DebondingDelegationList  />', () => {
   it('should expand and display the delegation on click', async () => {
     renderComponent(store)
     store.dispatch(
-      stakingActions.updateDebondingDelegations([
-        {
-          epoch: 100,
-          amount: '100',
-          shares: '100',
-          validatorAddress: 'oasis1qqv25adrld8jjquzxzg769689lgf9jxvwgjs8tha',
-          validator: {
-            address: 'oasis1qqv25adrld8jjquzxzg769689lgf9jxvwgjs8tha',
-            current_rate: 0,
-            rank: 1,
-            status: 'active',
-            name: 'test-validator1',
-            nodeAddress: 'oasis1qq7pgk9v8l3hu2aenjtflezy5vajc2cz3y4d96rj',
+      stakingActions.updateDelegations({
+        delegations: [],
+        debondingDelegations: [
+          {
+            epoch: 100,
+            amount: '100',
+            shares: '100',
+            validatorAddress: 'oasis1qqv25adrld8jjquzxzg769689lgf9jxvwgjs8tha',
+            validator: {
+              address: 'oasis1qqv25adrld8jjquzxzg769689lgf9jxvwgjs8tha',
+              current_rate: 0,
+              rank: 1,
+              status: 'active',
+              name: 'test-validator1',
+              nodeAddress: 'oasis1qq7pgk9v8l3hu2aenjtflezy5vajc2cz3y4d96rj',
+            },
           },
-        },
-        {
-          amount: '50',
-          shares: '50',
-          validatorAddress: 'oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4',
-          epoch: 100,
-        },
-      ]),
+          {
+            amount: '50',
+            shares: '50',
+            validatorAddress: 'oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4',
+            epoch: 100,
+          },
+        ],
+      }),
     )
 
     let row = screen.getByText(/test-validator1/)

--- a/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
@@ -4,6 +4,7 @@
  *
  */
 import { AmountFormatter } from 'app/components/AmountFormatter'
+import { ErrorFormatter } from 'app/components/ErrorFormatter'
 import { ShortAddress } from 'app/components/ShortAddress'
 import { ValidatorStatus } from 'app/pages/StakingPage/Features/ValidatorList/ValidatorStatus'
 import { stakingActions } from 'app/state/staking'
@@ -112,7 +113,9 @@ export const ValidatorList = memo((props: Props) => {
               staleTimestamp: new Date(validatorsTimestamp!).toLocaleString(),
             })}
           <br />
-          {updateValidatorsError}
+          {validators.length <= 0 && (
+            <ErrorFormatter code={updateValidatorsError.code} message={updateValidatorsError.message} />
+          )}
         </p>
       )}
       <TypeSafeDataTable

--- a/src/app/state/account/index.ts
+++ b/src/app/state/account/index.ts
@@ -1,5 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit'
 import { Transaction } from 'app/state/transaction/types'
+import { ErrorPayload } from 'types/errors'
 import { createSlice } from 'utils/@reduxjs/toolkit'
 import { AccountState, Account } from './types'
 
@@ -7,9 +8,9 @@ export const initialState: AccountState = {
   address: '',
   liquid_balance: 0,
 
-  accountError: null,
+  accountError: undefined,
   transactions: [],
-  transactionsError: null,
+  transactionsError: undefined,
   loading: true,
 }
 
@@ -22,17 +23,17 @@ const slice = createSlice({
     },
     fetchAccount(state, action: PayloadAction<string>) {},
     accountLoaded(state, action: PayloadAction<Account>) {
-      state.accountError = null
+      state.accountError = undefined
       Object.assign(state, action.payload)
     },
-    accountError(state, action: PayloadAction<string>) {
+    accountError(state, action: PayloadAction<ErrorPayload>) {
       state.accountError = action.payload
     },
     transactionsLoaded(state, action: PayloadAction<Transaction[]>) {
-      state.transactionsError = null
+      state.transactionsError = undefined
       state.transactions = action.payload
     },
-    transactionsError(state, action: PayloadAction<string>) {
+    transactionsError(state, action: PayloadAction<ErrorPayload>) {
       state.transactionsError = action.payload
     },
     setLoading(state, action: PayloadAction<boolean>) {

--- a/src/app/state/account/types.ts
+++ b/src/app/state/account/types.ts
@@ -1,4 +1,5 @@
 import { Transaction } from 'app/state/transaction/types'
+import { ErrorPayload } from 'types/errors'
 
 export interface BalanceDetails {
   total: number
@@ -15,7 +16,7 @@ export interface Account {
 /* --- STATE --- */
 export interface AccountState extends Account {
   loading: boolean
-  accountError: string | null
+  accountError?: ErrorPayload
   transactions: Transaction[]
-  transactionsError: string | null
+  transactionsError?: ErrorPayload
 }

--- a/src/app/state/staking/index.ts
+++ b/src/app/state/staking/index.ts
@@ -29,11 +29,12 @@ const slice = createSlice({
       state.updateValidatorsError = action.payload.error
       state.validators = action.payload.validators
     },
-    updateDelegations(state, action: PayloadAction<Delegation[]>) {
-      state.delegations = action.payload
-    },
-    updateDebondingDelegations(state, action: PayloadAction<DebondingDelegation[]>) {
-      state.debondingDelegations = action.payload
+    updateDelegations(
+      state,
+      action: PayloadAction<{ delegations: Delegation[]; debondingDelegations: DebondingDelegation[] }>,
+    ) {
+      state.delegations = action.payload.delegations
+      state.debondingDelegations = action.payload.debondingDelegations
     },
     validatorSelected(state, action: PayloadAction<string>) {
       state.selectedValidator = action.payload

--- a/src/app/state/staking/index.ts
+++ b/src/app/state/staking/index.ts
@@ -1,4 +1,5 @@
 import { PayloadAction } from '@reduxjs/toolkit'
+import { ErrorPayload } from 'types/errors'
 import { createSlice } from 'utils/@reduxjs/toolkit'
 
 import { DebondingDelegation, Delegation, StakingState, Validators, ValidatorDetails } from './types'
@@ -6,6 +7,7 @@ import { DebondingDelegation, Delegation, StakingState, Validators, ValidatorDet
 export const initialState: StakingState = {
   debondingDelegations: [],
   delegations: [],
+  updateDelegationsError: undefined,
   validators: null,
   updateValidatorsError: null,
   selectedValidatorDetails: null,
@@ -33,8 +35,12 @@ const slice = createSlice({
       state,
       action: PayloadAction<{ delegations: Delegation[]; debondingDelegations: DebondingDelegation[] }>,
     ) {
+      state.updateDelegationsError = undefined
       state.delegations = action.payload.delegations
       state.debondingDelegations = action.payload.debondingDelegations
+    },
+    updateDelegationsError(state, action: PayloadAction<ErrorPayload>) {
+      state.updateDelegationsError = action.payload
     },
     validatorSelected(state, action: PayloadAction<string>) {
       state.selectedValidator = action.payload

--- a/src/app/state/staking/index.ts
+++ b/src/app/state/staking/index.ts
@@ -9,7 +9,7 @@ export const initialState: StakingState = {
   delegations: [],
   updateDelegationsError: undefined,
   validators: null,
-  updateValidatorsError: null,
+  updateValidatorsError: undefined,
   selectedValidatorDetails: null,
   selectedValidator: null,
   loading: false,
@@ -24,10 +24,10 @@ const slice = createSlice({
     },
     fetchAccount(state, action: PayloadAction<string>) {},
     updateValidators(state, action: PayloadAction<Validators>) {
-      state.updateValidatorsError = null
+      state.updateValidatorsError = undefined
       state.validators = action.payload
     },
-    updateValidatorsError(state, action: PayloadAction<{ error: string; validators: Validators }>) {
+    updateValidatorsError(state, action: PayloadAction<{ error: ErrorPayload; validators: Validators }>) {
       state.updateValidatorsError = action.payload.error
       state.validators = action.payload.validators
     },

--- a/src/app/state/staking/saga.test.ts
+++ b/src/app/state/staking/saga.test.ts
@@ -1,5 +1,4 @@
 import * as oasis from '@oasisprotocol/client'
-import { StakingDebondingDelegationInfo, StakingDelegationInfo } from '@oasisprotocol/client/dist/types'
 import { expectSaga, testSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { EffectProviders, StaticProvider } from 'redux-saga-test-plan/providers'
@@ -17,19 +16,9 @@ import {
   now,
   stakingSaga,
 } from './saga'
-import { StakingState, Validator } from './types'
+import { DebondingDelegation, Delegation, StakingState, Validator } from './types'
 
 const qty = (number: number) => oasis.quantity.fromBigInt(BigInt(number))
-const fixtureDebondingDelegation = new Map<Uint8Array, StakingDebondingDelegationInfo[]>([
-  [
-    new Uint8Array(),
-    [{ debond_end: 1234, pool: { balance: qty(1000), total_shares: qty(1000) }, shares: qty(100) }],
-  ],
-])
-
-const fixtureDelegation = new Map<Uint8Array, StakingDelegationInfo>([
-  [new Uint8Array(), { pool: { balance: qty(1000), total_shares: qty(1000) }, shares: qty(100) }],
-])
 
 describe('Staking Sagas', () => {
   const getAllValidators = jest.fn()
@@ -60,8 +49,11 @@ describe('Staking Sagas', () => {
       ] as Validator[])
 
       getDelegations.mockResolvedValue({
-        delegations: fixtureDelegation,
-        debonding: fixtureDebondingDelegation,
+        delegations: [{ validatorAddress: 'dummy', amount: '100', shares: '100' }],
+        debonding: [{ validatorAddress: 'dummy', amount: '100', shares: '100', epoch: 1234 }],
+      } as {
+        delegations: Delegation[]
+        debonding: DebondingDelegation[]
       })
 
       return (

--- a/src/app/state/staking/saga.test.ts
+++ b/src/app/state/staking/saga.test.ts
@@ -4,6 +4,7 @@ import * as matchers from 'redux-saga-test-plan/matchers'
 import { EffectProviders, StaticProvider } from 'redux-saga-test-plan/providers'
 import { select } from 'redux-saga/effects'
 import { RootState } from 'types'
+import { WalletError, WalletErrors } from 'types/errors'
 
 import { initialState, stakingActions, stakingReducer } from '.'
 import { getExplorerAPIs, getOasisNic } from '../network/saga'
@@ -144,7 +145,7 @@ describe('Staking Sagas', () => {
     })
 
     it('should use fallback on mainnet', () => {
-      getAllValidators.mockRejectedValue('apiFailed')
+      getAllValidators.mockRejectedValue(new WalletError(WalletErrors.IndexerAPIError, 'Request failed'))
       const getMainnetDumpValidatorsMock = {
         dump_timestamp: 1647996761337,
         dump_timestamp_iso: '2022-03-23T00:52:41.337Z',
@@ -185,7 +186,10 @@ describe('Staking Sagas', () => {
         .provide([...providers, [matchers.call.fn(getMainnetDumpValidators), getMainnetDumpValidatorsMock]])
         .put(
           stakingActions.updateValidatorsError({
-            error: 'apiFailed',
+            error: {
+              code: WalletErrors.IndexerAPIError,
+              message: 'Request failed',
+            },
             validators: {
               timestamp: getMainnetDumpValidatorsMock.dump_timestamp,
               network: 'mainnet',

--- a/src/app/state/staking/types.ts
+++ b/src/app/state/staking/types.ts
@@ -1,6 +1,7 @@
 /* --- STATE --- */
 
 import { NetworkType } from 'app/state/network/types'
+import { ErrorPayload } from 'types/errors'
 
 export interface Validator {
   address: string
@@ -66,6 +67,9 @@ export interface StakingState {
 
   /** List of debonding delegations for the selected account */
   debondingDelegations: DebondingDelegation[]
+
+  /** Error from fetching delegations */
+  updateDelegationsError?: ErrorPayload
 
   /** Addresss of the selected validator */
   selectedValidator?: string | null

--- a/src/app/state/staking/types.ts
+++ b/src/app/state/staking/types.ts
@@ -60,7 +60,7 @@ export interface StakingState {
   validators: Validators | null
 
   /** Error from last attempt to update our list of validators */
-  updateValidatorsError: string | null
+  updateValidatorsError?: ErrorPayload
 
   /** List of active delegations for the selected account */
   delegations: Delegation[]

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -71,6 +71,10 @@
       "showingStale": "Showing validator list as of {{staleTimestamp}}."
     }
   },
+  "backends": {
+    "oasismonitor": "Oasis Monitor API",
+    "oasisscan": "Oasis Scan API"
+  },
   "common": {
     "amount": "Amount",
     "block": "Block",
@@ -96,12 +100,14 @@
     "debondingDelegations": "Debonding delegations",
     "debondingEpoch": "Debonding epoch",
     "delegatedAmount": "Delegated amount",
+    "loadingError": "Couldn't load delegations.",
     "reclaimedAmount": "Amount to reclaim"
   },
   "errors": {
     "LedgerOasisAppIsNotOpen": "Oasis App on Ledger is closed.",
     "cannotSendToSelf": "Cannot send to yourself",
     "duplicateTransaction": "Duplicate transaction",
+    "indexerAPIError": "{{indexerName}} appears to be down, some information may be missing or out of date. Please, come back later.",
     "insufficientBalance": "Insufficient balance",
     "invalidAddress": "Invalid address",
     "invalidNonce": "Invalid nonce (transaction number)",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -12,7 +12,7 @@
       "delegate": "Delegate"
     },
     "loading": "Loading account",
-    "loadingError": "Couldn't load account. Information may be missing or out of date.",
+    "loadingError": "Couldn't load account.",
     "otherTransaction": {
       "designation": "Other address",
       "header": "Unrecognized transaction, method '{{method}}'"
@@ -54,7 +54,7 @@
         "received": "Received <0></0> delegation in escrow",
         "sent": "Delegated <0></0> to validator"
       },
-      "loadingError": "Couldn't load transactions. List may be empty or out of date.",
+      "loadingError": "Couldn't load transactions.",
       "reclaimEscrow": {
         "received": "<0></0> reclaimed by delegator",
         "sent": "Reclaimed <0></0> from validator"
@@ -106,6 +106,7 @@
   "errors": {
     "LedgerOasisAppIsNotOpen": "Oasis App on Ledger is closed.",
     "cannotSendToSelf": "Cannot send to yourself",
+    "disconnectedError": "Lost connection.",
     "duplicateTransaction": "Duplicate transaction",
     "indexerAPIError": "{{indexerName}} appears to be down, some information may be missing or out of date. Please, come back later.",
     "insufficientBalance": "Insufficient balance",

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -22,6 +22,7 @@ export enum WalletErrors {
   LedgerNoDeviceSelected = 'no_device_selected',
   LedgerTransactionRejected = 'transaction_rejected',
   LedgerAppVersionNotSupported = 'ledger_version_not_supported',
+  IndexerAPIError = 'indexer_api_error',
 }
 
 export interface ErrorPayload {

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,5 +1,5 @@
 export class WalletError extends Error {
-  constructor(public readonly type: WalletErrors, message: string, originalError?: Error) {
+  constructor(public readonly type: WalletErrors, message: string, public readonly originalError?: Error) {
     super(message)
   }
 }

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -23,6 +23,7 @@ export enum WalletErrors {
   LedgerTransactionRejected = 'transaction_rejected',
   LedgerAppVersionNotSupported = 'ledger_version_not_supported',
   IndexerAPIError = 'indexer_api_error',
+  DisconnectedError = 'disconnected_error',
 }
 
 export interface ErrorPayload {

--- a/src/vendors/__tests__/throwAPIErrors.test.ts
+++ b/src/vendors/__tests__/throwAPIErrors.test.ts
@@ -6,6 +6,15 @@ describe('throwAPIErrors', () => {
     jest.resetAllMocks()
   })
 
+  test('should throw an error when fetching fails (e.g. missing CORS headers)', async () => {
+    jest.spyOn(window, 'fetch').mockImplementationOnce(async () => {
+      throw new TypeError('Failed to fetch')
+    })
+    const fetchFail = getOasisscanAPIs('https://api.oasisscan.com/mainnet/').getAccount('oasis1')
+    await expect(fetchFail).rejects.toThrowError(WalletError)
+    await expect(fetchFail).rejects.toHaveProperty('type', WalletErrors.IndexerAPIError)
+  })
+
   test('should throw an error on HTTP error status', async () => {
     jest.spyOn(window, 'fetch').mockImplementationOnce(async info => {
       return Object.assign(

--- a/src/vendors/__tests__/throwAPIErrors.test.ts
+++ b/src/vendors/__tests__/throwAPIErrors.test.ts
@@ -1,0 +1,24 @@
+import { WalletError, WalletErrors } from 'types/errors'
+import { getOasisscanAPIs } from '../oasisscan'
+
+describe('throwAPIErrors', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('should throw an error on HTTP error status', async () => {
+    jest.spyOn(window, 'fetch').mockImplementationOnce(async info => {
+      return Object.assign(
+        new Response('', {
+          status: 502,
+        }),
+        {
+          url: new Request(info).url,
+        },
+      )
+    })
+    const http502 = getOasisscanAPIs('https://api.oasisscan.com/mainnet/').getAccount('oasis1')
+    await expect(http502).rejects.toThrowError(WalletError)
+    await expect(http502).rejects.toHaveProperty('type', WalletErrors.IndexerAPIError)
+  })
+})

--- a/src/vendors/explorer/runtime.ts
+++ b/src/vendors/explorer/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw new Error(`request ${url} status ${response.status}`);
+        throw response;
     }
 
     private createFetchParams(context: RequestOpts) {

--- a/src/vendors/helpers.ts
+++ b/src/vendors/helpers.ts
@@ -1,4 +1,7 @@
 import { Validator } from 'app/state/staking/types'
+import { WalletError, WalletErrors } from 'types/errors'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { BaseAPI, ConfigurationParameters } from 'vendors/oasisscan/runtime'
 
 const ValidatorStatusPriority = {
   active: 1,
@@ -8,3 +11,22 @@ const ValidatorStatusPriority = {
 
 export const sortByStatus = (a: Validator, b: Validator) =>
   ValidatorStatusPriority[a.status] - ValidatorStatusPriority[b.status]
+
+/**
+ * Throw errors instead of OpenAPI-generated-code throwing response objects.
+ * See {@link BaseAPI#request}
+ */
+export const throwAPIErrors: ConfigurationParameters = {
+  middleware: [
+    {
+      post: async ({ response }) => {
+        if (response.status < 200 || response.status >= 300) {
+          throw new WalletError(
+            WalletErrors.IndexerAPIError,
+            `Request failed ${response.url} with status ${response.status}`,
+          )
+        }
+      },
+    },
+  ],
+}

--- a/src/vendors/helpers.ts
+++ b/src/vendors/helpers.ts
@@ -17,6 +17,15 @@ export const sortByStatus = (a: Validator, b: Validator) =>
  * See {@link BaseAPI#request}
  */
 export const throwAPIErrors: ConfigurationParameters = {
+  fetchApi: async (info, init) => {
+    try {
+      const response = await window.fetch(info, init)
+      return response
+    } catch (err: any) {
+      const url = new Request(info).url
+      throw new WalletError(WalletErrors.IndexerAPIError, `Request failed ${url} with ${err}`, err)
+    }
+  },
   middleware: [
     {
       post: async ({ response }) => {

--- a/src/vendors/monitor.ts
+++ b/src/vendors/monitor.ts
@@ -16,11 +16,12 @@ import {
 } from 'vendors/explorer'
 import { addressToPublicKey } from 'app/lib/helpers'
 
-import { sortByStatus } from './helpers'
+import { sortByStatus, throwAPIErrors } from './helpers'
 
 export function getMonitorAPIs(url: string | 'https://monitor.oasis.dev/') {
   const explorerConfig = new Configuration({
     basePath: url,
+    ...throwAPIErrors,
   })
 
   const accounts = new AccountsApi(explorerConfig)

--- a/src/vendors/oasisscan.ts
+++ b/src/vendors/oasisscan.ts
@@ -15,11 +15,12 @@ import {
   OperationsRowMethodEnum,
 } from 'vendors/oasisscan/index'
 
-import { sortByStatus } from './helpers'
+import { throwAPIErrors, sortByStatus } from './helpers'
 
 export function getOasisscanAPIs(url: string | 'https://api.oasisscan.com/mainnet/') {
   const explorerConfig = new Configuration({
     basePath: url,
+    ...throwAPIErrors,
   })
 
   const accounts = new AccountsApi(explorerConfig)


### PR DESCRIPTION
Related to https://github.com/oasisprotocol/oasis-wallet-web/issues/403

- Revert https://github.com/oasisprotocol/oasis-wallet-web/commit/8c483c0e47f2108a7b8e41dcf13be1c94ba04c3f and use middleware to throw IndexerAPIError instead.
  (related https://github.com/oasisprotocol/oasis-wallet-web/commit/cac52d18004c14704647a623d58f8c729e243331 and https://github.com/oasisprotocol/oasis-wallet-web/commit/6a59864e01c6896928d94e098d2d8441b820b479)
- Use the same middleware for oasisscan too
- Survive getting delegations failures
- Simplify displayed text of existing "survivable" errors and tell users to come back :pleading_face: 

| Before | After |
| --- | --- |
| Loading delegations error: | |
| ![delegations_before](https://user-images.githubusercontent.com/3758846/175657176-0b63a2b9-96f9-4707-9cd1-adb250485d21.png) | ![delegations_after](https://user-images.githubusercontent.com/3758846/175657173-d3f81585-a47c-4434-812b-114f577bb996.png) |
| Loading account error: | |
| ![account_before](https://user-images.githubusercontent.com/3758846/175657169-6f8185c0-9544-4796-b96a-20a463afb3fc.png)  | ![account_after](https://user-images.githubusercontent.com/3758846/175657164-9d06f900-32a0-4b19-923f-36d5f38f1373.png)  |
| Loading validators error: | |
| ![validators_before](https://user-images.githubusercontent.com/3758846/175657178-99c73829-98de-46c5-aa1a-5cc0febcd4d7.png) | ![validators_after](https://user-images.githubusercontent.com/3758846/175657177-8b4b94a9-39e8-4e6d-8ef6-0946995ed6fd.png) |
