### PR TITLE
Improve the trimLongStart function

### DIFF
--- a/src/app/components/ShortAddress/__tests__/index.test.tsx
+++ b/src/app/components/ShortAddress/__tests__/index.test.tsx
@@ -4,8 +4,8 @@ import { trimLongString, ShortAddress } from '..'
 
 describe('trimLongString', () => {
   it('should return trimmed string', () => {
-    expect(trimLongString('qwertyuiopasdfghjkl')).toEqual('qwertyuiop...sdfghjkl')
-    expect(trimLongString('qwertyuiopasdfghjkl', 2, -2)).toEqual('qw...kl')
+    expect(trimLongString('oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4')).toEqual('oasis1qq2v...sv0d5eq4')
+    expect(trimLongString('oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4', 2, -2)).toEqual('oa...q4')
   })
 
   it('should return short hash', () => {
@@ -17,12 +17,16 @@ describe('trimLongString', () => {
   it('should return original string if it is shorter than trimStart value', () => {
     expect(trimLongString('foo')).toEqual('foo')
   })
+
+  it('it should not return a "trimmed" version that is actually longer than the original, even if longer than trimStart', () => {
+    expect(trimLongString('unavailable')).toEqual('unavailable')
+  })
 })
 
 describe('<ShortAddress  />', () => {
   it('should render short address', () => {
-    render(<ShortAddress address="qwertyuiopasdfghjkl" />)
-    expect(screen.getByText('qwertyuiop...sdfghjkl')).toBeInTheDocument()
+    render(<ShortAddress address="oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4" />)
+    expect(screen.getByText('oasis1qq2v...sv0d5eq4')).toBeInTheDocument()
   })
 
   it('should render hash', () => {

--- a/src/app/components/ShortAddress/index.tsx
+++ b/src/app/components/ShortAddress/index.tsx
@@ -14,8 +14,9 @@ interface Props {
 export function trimLongString(value: string, trimStart = 10, trimEnd = -8) {
   // The length of a trimmed string
   const trimmedLength = trimStart + 3 - trimEnd // trimEnd is negative..
-  if (value.length <= trimStart || trimmedLength > value.length) {
+  if (trimmedLength > value.length) {
     // If the "trimmed" version would be longer, don't bother
+    // (This also covers the case when the length is et most trimStart)
     return value
   }
 

--- a/src/app/components/ShortAddress/index.tsx
+++ b/src/app/components/ShortAddress/index.tsx
@@ -12,7 +12,10 @@ interface Props {
 }
 
 export function trimLongString(value: string, trimStart = 10, trimEnd = -8) {
-  if (value.length <= trimStart) {
+  // The length of a trimmed string
+  const trimmedLength = trimStart + 3 - trimEnd // trimEnd is negative..
+  if (value.length <= trimStart || trimmedLength > value.length) {
+    // If the "trimmed" version would be longer, don't bother
     return value
   }
 


### PR DESCRIPTION
... so that it doesn't "trim" strings in a way which makes them longer.

(Also improve the tests a bit.)

Fixes #950