### PR TITLE
Don't use misleading balance fields from RPC

### DIFF
--- a/src/app/components/Toolbar/Features/AccountSelector/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Toolbar/Features/AccountSelector/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,243 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<AccountSelector  /> should match snapshot 1`] = `
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 24px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: auto;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-height: 400px;
+  padding-top: 24px;
+  padding-bottom: 24px;
+  padding-right: 12px;
+  overflow-y: auto;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 1px #0092f6;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  width: 100%;
+  padding: 12px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.c8:hover {
+  background-color: #0092f6;
+  color: #FFFFFF;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-top: 24px;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c15 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #0092f6;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #0092f6;
+  color: #f8f8f8;
+  border-radius: 18px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  font-weight: bold;
+}
+
+.c15:hover {
+  box-shadow: 0px 0px 0px 2px #0092f6;
+}
+
+.c15:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c15:focus > circle,
+.c15:focus > ellipse,
+.c15:focus > line,
+.c15:focus > path,
+.c15:focus > polygon,
+.c15:focus > polyline,
+.c15:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c15:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c15:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c15:focus:not(:focus-visible) > circle,
+.c15:focus:not(:focus-visible) > ellipse,
+.c15:focus:not(:focus-visible) > line,
+.c15:focus:not(:focus-visible) > path,
+.c15:focus:not(:focus-visible) > polygon,
+.c15:focus:not(:focus-visible) > polyline,
+.c15:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c15:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  margin-top: 12px;
+  margin-bottom: 12px;
+  font-size: 1;
+  line-height: normal;
+  max-width: 1200px;
+  font-weight: 600;
+}
+
 .c0 {
   font-family: Rubik;
   font-size: 18px;
@@ -14,56 +251,267 @@ exports[`<AccountSelector  /> should match snapshot 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-@media only screen and (max-width:768px) {
+.c1 {
+  font-family: Rubik;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #ffffff;
+  color: #444444;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  background: transparent;
+  position: relative;
+  z-index: 20;
+  pointer-events: none;
+  outline: none;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+}
 
+.c2 {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background-color: rgba(0,0,0,0.5);
+  color: #f8f8f8;
+  pointer-events: all;
+  will-change: transform;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 48px;
+  background-color: #FFFFFF;
+  color: #444444;
+  outline: none;
+  pointer-events: all;
+  z-index: 20;
+  position: absolute;
+  max-height: calc(100% - 0px - 0px);
+  max-width: calc(100% - 0px - 0px);
+  border-radius: 4px;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  -webkit-animation: hWAzxx 0.2s ease-in-out forwards;
+  animation: hWAzxx 0.2s ease-in-out forwards;
+}
+
+.c4 {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  position: absolute;
 }
 
 @media only screen and (max-width:768px) {
-
+  .c5 {
+    margin: 12px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c5 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c7 {
+    padding-top: 12px;
+    padding-bottom: 12px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c7 {
+    padding-right: 6px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c8 {
+    border: solid 1px #0092f6;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c8 {
+    padding: 6px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c12 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-flex-basis: auto;
+    -ms-flex-preferred-size: auto;
+    flex-basis: auto;
+    -webkit-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c14 {
+    padding-top: 12px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c6 {
+    margin-top: 6px;
+    margin-bottom: 6px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c1 {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    min-height: 100vh;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c2 {
+    position: relative;
+  }
 }
 
-<div
-  class="c0"
-  style="min-height: 100vh;"
-/>
+@media only screen and (max-width:768px) {
+  .c3 {
+    position: relative;
+    max-height: none;
+    max-width: none;
+    border-radius: 0;
+    height: 100vh;
+    width: 100vw;
+  }
+}
+
+<body
+  style=""
+>
+  <div>
+    <div
+      class="c0"
+      style="min-height: 100vh;"
+    />
+  </div>
+  <div>
+    <div
+      aria-hidden="false"
+    >
+      <div
+        class="c1"
+        tabindex="-1"
+      >
+        <div
+          class="c2"
+        />
+        <div
+          class="c3"
+          data-g-portal-id="0"
+          style="overflow-y: auto;"
+        >
+          <a
+            aria-hidden="true"
+            class="c4"
+            tabindex="-1"
+          />
+          <div>
+            <div
+              class="c5"
+            >
+              <h1
+                class="c6"
+                size="1"
+              >
+                toolbar.wallets.switchOtherWallet
+              </h1>
+              <div
+                class="c7"
+              >
+                <div
+                  class="c8"
+                  data-testid="account-choice"
+                  tabindex="0"
+                >
+                  <div
+                    class="c9"
+                  >
+                    <div
+                      class="c10"
+                    >
+                      <span
+                        class="c11"
+                      >
+                        dummy...dummy
+                      </span>
+                    </div>
+                    <div
+                      class="c12"
+                    >
+                      <div
+                        class="c13"
+                      >
+                        toolbar.wallets.type.ledger
+                         
+                      </div>
+                      <div
+                        class="c10"
+                      >
+                        0.0000001
+                         
+                        
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="c14"
+              >
+                <button
+                  class="c15"
+                  style="border-radius: 4px;"
+                  type="button"
+                >
+                  toolbar.wallets.close
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
 `;

--- a/src/app/components/Toolbar/Features/AccountSelector/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Toolbar/Features/AccountSelector/__tests__/__snapshots__/index.test.tsx.snap
@@ -488,7 +488,7 @@ exports[`<AccountSelector  /> should match snapshot 1`] = `
                       <div
                         class="c10"
                       >
-                        0.0000054
+                        0.0000001
                          
                         
                       </div>

--- a/src/app/components/Toolbar/Features/AccountSelector/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Toolbar/Features/AccountSelector/__tests__/__snapshots__/index.test.tsx.snap
@@ -488,7 +488,7 @@ exports[`<AccountSelector  /> should match snapshot 1`] = `
                       <div
                         class="c10"
                       >
-                        0.0000001
+                        0.0000054
                          
                         
                       </div>

--- a/src/app/components/Toolbar/Features/AccountSelector/__tests__/index.test.tsx
+++ b/src/app/components/Toolbar/Features/AccountSelector/__tests__/index.test.tsx
@@ -26,7 +26,7 @@ describe('<AccountSelector  />', () => {
         wallets: {
           1: {
             address: 'dummy',
-            balance: { available: '100', debonding: '0', escrow: '0', total: '100' },
+            balance: { available: '100', debonding: '300', escrow: '5000', total: '5400' },
             id: 1,
             publicKey: '00',
             type: WalletType.Ledger,

--- a/src/app/components/Toolbar/Features/AccountSelector/__tests__/index.test.tsx
+++ b/src/app/components/Toolbar/Features/AccountSelector/__tests__/index.test.tsx
@@ -38,6 +38,6 @@ describe('<AccountSelector  />', () => {
 
   it('should match snapshot', () => {
     const component = renderComponent(store)
-    expect(component.container.firstChild).toMatchSnapshot()
+    expect(component.baseElement).toMatchSnapshot()
   })
 })

--- a/src/app/components/Toolbar/Features/AccountSelector/__tests__/index.test.tsx
+++ b/src/app/components/Toolbar/Features/AccountSelector/__tests__/index.test.tsx
@@ -26,7 +26,7 @@ describe('<AccountSelector  />', () => {
         wallets: {
           1: {
             address: 'dummy',
-            balance: { available: '100', debonding: '300', escrow: '5000', total: '5400' },
+            balance: { available: '100', validator: { escrow: '5000', escrow_debonding: '300' } },
             id: 1,
             publicKey: '00',
             type: WalletType.Ledger,

--- a/src/app/components/Toolbar/Features/AccountSelector/index.tsx
+++ b/src/app/components/Toolbar/Features/AccountSelector/index.tsx
@@ -103,7 +103,7 @@ export const AccountSelector = memo((props: Props) => {
       key={index}
       index={wallet.id}
       address={wallet.address}
-      balance={wallet.balance.total}
+      balance={wallet.balance.available} // TODO: get total balance
       type={wallet.type}
       onClick={switchAccount}
       isActive={wallet.id === activeWalletIndex}

--- a/src/app/lib/helpers.test.ts
+++ b/src/app/lib/helpers.test.ts
@@ -73,9 +73,10 @@ describe('parseRpcBalance', () => {
       }),
     ).toEqual({
       available: '19799999999',
-      debonding: '0',
-      escrow: '0',
-      total: '19799999999',
+      validator: {
+        escrow: '0',
+        escrow_debonding: '0',
+      },
     })
   })
 
@@ -101,9 +102,10 @@ describe('parseRpcBalance', () => {
       }),
     ).toEqual({
       available: '11475573433450',
-      debonding: '131199903851726',
-      escrow: '239806259647933506',
-      total: '239948935125218682',
+      validator: {
+        escrow: '239806259647933506',
+        escrow_debonding: '131199903851726',
+      },
     })
   })
 })

--- a/src/app/lib/helpers.ts
+++ b/src/app/lib/helpers.ts
@@ -55,13 +55,11 @@ export const parseStringValueToInt = (value: string) => parseFloat(value) * 10 *
 export function parseRpcBalance(account: types.StakingAccount): WalletBalance {
   const zero = stringBigint2uint('0')
 
-  const balance = {
+  return {
     available: uint2bigintString(account.general?.balance || zero),
-    debonding: uint2bigintString(account.escrow?.debonding?.balance || zero),
-    escrow: uint2bigintString(account.escrow?.active?.balance || zero),
+    validator: {
+      escrow: uint2bigintString(account.escrow?.active?.balance || zero),
+      escrow_debonding: uint2bigintString(account.escrow?.debonding?.balance || zero),
+    },
   }
-
-  const total = BigInt(balance.available) + BigInt(balance.debonding) + BigInt(balance.escrow)
-
-  return { ...balance, total: total.toString() }
 }

--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -23,7 +23,12 @@ import { TransitionGroup } from 'react-transition-group'
 import { accountActions } from '../../state/account'
 import { selectAccount } from '../../state/account/selectors'
 import { BalanceDetails } from '../../state/account/types'
-import { selectAddress, selectIsOpen, selectWallets } from '../../state/wallet/selectors'
+import {
+  selectAddress,
+  selectIsOpen,
+  selectWallets,
+  selectWalletsPublicKeys,
+} from '../../state/wallet/selectors'
 import { ActiveDelegationList } from '../StakingPage/Features/DelegationList/ActiveDelegationList'
 import { DebondingDelegationList } from '../StakingPage/Features/DelegationList/DebondingDelegationList'
 import { ValidatorList } from '../StakingPage/Features/ValidatorList'
@@ -79,6 +84,7 @@ export function AccountPage(props: Props) {
   const selectedNetwork = useSelector(selectSelectedNetwork)
   const { active } = useSelector(selectTransaction)
   const wallets = useSelector(selectWallets)
+  const walletsPublicKeys = useSelector(selectWalletsPublicKeys)
 
   const balanceDelegations = stake.delegations.reduce((acc, v) => acc + Number(v.amount), 0)
   const balanceDebondingDelegations = stake.debondingDelegations.reduce((acc, v) => acc + Number(v.amount), 0)
@@ -103,7 +109,9 @@ export function AccountPage(props: Props) {
     for (const wallet of Object.values(wallets)) {
       dispatch(walletActions.fetchWallet(wallet))
     }
-  }, [dispatch, wallets, selectedNetwork])
+    // Using `walletsPublicKeys` dependency instead of `wallets` to avoid infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, walletsPublicKeys.join(','), selectedNetwork])
 
   return (
     <Box pad="small">

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/__tests__/index.test.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/__tests__/index.test.tsx
@@ -51,7 +51,7 @@ describe('<FromLedgerModal  />', () => {
       ledgerActions.accountsListed([
         {
           address: 'oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe',
-          balance: { available: '0', debonding: '0', escrow: '0', total: '0' },
+          balance: { available: '0', validator: { escrow: '0', escrow_debonding: '0' } },
           path: [44, 474, 0],
           publicKey: '00',
           selected: false,
@@ -72,14 +72,14 @@ describe('<FromLedgerModal  />', () => {
       ledgerActions.accountsListed([
         {
           address: 'oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe',
-          balance: { available: '0', debonding: '0', escrow: '0', total: '0' },
+          balance: { available: '0', validator: { escrow: '0', escrow_debonding: '0' } },
           path: [44, 474, 0],
           publicKey: '00',
           selected: false,
         },
         {
           address: 'oasis1qqv25adrld8jjquzxzg769689lgf9jxvwgjs8tha',
-          balance: { available: '0', debonding: '0', escrow: '0', total: '0' },
+          balance: { available: '0', validator: { escrow: '0', escrow_debonding: '0' } },
           path: [44, 474, 1],
           publicKey: '00',
           selected: false,

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
@@ -32,7 +32,7 @@ function LedgerAccountSelector(props: LedgerAccountSelectorProps) {
     <Account
       index={index}
       address={a.address}
-      balance={a.balance.total}
+      balance={a.balance.available} // TODO: get total balance
       type={WalletType.Ledger}
       onClick={toggleAccount}
       isActive={a.selected}

--- a/src/app/state/wallet/saga.test.ts
+++ b/src/app/state/wallet/saga.test.ts
@@ -58,7 +58,7 @@ describe('Wallet Sagas', () => {
           walletActions.openWalletsFromLedger([
             {
               address: addressHex,
-              balance: { available: '0', debonding: '0', escrow: '0', total: '0' },
+              balance: { available: '0', validator: { escrow: '0', escrow_debonding: '0' } },
               path: [44, 474, 0, 0, 0],
               publicKey: '00',
               selected: true,

--- a/src/app/state/wallet/selectors.ts
+++ b/src/app/state/wallet/selectors.ts
@@ -14,6 +14,9 @@ export const selectActiveWallet = createSelector([selectSlice, selectActiveWalle
 })
 
 export const selectWallets = createSelector([selectSlice], state => state.wallets ?? {})
+export const selectWalletsPublicKeys = createSelector([selectWallets], wallets =>
+  Object.values(wallets).map(w => w.publicKey),
+)
 export const selectAddress = createSelector([selectActiveWallet], wallet => wallet?.address ?? '')
 export const selectPublicKey = createSelector([selectActiveWallet], wallet => wallet?.publicKey ?? '')
 export const selectBalance = createSelector([selectActiveWallet], wallet => wallet?.balance)

--- a/src/app/state/wallet/types.ts
+++ b/src/app/state/wallet/types.ts
@@ -13,9 +13,10 @@ export enum WalletType {
  */
 export interface WalletBalance {
   available: string
-  escrow: string
-  debonding: string
-  total: string
+  validator: {
+    escrow: string
+    escrow_debonding: string
+  }
 }
 
 export interface BalanceUpdatePayload {


### PR DESCRIPTION
Stop using misleading `total` field from parseRpcBalance, remove it, and group validator-specific fields. In the future we should convert some of these RPC calls to API calls and use correct `total`

| Before `available + escrow (validator) + escrow_debonding (validator)` | After `available` |
| --- | --- |
|  ![before](https://user-images.githubusercontent.com/3758846/178626051-a10f66a7-58f9-4de3-8593-178ce712e192.png) | ![after](https://user-images.githubusercontent.com/3758846/178626048-d05127a6-9d4f-44d4-87a6-98b84d23e4b0.png)  |
