### PR TITLE
trimLongString(): flip semantics of trimEnd

### DIFF
--- a/src/app/components/ShortAddress/__tests__/index.test.tsx
+++ b/src/app/components/ShortAddress/__tests__/index.test.tsx
@@ -5,7 +5,7 @@ import { trimLongString, ShortAddress } from '..'
 describe('trimLongString', () => {
   it('should return trimmed string', () => {
     expect(trimLongString('oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4')).toEqual('oasis1qq2v...sv0d5eq4')
-    expect(trimLongString('oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4', 2, -2)).toEqual('oa...q4')
+    expect(trimLongString('oasis1qq2vzcvxn0js5unsch5me2xz4kr43vcasv0d5eq4', 2, 2)).toEqual('oa...q4')
   })
 
   it('should return short hash', () => {

--- a/src/app/components/ShortAddress/index.tsx
+++ b/src/app/components/ShortAddress/index.tsx
@@ -11,16 +11,15 @@ interface Props {
   address: string
 }
 
-export function trimLongString(value: string, trimStart = 10, trimEnd = -8) {
-  // The length of a trimmed string
-  const trimmedLength = trimStart + 3 - trimEnd // trimEnd is negative..
+export function trimLongString(value: string, trimStart = 10, trimEnd = 8) {
+  const trimmedLength = trimStart + 3 + trimEnd
   if (trimmedLength > value.length) {
     // If the "trimmed" version would be longer, don't bother
     // (This also covers the case when the length is et most trimStart)
     return value
   }
 
-  return `${value.slice(0, trimStart)}...${value.slice(trimEnd)}`
+  return `${value.slice(0, trimStart)}...${value.slice(-trimEnd)}`
 }
 
 export function ShortAddress(props: Props) {


### PR DESCRIPTION
... from negative to positive.
Update the tests accordingly.

(Also remove useless comment.)

This is the next step of #1006, Inspired by a comment made by @lukaw3d  [here](https://github.com/oasisprotocol/oasis-wallet-web/pull/1006#discussion_r977092236).

