### PR TITLE
Fix extension production build errors and inject missing env variables

### DIFF
--- a/extension/src/background.html
+++ b/extension/src/background.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script type="module" src="./background.ts"></script>
+  </body>
+</html>

--- a/internals/getBuildData.js
+++ b/internals/getBuildData.js
@@ -1,0 +1,5 @@
+// @ts-check
+const buildSha = require('child_process').execSync('git rev-parse HEAD').toString().trim()
+const buildDatetime = Date.now().toString()
+
+module.exports = { buildDatetime, buildSha }

--- a/internals/prod-ext.js
+++ b/internals/prod-ext.js
@@ -1,0 +1,14 @@
+// @ts-check
+const execSync = require('child_process').execSync
+const { getCsp } = require('./getCsp.js')
+const { buildDatetime, buildSha } = require('./getBuildData')
+
+process.env.REACT_APP_BUILD_DATETIME = buildDatetime
+process.env.REACT_APP_BUILD_SHA = buildSha
+process.env.EXTENSION_CSP = getCsp({ isExtension: true })
+
+console.log(`Content-Security-Policy: ${process.env.EXTENSION_CSP}\n`)
+
+execSync('yarn clean:ext', { stdio: 'inherit' })
+execSync('parcel build --target ext --dist-dir build-ext', { stdio: 'inherit' })
+execSync('node ./internals/scripts/validate-ext-manifest.js', { stdio: 'inherit' })

--- a/internals/prod-web.js
+++ b/internals/prod-web.js
@@ -1,12 +1,13 @@
 // @ts-check
 const execSync = require('child_process').execSync
 const { getCsp } = require('./getCsp.js')
+const { buildDatetime, buildSha } = require('./getBuildData')
 
-process.env.REACT_APP_BUILD_DATETIME = Date.now().toString()
-process.env.REACT_APP_BUILD_SHA = execSync('git rev-parse HEAD').toString().trim()
+process.env.REACT_APP_BUILD_DATETIME = buildDatetime
+process.env.REACT_APP_BUILD_SHA = buildSha
 process.env.REACT_APP_META_CSP = getCsp()
 
 console.log(`Content-Security-Policy: ${process.env.REACT_APP_META_CSP}\n`)
 
-execSync('yarn parcel:prod', { stdio: 'inherit' })
+execSync('yarn clean && parcel build --target web --dist-dir build', { stdio: 'inherit' })
 execSync('cp public/robots.txt build/robots.txt', { encoding: 'utf8' })

--- a/package.json
+++ b/package.json
@@ -8,14 +8,13 @@
     "url": "https://github.com/oasisprotocol/oasis-wallet-web.git"
   },
   "scripts": {
+    "build": "node ./internals/prod-web.js",
+    "build:ext": "node ./internals/prod-ext.js",
     "clean": "rm -rf build/ .parcel-cache",
-    "parcel:prod": "parcel build --target web --dist-dir build",
     "clean:ext": "rm -rf build-ext/ .parcel-cache",
     "start": "REACT_APP_META_CSP= HMR_PORT=2222 EXTENSION_CSP=`yarn --silent print-extension-csp` parcel --host localhost --port 3000 --dist-dir build-dev",
-    "build:ext": "yarn clean:ext && EXTENSION_CSP=`yarn --silent print-extension-csp` parcel build --target ext --dist-dir build-ext && node ./internals/scripts/validate-ext-manifest.js",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
-    "build": "yarn clean && node ./internals/prod-scripts.js",
     "test": "REACT_APP_LOCALNET=1 jest --color",
     "test:web": "yarn run test --projects internals/jest/jest.web-config.js",
     "test:ext": "yarn run test --projects internals/jest/jest.ext-config.js",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,6 +30,9 @@
   },
   "permissions": ["storage", "notifications", "activeTab"],
   "content_security_policy": "{{{ EXTENSION_CSP }}}",
-  "background": { "scripts": ["../extension/src/background.ts"], "persistent": true },
+  "background": {
+    "page": "../extension/src/background.html",
+    "persistent": true
+  },
   "web_accessible_resources": ["./oasis-xu-frame.html"]
 }


### PR DESCRIPTION
Targets #853 
So far I found three workarounds:

1. Init background via background `page` instead of `scripts` array. Compiled html has all chunks and issue with chunks is fixed.

Other workarounds:

2. kill chunks/code split, which is controlled by entry in [package.json](https://parceljs.org/features/code-splitting/#configuration)

```
  "@parcel/bundler-default": {
    "minBundles": 10 // some magic number
  }
```


3. Do not share deps between popup and background (avoid shared chunk) for example by using dynamically imported modules. This can be achieved in different ways probably and would allow us to keep chunks that will work in FF.
Without going too deep in debugging I think background script was executed without runtime (or shared modules), or before runtime was initialised and because of bg popup was failing to init as well. Couldn't make it work with async/await.  

background.ts
```
import('./backgroundImportHelper').then(({ configureAppStore, wrapStore }) => {
   const store = configureAppStore()
   wrapStore(store)
})

export {}
```
backgroundImportHelper.ts

```
export { wrapStore } from 'webext-redux'
export { configureAppStore } from 'store/configureStore'
```

