### PR TITLE
UI tweaks for extension and mobile

### DIFF
--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -5,7 +5,7 @@
     <title>Oasis Web Extension</title>
   </head>
   <body>
-    <div id="root" style="min-width: 300px; min-height: 300px"></div>
+    <div id="root" style="min-width: 360px; min-height: 600px"></div>
     <script type="module" src="./popup/popup.tsx"></script>
     <a href="./popup.html" target="_blank">Open in new tab</a>
   </body>

--- a/src/app/components/Header/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Header/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ResponsiveGridRow /> should render component 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <span
+      class="c1"
+    >
+      Type
+    </span>
+  </div>
+  <div
+    class="c2"
+  >
+    transfer
+  </div>
+</div>
+`;

--- a/src/app/components/Header/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Header/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,54 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ResponsiveGridRow /> should render component 1`] = `
+exports[`<Header /> should render component 1`] = `
 .c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  margin-top: 0px;
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
+  font-weight: 600;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+@media only screen and (max-width:768px) {
+  .c0 {
+    margin-top: 0px;
+  }
 }
 
-.c1 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
+@media only screen and (max-width:768px) {
+  .c0 {
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
+  }
 }
 
 <div>
-  <div
+  <h1
     class="c0"
   >
-    <span
-      class="c1"
-    >
-      Type
-    </span>
-  </div>
-  <div
-    class="c2"
+    Title
+  </h1>
+</div>
+`;
+
+exports[`<ModalHeader /> should render component 1`] = `
+.c0 {
+  margin-top: 0px;
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
+  font-weight: 600;
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    margin-top: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
+  }
+}
+
+<div>
+  <h2
+    class="c0"
   >
-    transfer
-  </div>
+    Title
+  </h2>
 </div>
 `;

--- a/src/app/components/Header/__tests__/index.test.tsx
+++ b/src/app/components/Header/__tests__/index.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { Header, ModalHeader } from '..'
+
+describe('<Header />', () => {
+  it('should render component', () => {
+    const { container } = render(<Header>Title</Header>)
+
+    expect(container).toMatchSnapshot()
+  })
+})
+
+describe('<ModalHeader />', () => {
+  it('should render component', () => {
+    const { container } = render(<ModalHeader>Title</ModalHeader>)
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/app/components/Header/index.tsx
+++ b/src/app/components/Header/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Heading, HeadingProps } from 'grommet'
+
+interface HeaderProps extends Pick<HeadingProps, 'level' | 'size' | 'margin'> {
+  children: React.ReactNode
+}
+
+export const Header = ({
+  children,
+  level = 1,
+  size = 'small',
+  margin = { top: 'none' },
+  ...props
+}: HeaderProps) => (
+  <Heading level={level} size={size} margin={margin} {...props}>
+    {children}
+  </Heading>
+)
+
+interface ModalHeaderProps {
+  children: React.ReactNode
+}
+export const ModalHeader = ({ children, ...props }: ModalHeaderProps) => (
+  <Header level={2} size="medium" {...props}>
+    {children}
+  </Header>
+)

--- a/src/app/components/MnemonicValidation/index.tsx
+++ b/src/app/components/MnemonicValidation/index.tsx
@@ -1,8 +1,9 @@
 import { MnemonicGrid } from 'app/components/MnemonicGrid'
 import { validateMnemonic } from 'bip39'
-import { Grid, Box, Form, Heading, Paragraph, FormField, TextArea, Button, ResponsiveContext } from 'grommet'
+import { Grid, Box, Form, Paragraph, FormField, TextArea, Button, ResponsiveContext } from 'grommet'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { Header } from 'app/components/Header'
 
 interface Props {
   /** Called once the mnemonic is confirmed */
@@ -39,55 +40,53 @@ export function MnemonicValidation(props: Props) {
       round="5px"
       border={{ color: 'background-front-border', size: '1px' }}
     >
-      <Grid gap="small" pad="small" columns={size === 'small' ? '100%' : ['1fr', '1fr']}>
-        <Box margin={{ left: 'small', vertical: 'small', right: 'large' }}>
-          <Form>
-            <Heading margin="0">{t('openWallet.mnemonic.header', 'Enter your keyphrase')}</Heading>
-            <Paragraph>
-              {t(
-                'openWallet.mnemonic.instruction',
-                'Enter all your keyphrase words below separated by spaces. Most keyphrases are made of either 24 or 12 words.',
-              )}
-            </Paragraph>
-            <Box border={false}>
-              <FormField
-                htmlFor="mnemonic"
-                error={
-                  mnemonicIsValid === false
-                    ? t(
-                        'openWallet.mnemonic.error',
-                        'Invalid keyphrase. Please make sure to input the words in the right order, all lowercase.',
-                      )
-                    : ''
-                }
-              >
-                <Box border={false}>
-                  <TextArea
-                    id="mnemonic"
-                    data-testid="mnemonic"
-                    placeholder={t('openWallet.mnemonic.enterPhraseHere', 'Enter your keyphrase here')}
-                    size="medium"
-                    rows={5}
-                    value={rawMnemonic}
-                    onChange={onChange}
-                    fill
-                  />
-                </Box>
-              </FormField>
-            </Box>
-            <Box direction="row" gap="small" margin={{ top: 'medium' }}>
-              <Button
-                type="submit"
-                label={t('openWallet.mnemonic.import', 'Import my wallet')}
-                primary
-                onClick={onSubmit}
-              />
-              {props.abortHandler && (
-                <Button label={t('common.cancel', 'Cancel')} secondary onClick={props.abortHandler} />
-              )}
-            </Box>
-          </Form>
-        </Box>
+      <Grid gap="small" pad="none" columns={size === 'small' ? '100%' : ['1fr', '1fr']}>
+        <Form>
+          <Header>{t('openWallet.mnemonic.header', 'Enter your keyphrase')}</Header>
+          <Paragraph>
+            {t(
+              'openWallet.mnemonic.instruction',
+              'Enter all your keyphrase words below separated by spaces. Most keyphrases are made of either 24 or 12 words.',
+            )}
+          </Paragraph>
+          <Box border={false}>
+            <FormField
+              htmlFor="mnemonic"
+              error={
+                mnemonicIsValid === false
+                  ? t(
+                      'openWallet.mnemonic.error',
+                      'Invalid keyphrase. Please make sure to input the words in the right order, all lowercase.',
+                    )
+                  : ''
+              }
+            >
+              <Box border={false}>
+                <TextArea
+                  id="mnemonic"
+                  data-testid="mnemonic"
+                  placeholder={t('openWallet.mnemonic.enterPhraseHere', 'Enter your keyphrase here')}
+                  size="medium"
+                  rows={5}
+                  value={rawMnemonic}
+                  onChange={onChange}
+                  fill
+                />
+              </Box>
+            </FormField>
+          </Box>
+          <Box direction="row" gap="small" margin={{ top: 'medium' }}>
+            <Button
+              type="submit"
+              label={t('openWallet.mnemonic.import', 'Import my wallet')}
+              primary
+              onClick={onSubmit}
+            />
+            {props.abortHandler && (
+              <Button label={t('common.cancel', 'Cancel')} secondary onClick={props.abortHandler} />
+            )}
+          </Box>
+        </Form>
         <Box background="background-contrast">
           <MnemonicGrid mnemonic={mnemonic.split(' ')} />
         </Box>

--- a/src/app/components/Modal/index.tsx
+++ b/src/app/components/Modal/index.tsx
@@ -39,7 +39,7 @@ const ModalContainer = ({ modal, closeModal }: ModalContainerProps) => {
       <Box margin="medium">
         <ModalHeader>{modal.title}</ModalHeader>
         <Paragraph fill>{modal.description}</Paragraph>
-        <Box direction="row" gap="small" alignSelf="end" pad={{ top: 'large' }}>
+        <Box direction="row" gap="small" justify="between" pad={{ top: 'large' }}>
           <Button
             label={t('common.cancel', 'Cancel')}
             onClick={closeModal}

--- a/src/app/components/Modal/index.tsx
+++ b/src/app/components/Modal/index.tsx
@@ -1,7 +1,8 @@
 import { createContext, useCallback, useContext, useState } from 'react'
-import { Box, Button, Layer, Heading, Paragraph } from 'grommet'
+import { Box, Button, Layer, Paragraph } from 'grommet'
 import { useTranslation } from 'react-i18next'
 import { Alert, Checkmark, Close } from 'grommet-icons'
+import { ModalHeader } from 'app/components/Header'
 
 interface Modal {
   title: string
@@ -36,7 +37,7 @@ const ModalContainer = ({ modal, closeModal }: ModalContainerProps) => {
   return (
     <Layer modal onEsc={closeModal} onClickOutside={closeModal} background="background-front">
       <Box margin="medium">
-        <Heading size="small">{modal.title}</Heading>
+        <ModalHeader>{modal.title}</ModalHeader>
         <Paragraph fill>{modal.description}</Paragraph>
         <Box direction="row" gap="small" alignSelf="end" pad={{ top: 'large' }}>
           <Button

--- a/src/app/components/Toolbar/Features/AccountSelector/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Toolbar/Features/AccountSelector/__tests__/__snapshots__/index.test.tsx.snap
@@ -15,8 +15,6 @@ exports[`<AccountSelector  /> should match snapshot 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   width: auto;
-  padding-top: 12px;
-  padding-bottom: 12px;
 }
 
 .c7 {
@@ -233,11 +231,10 @@ exports[`<AccountSelector  /> should match snapshot 1`] = `
 }
 
 .c6 {
-  margin-top: 12px;
-  margin-bottom: 12px;
-  font-size: 1;
-  line-height: normal;
-  max-width: 1200px;
+  margin-top: 0px;
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
   font-weight: 600;
 }
 
@@ -330,13 +327,6 @@ exports[`<AccountSelector  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c7 {
     padding-top: 12px;
     padding-bottom: 12px;
@@ -388,8 +378,15 @@ exports[`<AccountSelector  /> should match snapshot 1`] = `
 
 @media only screen and (max-width:768px) {
   .c6 {
-    margin-top: 6px;
-    margin-bottom: 6px;
+    margin-top: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
   }
 }
 
@@ -453,12 +450,11 @@ exports[`<AccountSelector  /> should match snapshot 1`] = `
             <div
               class="c5"
             >
-              <h1
+              <h2
                 class="c6"
-                size="1"
               >
                 toolbar.wallets.switchOtherWallet
-              </h1>
+              </h2>
               <div
                 class="c7"
               >

--- a/src/app/components/Toolbar/Features/AccountSelector/index.tsx
+++ b/src/app/components/Toolbar/Features/AccountSelector/index.tsx
@@ -7,10 +7,11 @@ import { AmountFormatter } from 'app/components/AmountFormatter'
 import { PrettyAddress } from 'app/components/PrettyAddress'
 import { ResponsiveLayer } from 'app/components/ResponsiveLayer'
 import { ShortAddress } from 'app/components/ShortAddress'
+import { ModalHeader } from 'app/components/Header'
 import { walletActions } from 'app/state/wallet'
 import { selectAddress, selectWallets } from 'app/state/wallet/selectors'
 import { WalletType } from 'app/state/wallet/types'
-import { Box, Button, CheckBox, Heading, ResponsiveContext, Text } from 'grommet'
+import { Box, Button, CheckBox, ResponsiveContext, Text } from 'grommet'
 import React, { memo, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -118,10 +119,8 @@ export const AccountSelector = memo((props: Props) => {
       background="background-front"
       modal
     >
-      <Box pad={{ vertical: 'small' }} margin="medium" width={size === 'small' ? 'auto' : '700px'}>
-        <Heading size="1" margin={{ vertical: 'small' }}>
-          {t('toolbar.wallets.switchOtherWallet', 'Switch to another account')}
-        </Heading>
+      <Box margin="medium" width={size === 'small' ? 'auto' : '700px'}>
+        <ModalHeader>{t('toolbar.wallets.switchOtherWallet', 'Switch to another account')}</ModalHeader>
         <Box
           gap="small"
           pad={{ vertical: 'medium', right: 'small' }}

--- a/src/app/components/TransactionModal/index.tsx
+++ b/src/app/components/TransactionModal/index.tsx
@@ -1,10 +1,11 @@
 import { AlertBox } from 'app/components/AlertBox'
+import { ModalHeader } from 'app/components/Header'
 import { selectChainContext } from 'app/state/network/selectors'
 import { transactionActions } from 'app/state/transaction'
 import { selectTransaction } from 'app/state/transaction/selectors'
 import { TransactionStep } from 'app/state/transaction/types'
 import { selectAddress, selectBalance } from 'app/state/wallet/selectors'
-import { Box, Button, Heading, Spinner, Text } from 'grommet'
+import { Box, Button, Spinner, Text } from 'grommet'
 import { Checkmark, Close } from 'grommet-icons'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -49,9 +50,7 @@ export function TransactionModal() {
     <ResponsiveLayer modal position="center" background="background-front">
       <Box pad="medium" gap="medium" width="800px">
         <Box>
-          <Heading level="2" margin="none">
-            {t('transaction.step.preview', 'Preview transaction')}
-          </Heading>
+          <ModalHeader>{t('transaction.step.preview', 'Preview transaction')}</ModalHeader>
           <Box margin={{ vertical: 'small' }}>
             <AlertBox color="status-warning">
               {t(

--- a/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -857,6 +857,12 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   }
 }
 
+@media only screen and (max-width:768px) {
+  .c16 {
+    padding: 6px;
+  }
+}
+
 <div
   class="c0"
   style="min-height: 100vh;"

--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -48,6 +48,10 @@ const StyledNavItem = styled(NavLink)`
   &.active {
     background-color: ${({ theme }) => normalizeColor('background-back', theme)};
   }
+
+  @media only screen and (max-width: ${({ theme }) => `${theme.global?.breakpoints?.small?.value}px`}) {
+    padding: ${({ theme }) => theme.global?.edgeSize?.xsmall};
+  }
 `
 
 interface NavItemProps {

--- a/src/app/pages/CreateWalletPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/CreateWalletPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -121,10 +121,7 @@ exports[`<CreateWalletPage  /> should match snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 12px;
-  padding-right: 12px;
+  padding: 24px;
   border-radius: 5px;
 }
 
@@ -466,7 +463,7 @@ exports[`<CreateWalletPage  /> should match snapshot 1`] = `
 }
 
 .c15 {
-  margin: 0;
+  margin-top: 0px;
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
@@ -566,20 +563,7 @@ exports[`<CreateWalletPage  /> should match snapshot 1`] = `
 
 @media only screen and (max-width:768px) {
   .c14 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c14 {
-    padding-left: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c14 {
-    padding-right: 6px;
+    padding: 12px;
   }
 }
 
@@ -661,7 +645,7 @@ exports[`<CreateWalletPage  /> should match snapshot 1`] = `
 
 @media only screen and (max-width:768px) {
   .c15 {
-    margin: 0;
+    margin-top: 0px;
   }
 }
 
@@ -1447,11 +1431,11 @@ exports[`<CreateWalletPage  /> should match snapshot 1`] = `
     <div
       class="c14"
     >
-      <h2
+      <h1
         class="c15"
       >
         createWallet.thisIsYourPhrase
-      </h2>
+      </h1>
       <div
         class="c16"
       >

--- a/src/app/pages/CreateWalletPage/index.tsx
+++ b/src/app/pages/CreateWalletPage/index.tsx
@@ -9,12 +9,13 @@ import { MnemonicValidation } from 'app/components/MnemonicValidation'
 import { NoTranslate } from 'app/components/NoTranslate'
 import { ResponsiveLayer } from 'app/components/ResponsiveLayer'
 import { importAccountsActions } from 'app/state/importaccounts'
-import { Box, Button, CheckBox, Grid, Heading, Layer, ResponsiveContext, Text } from 'grommet'
+import { Box, Button, CheckBox, Grid, Layer, ResponsiveContext, Text } from 'grommet'
 import { Refresh } from 'grommet-icons'
 import * as React from 'react'
 import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
+import { Header } from 'app/components/Header'
 import { ImportAccountsSelectionModal } from 'app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal'
 import { selectShowAccountsSelectionModal } from 'app/state/importaccounts/selectors'
 import { createWalletActions } from './slice'
@@ -117,14 +118,8 @@ export function CreateWalletPage(props: CreateWalletProps) {
             </Box>
           </Box>
         </Box>
-        <Box
-          pad={{ left: 'small', vertical: 'small', right: 'small' }}
-          background="background-front"
-          round="5px"
-        >
-          <Heading margin="0" level="2">
-            {t('createWallet.thisIsYourPhrase', 'This is your mnemonic')}
-          </Heading>
+        <Box pad="medium" background="background-front" round="5px">
+          <Header>{t('createWallet.thisIsYourPhrase', 'This is your mnemonic')}</Header>
           <Box width="100%" justify="evenly" margin={{ vertical: 'small' }}>
             <Text margin="0">
               <Trans

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -1,8 +1,9 @@
-import { Box, Button, Grid, Heading, Paragraph, ResponsiveContext } from 'grommet'
+import { Box, Button, Grid, Paragraph, ResponsiveContext } from 'grommet'
 import { Add, Unlock } from 'grommet-icons'
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { NavLink } from 'react-router-dom'
+import { Header } from 'app/components/Header'
 
 export function HomePage() {
   const size = useContext(ResponsiveContext)
@@ -16,7 +17,7 @@ export function HomePage() {
           background="background-front"
           pad="large"
         >
-          <Heading size="1">{t('home.existing.header', 'Access existing wallet')}</Heading>
+          <Header>{t('home.existing.header', 'Access existing wallet')}</Header>
           <Paragraph>
             {t(
               'home.existing.description',
@@ -40,7 +41,7 @@ export function HomePage() {
           background="background-front"
           pad="large"
         >
-          <Heading size="1">{t('home.create.header', 'Create new wallet')}</Heading>
+          <Header>{t('home.create.header', 'Create new wallet')}</Header>
           <Paragraph>
             {t(
               'home.create.description',

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/__tests__/__snapshots__/index.test.tsx.snap
@@ -106,10 +106,10 @@ exports[`<FromLedger /> should render component 1`] = `
 }
 
 .c1 {
-  margin-top: 0;
-  font-size: 50px;
-  line-height: 56px;
-  max-width: 1200px;
+  margin-top: 0px;
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
   font-weight: 600;
 }
 
@@ -147,15 +147,15 @@ exports[`<FromLedger /> should render component 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    margin-top: 0;
+    margin-top: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c1 {
-    font-size: 34px;
-    line-height: 40px;
-    max-width: 816px;
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
   }
 }
 

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { ImportAccountsSelectionModal } from 'app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal'
 import { selectShowAccountsSelectionModal } from 'app/state/importaccounts/selectors'
+import { Header } from 'app/components/Header'
 
 export function FromLedger() {
   const { t } = useTranslation()
@@ -19,7 +20,7 @@ export function FromLedger() {
       round="5px"
       border={{ color: 'background-front-border', size: '1px' }}
     >
-      <Heading margin={{ top: '0' }}>{t('openWallet.ledger.header', 'Open from Ledger device')}</Heading>
+      <Header>{t('openWallet.ledger.header', 'Open from Ledger device')}</Header>
 
       <Heading level="3" margin="0">
         {t('ledger.instructionSteps.header', 'Steps:')}

--- a/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/__snapshots__/index.test.tsx.snap
@@ -21,17 +21,13 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   border-radius: 5px;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin-top: 12px;
-  margin-bottom: 12px;
-  margin-left: 12px;
-  margin-right: 48px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -46,6 +42,7 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  margin-bottom: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -60,21 +57,6 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -83,7 +65,7 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -98,7 +80,7 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   flex-direction: row;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -113,7 +95,7 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -131,7 +113,7 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   padding: 6px;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -146,12 +128,12 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   padding-right: 12px;
 }
 
-.c16 {
+.c15 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -180,56 +162,56 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   font-weight: bold;
 }
 
-.c11:hover {
+.c10:hover {
   box-shadow: 0px 0px 0px 2px #0092f6;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  margin: 0;
-  font-size: 50px;
-  line-height: 56px;
-  max-width: 1200px;
+.c3 {
+  margin-top: 0px;
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
   font-weight: 600;
 }
 
-.c13 {
+.c12 {
   display: grid;
   box-sizing: border-box;
   grid-template-columns: repeat( auto-fill,minmax(14ch,1fr) );
@@ -240,7 +222,7 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   box-sizing: border-box;
   grid-template-columns: repeat( auto-fill,minmax(100%,1fr) );
   grid-gap: 12px 12px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c0 {
@@ -256,13 +238,13 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
+.c4 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
 }
 
-.c9 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -281,49 +263,49 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
   height: 100%;
 }
 
-.c9:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
@@ -346,77 +328,58 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
-    margin-top: 6px;
+  .c6 {
     margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    margin-left: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    margin-right: 24px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c7 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     margin-top: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c13 {
     margin: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c13 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c13 {
     padding: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
+  .c14 {
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
-    margin: 0;
+  .c3 {
+    margin-top: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
-    font-size: 34px;
-    line-height: 40px;
-    max-width: 816px;
+  .c3 {
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
   }
 }
 
@@ -426,7 +389,7 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -440,74 +403,70 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <div
-        class="c3"
-      >
-        <form>
-          <h1
-            class="c4"
-          >
-            openWallet.mnemonic.header
-          </h1>
-          <p
-            class="c5"
-          >
-            openWallet.mnemonic.instruction
-          </p>
+      <form>
+        <h1
+          class="c3"
+        >
+          openWallet.mnemonic.header
+        </h1>
+        <p
+          class="c4"
+        >
+          openWallet.mnemonic.instruction
+        </p>
+        <div
+          class="c5"
+        >
           <div
-            class="c6"
+            class="c6 "
           >
             <div
               class="c7 "
             >
               <div
-                class="c8 "
+                class="c5"
               >
-                <div
-                  class="c6"
-                >
-                  <textarea
-                    class="c9"
-                    data-testid="mnemonic"
-                    id="mnemonic"
-                    placeholder="openWallet.mnemonic.enterPhraseHere"
-                    rows="5"
-                  />
-                </div>
+                <textarea
+                  class="c8"
+                  data-testid="mnemonic"
+                  id="mnemonic"
+                  placeholder="openWallet.mnemonic.enterPhraseHere"
+                  rows="5"
+                />
               </div>
             </div>
           </div>
-          <div
+        </div>
+        <div
+          class="c9"
+        >
+          <button
             class="c10"
+            type="submit"
           >
-            <button
-              class="c11"
-              type="submit"
-            >
-              openWallet.mnemonic.import
-            </button>
-          </div>
-        </form>
-      </div>
+            openWallet.mnemonic.import
+          </button>
+        </div>
+      </form>
       <div
-        class="c12"
+        class="c11"
       >
         <span
           class="notranslate"
           translate="no"
         >
           <div
-            class="c13"
+            class="c12"
             data-testid="mnemonic-grid"
           >
             <div
-              class="c14"
+              class="c13"
             >
               <div
-                class="c15"
+                class="c14"
               >
                 <span
-                  class="c16"
+                  class="c15"
                   style="user-select: none;"
                 >
                   1
@@ -515,7 +474,7 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
                 </span>
               </div>
               <div
-                class="c6"
+                class="c5"
               >
                 <span
                   class="notranslate"

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -266,10 +266,10 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
 }
 
 .c2 {
-  margin: 0;
-  font-size: 50px;
-  line-height: 56px;
-  max-width: 1200px;
+  margin-top: 0px;
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
   font-weight: 600;
 }
 
@@ -412,15 +412,15 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
 
 @media only screen and (max-width:768px) {
   .c2 {
-    margin: 0;
+    margin-top: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    font-size: 34px;
-    line-height: 40px;
-    max-width: 816px;
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
   }
 }
 

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  width: 1152px;
+  width: auto;
   border-radius: 12px;
 }
 

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
@@ -64,7 +64,7 @@ export function FromPrivateKey(props: Props) {
           error={privateKeyIsValid ? false : t('openWallet.privateKey.error', 'Invalid private key')}
           showTip={t('openWallet.privateKey.showPrivateKey', 'Show private key')}
           hideTip={t('openWallet.privateKey.hidePrivateKey', 'Hide private key')}
-          width="xlarge"
+          width="auto"
         />
 
         <Box pad={{ vertical: 'medium' }}>

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
@@ -1,11 +1,12 @@
 import { walletActions } from 'app/state/wallet'
-import { Box, Form, Heading, Paragraph, Button } from 'grommet'
+import { Box, Form, Paragraph, Button } from 'grommet'
 import * as React from 'react'
 import { useDispatch } from 'react-redux'
 import { OasisKey } from 'app/lib/key'
 import { base64ToUint, uint2hex } from 'app/lib/helpers'
 import { useTranslation } from 'react-i18next'
 import { PasswordField } from 'app/components/PasswordField'
+import { Header } from 'app/components/Header'
 
 interface Props {}
 
@@ -47,7 +48,7 @@ export function FromPrivateKey(props: Props) {
       border={{ color: 'background-front-border', size: '1px' }}
     >
       <Form>
-        <Heading margin="0">{t('openWallet.privateKey.header', 'Enter your private key')}</Heading>
+        <Header>{t('openWallet.privateKey.header', 'Enter your private key')}</Header>
         <Paragraph>
           <label htmlFor="privatekey">
             {t('openWallet.privateKey.instruction', 'Enter your private key in Base64 format.')}

--- a/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/__tests__/__snapshots__/index.test.tsx.snap
@@ -24,14 +24,15 @@ exports[`<ImportAccountsSelectionModal  /> should match snapshot 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  -webkit-align-self: flex-end;
-  -ms-flex-item-align: end;
-  align-self: flex-end;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-top: 48px;
 }
 

--- a/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/__tests__/__snapshots__/index.test.tsx.snap
@@ -183,10 +183,9 @@ exports[`<ImportAccountsSelectionModal  /> should match snapshot 1`] = `
 
 .c6 {
   margin-top: 0px;
-  margin-bottom: 24px;
-  font-size: 1;
-  line-height: normal;
-  max-width: 1200px;
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
   font-weight: 600;
 }
 
@@ -298,7 +297,9 @@ exports[`<ImportAccountsSelectionModal  /> should match snapshot 1`] = `
 
 @media only screen and (max-width:768px) {
   .c6 {
-    margin-bottom: 12px;
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
   }
 }
 
@@ -362,12 +363,11 @@ exports[`<ImportAccountsSelectionModal  /> should match snapshot 1`] = `
             <div
               class="c5"
             >
-              <h1
+              <h2
                 class="c6"
-                size="1"
               >
                 openWallet.importAccounts.selectWallets
-              </h1>
+              </h2>
               <div
                 class="c7"
               >

--- a/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { AlertBox } from 'app/components/AlertBox'
 import { ErrorFormatter } from 'app/components/ErrorFormatter'
+import { ModalHeader } from 'app/components/Header'
 import { ImportAccountsStepFormatter } from 'app/components/ImportAccountsStepFormatter'
 import { ResponsiveLayer } from 'app/components/ResponsiveLayer'
 import { Account } from 'app/components/Toolbar/Features/AccountSelector'
@@ -10,7 +11,7 @@ import { importAccountsActions } from 'app/state/importaccounts'
 import { selectImportAccounts, selectSelectedAccounts } from 'app/state/importaccounts/selectors'
 import { ImportAccountsListAccount, ImportAccountsStep } from 'app/state/importaccounts/types'
 import { walletActions } from 'app/state/wallet'
-import { Box, Button, Heading, Spinner, Text } from 'grommet'
+import { Box, Button, Spinner, Text } from 'grommet'
 
 interface ImportAccountsSelectorSelectorProps {
   accounts: ImportAccountsListAccount[]
@@ -73,9 +74,7 @@ export function ImportAccountsSelectionModal(props: ImportAccountsSelectionModal
   return (
     <ResponsiveLayer onEsc={props.abort} onClickOutside={props.abort} modal background="background-front">
       <Box width="750px" pad="medium">
-        <Heading size="1" margin={{ bottom: 'medium', top: 'none' }}>
-          {t('openWallet.importAccounts.selectWallets', 'Select accounts to open')}
-        </Heading>
+        <ModalHeader>{t('openWallet.importAccounts.selectWallets', 'Select accounts to open')}</ModalHeader>
         {importAccounts.step && importAccounts.step !== ImportAccountsStep.Done && (
           <Box direction="row" gap="medium" alignContent="center">
             <Spinner size="medium" />

--- a/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/index.tsx
@@ -95,7 +95,7 @@ export function ImportAccountsSelectionModal(props: ImportAccountsSelectionModal
             <ErrorFormatter code={error.code} message={error.message} />
           </AlertBox>
         )}
-        <Box direction="row" gap="small" alignSelf="end" pad={{ top: 'large' }}>
+        <Box direction="row" gap="small" justify="between" pad={{ top: 'large' }}>
           <Button
             secondary
             label={t('common.cancel', 'Cancel')}

--- a/src/app/pages/OpenWalletPage/index.tsx
+++ b/src/app/pages/OpenWalletPage/index.tsx
@@ -3,12 +3,12 @@
  * OpenWalletPage
  *
  */
-import { Anchor, Box, Button, Heading } from 'grommet'
+import { Anchor, Box, Button } from 'grommet'
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { NavLink, Route, Routes } from 'react-router-dom'
+import { Header } from 'app/components/Header'
 import { FromLedger } from './Features/FromLedger'
-
 import { FromMnemonic } from './Features/FromMnemonic'
 import { FromPrivateKey } from './Features/FromPrivateKey'
 
@@ -23,7 +23,7 @@ export function SelectOpenMethod() {
       margin="small"
       pad="medium"
     >
-      <Heading level="3">{t('openWallet.header', 'How do you want to open your wallet?')}</Heading>
+      <Header>{t('openWallet.header', 'How do you want to open your wallet?')}</Header>
 
       <Box direction="row-responsive" justify="start" margin={{ top: 'medium' }} gap="medium">
         <NavLink to="mnemonic">

--- a/src/app/pages/StakingPage/Features/DelegationList/ActiveDelegationList.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/ActiveDelegationList.tsx
@@ -1,5 +1,6 @@
+import { Header } from 'app/components/Header'
 import { selectActiveDelegations } from 'app/state/staking/selectors'
-import { Box, Heading } from 'grommet'
+import { Box } from 'grommet'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -11,9 +12,7 @@ export const ActiveDelegationList = () => {
   const delegations = useSelector(selectActiveDelegations)
   return (
     <Box pad="medium" background="background-front">
-      <Heading margin="none" size="small">
-        {t('delegations.activeDelegations', 'Active delegations')}
-      </Heading>
+      <Header>{t('delegations.activeDelegations', 'Active delegations')}</Header>
       <DelegationList type="active" delegations={delegations ?? []} />
     </Box>
   )

--- a/src/app/pages/StakingPage/Features/DelegationList/DebondingDelegationList.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/DebondingDelegationList.tsx
@@ -1,5 +1,6 @@
+import { Header } from 'app/components/Header'
 import { selectDebondingDelegations } from 'app/state/staking/selectors'
-import { Box, Heading } from 'grommet'
+import { Box } from 'grommet'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -11,9 +12,7 @@ export const DebondingDelegationList = () => {
   const delegations = useSelector(selectDebondingDelegations)
   return (
     <Box pad="medium" background="background-front">
-      <Heading margin="none" size="small">
-        {t('delegations.debondingDelegations', 'Debonding delegations')}
-      </Heading>
+      <Header>{t('delegations.debondingDelegations', 'Debonding delegations')}</Header>
       <DelegationList type="debonding" delegations={delegations ?? []} />
     </Box>
   )

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
 }
 
 .c1 {
-  margin: 0px;
+  margin-top: 0px;
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
@@ -364,7 +364,7 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    margin: 0px;
+    margin-top: 0px;
   }
 }
 

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<DebondingDelegationList  /> should match snapshot 1`] = `
 }
 
 .c1 {
-  margin: 0px;
+  margin-top: 0px;
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
@@ -371,7 +371,7 @@ exports[`<DebondingDelegationList  /> should match snapshot 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    margin: 0px;
+    margin-top: 0px;
   }
 }
 

--- a/src/app/pages/StakingPage/Features/ValidatorList/ValidatorInformations.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/ValidatorInformations.tsx
@@ -1,10 +1,11 @@
 import { AddressBox } from 'app/components/AddressBox'
+import { Header } from 'app/components/Header'
 import { AmountFormatter } from 'app/components/AmountFormatter'
 import { ResponsiveGridRow } from 'app/components/ResponsiveGridRow'
 import { formatCommissionPercent } from 'app/lib/helpers'
 import { ValidatorStatus } from 'app/pages/StakingPage/Features/ValidatorList/ValidatorStatus'
 import { Validator, ValidatorDetails } from 'app/state/staking/types'
-import { Box, Grid, Heading, ResponsiveContext, Spinner } from 'grommet'
+import { Box, Grid, ResponsiveContext, Spinner } from 'grommet'
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -23,11 +24,11 @@ export const ValidatorInformations = (props: ValidatorProps) => {
 
   return (
     <>
-      <Box direction="row-responsive" gap={size !== 'small' ? 'medium' : 'none'}>
+      <Box align="center" direction="row-responsive" gap={size !== 'small' ? 'medium' : 'none'}>
         {validator.name && (
-          <Heading size="small" margin={{ bottom: 'none', top: 'none' }} data-testid="validator-item-name">
+          <Header level="2" margin={{ bottom: 'none', top: 'none' }} data-testid="validator-item-name">
             {validator.name}
-          </Heading>
+          </Header>
         )}
         {validator.media && (
           <Box direction="row">

--- a/src/app/pages/StakingPage/Features/ValidatorList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/ValidatorList/__tests__/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,15 @@ exports[`<ValidatorList  /> empty should match snapshot 1`] = `
   padding: 24px;
 }
 
-.c3 {
+.c1 {
+  margin-top: 0px;
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
+  font-weight: 600;
+}
+
+.c4 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -35,7 +43,7 @@ exports[`<ValidatorList  /> empty should match snapshot 1`] = `
   background-color: false;
 }
 
-.c1 {
+.c2 {
   position: relative;
   width: 100%;
   border-radius: inherit;
@@ -44,13 +52,13 @@ exports[`<ValidatorList  /> empty should match snapshot 1`] = `
   min-height: 0;
 }
 
-.c2 {
+.c3 {
   position: relative;
   width: 100%;
   display: table;
 }
 
-.c4 {
+.c5 {
   box-sizing: border-box;
   width: 100%;
   height: 100%;
@@ -76,22 +84,40 @@ exports[`<ValidatorList  /> empty should match snapshot 1`] = `
   }
 }
 
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin-top: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
+  }
+}
+
 <div
   class="c0"
 >
-  common.validators
-  <div
+  <h1
     class="c1"
   >
+    common.validators
+  </h1>
+  <div
+    class="c2"
+  >
     <div
-      class="c2"
+      class="c3"
     >
       <div
-        class="c3 rdt_Table"
+        class="c4 rdt_Table"
         role="table"
       >
         <div
-          class="c4"
+          class="c5"
         >
           <div
             style="padding: 24px;"
@@ -106,7 +132,7 @@ exports[`<ValidatorList  /> empty should match snapshot 1`] = `
 `;
 
 exports[`<ValidatorList  /> list should match snapshot 1`] = `
-.c10 {
+.c11 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -117,28 +143,28 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c11 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c11 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],.c10 *[STROKE*="#"] {
+.c11 *[stroke*="#"],.c11 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],.c10 *[FILL*="#"] {
+.c11 *[fill-rule],
+.c11 *[FILL-RULE],
+.c11 *[fill*="#"],.c11 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-.c17 {
+.c18 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -149,28 +175,28 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   stroke: #00C781;
 }
 
-.c17 g {
+.c18 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c17 *:not([stroke])[fill="none"] {
+.c18 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c17 *[stroke*="#"],.c17 *[STROKE*="#"] {
+.c18 *[stroke*="#"],.c18 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c17 *[fill-rule],
-.c17 *[FILL-RULE],
-.c17 *[fill*="#"],.c17 *[FILL*="#"] {
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],.c18 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-.c19 {
+.c20 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -181,23 +207,23 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   stroke: #FF4040;
 }
 
-.c19 g {
+.c20 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c19 *:not([stroke])[fill="none"] {
+.c20 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c19 *[stroke*="#"],.c19 *[STROKE*="#"] {
+.c20 *[stroke*="#"],.c20 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c19 *[fill-rule],
-.c19 *[FILL-RULE],
-.c19 *[fill*="#"],.c19 *[FILL*="#"] {
+.c20 *[fill-rule],
+.c20 *[FILL-RULE],
+.c20 *[fill*="#"],.c20 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -219,13 +245,21 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   padding: 24px;
 }
 
-.c18 {
+.c19 {
   margin-left: 3px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c3 {
+.c1 {
+  margin-top: 0px;
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
+  font-weight: 600;
+}
+
+.c4 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -242,7 +276,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   background-color: false;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -250,7 +284,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   text-align: left;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -267,7 +301,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   border-bottom-style: solid;
 }
 
-.c6 {
+.c7 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -286,7 +320,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   padding-right: 16px;
 }
 
-.c15 {
+.c16 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -303,7 +337,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   word-break: break-word;
 }
 
-.c7 {
+.c8 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -320,22 +354,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   max-width: 34px;
 }
 
-.c8 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  max-width: 100%;
-  min-width: 100px;
-}
-
-.c11 {
+.c9 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -363,15 +382,30 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   flex-basis: 0;
   max-width: 100%;
   min-width: 100px;
+}
+
+.c13 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  max-width: 100%;
+  min-width: 100px;
   min-width: 110px;
   max-width: 110px;
 }
 
-.c16 {
+.c17 {
   font-weight: 400;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -391,13 +425,13 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   min-height: 48px;
 }
 
-.c14:not(:last-of-type) {
+.c15:not(:last-of-type) {
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-bottom-color: #AAAAAAaa;
 }
 
-.c14:hover {
+.c15:hover {
   color: false;
   background-color: #88888833;
   -webkit-transition-duration: 0.15s;
@@ -410,11 +444,11 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   outline-color: false;
 }
 
-.c14:hover {
+.c15:hover {
   cursor: pointer;
 }
 
-.c9 {
+.c10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -431,17 +465,17 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   user-select: none;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   color: false;
 }
 
-.c9:hover {
+.c10:hover {
   color: false;
 }
 
-.c9 span.__rdt_custom_sort_icon__ i,
-.c9 span.__rdt_custom_sort_icon__ svg {
+.c10 span.__rdt_custom_sort_icon__ i,
+.c10 span.__rdt_custom_sort_icon__ svg {
   opacity: 0;
   color: inherit;
   font-size: 18px !important;
@@ -459,23 +493,23 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   transition-property: transform;
 }
 
-.c9 span.__rdt_custom_sort_icon__.asc i,
-.c9 span.__rdt_custom_sort_icon__.asc svg {
+.c10 span.__rdt_custom_sort_icon__.asc i,
+.c10 span.__rdt_custom_sort_icon__.asc svg {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 
-.c9:hover {
+.c10:hover {
   cursor: pointer;
 }
 
-.c9:hover span,
-.c9:hover span.__rdt_custom_sort_icon__ * {
+.c10:hover span,
+.c10:hover span.__rdt_custom_sort_icon__ * {
   opacity: 1;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -485,7 +519,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c1 {
+.c2 {
   position: relative;
   width: 100%;
   border-radius: inherit;
@@ -494,7 +528,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   min-height: 0;
 }
 
-.c2 {
+.c3 {
   position: relative;
   width: 100%;
   display: table;
@@ -506,9 +540,17 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   }
 }
 
-@media screen and (max-width:599px) {
-  .c11 {
-    display: none;
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin-top: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
   }
 }
 
@@ -518,39 +560,49 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   }
 }
 
+@media screen and (max-width:599px) {
+  .c13 {
+    display: none;
+  }
+}
+
 <div
   class="c0"
 >
-  common.validators
-  <div
+  <h1
     class="c1"
   >
+    common.validators
+  </h1>
+  <div
+    class="c2"
+  >
     <div
-      class="c2"
+      class="c3"
     >
       <div
-        class="c3 rdt_Table"
+        class="c4 rdt_Table"
         role="table"
       >
         <div
-          class="c4 rdt_TableHead"
+          class="c5 rdt_TableHead"
           role="rowgroup"
         >
           <div
-            class="c5 rdt_TableHeadRow"
+            class="c6 rdt_TableHeadRow"
             role="row"
           >
             <div
-              class="c6 c7 rdt_TableCol"
+              class="c7 c8 rdt_TableCol"
             />
             <div
-              class="c6 c7 rdt_TableCol"
+              class="c7 c8 rdt_TableCol"
             />
             <div
-              class="c6 c8 rdt_TableCol"
+              class="c7 c9 rdt_TableCol"
             >
               <div
-                class="c9 rdt_TableCol_Sortable"
+                class="c10 rdt_TableCol_Sortable"
                 id="column-name"
                 role="columnheader"
                 tabindex="0"
@@ -563,7 +615,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 >
                   <svg
                     aria-label="Down"
-                    class="c10"
+                    class="c11"
                     viewBox="0 0 24 24"
                   >
                     <path
@@ -577,10 +629,10 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="c6 c11 rdt_TableCol"
+              class="c7 c12 rdt_TableCol"
             >
               <div
-                class="c9 rdt_TableCol_Sortable"
+                class="c10 rdt_TableCol_Sortable"
                 id="column-escrow"
                 role="columnheader"
                 tabindex="0"
@@ -593,7 +645,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 >
                   <svg
                     aria-label="Down"
-                    class="c10"
+                    class="c11"
                     viewBox="0 0 24 24"
                   >
                     <path
@@ -607,10 +659,10 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="c6 c12 rdt_TableCol"
+              class="c7 c13 rdt_TableCol"
             >
               <div
-                class="c9 rdt_TableCol_Sortable"
+                class="c10 rdt_TableCol_Sortable"
                 id="column-fee"
                 role="columnheader"
                 tabindex="0"
@@ -623,7 +675,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 >
                   <svg
                     aria-label="Down"
-                    class="c10"
+                    class="c11"
                     viewBox="0 0 24 24"
                   >
                     <path
@@ -639,30 +691,30 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
           </div>
         </div>
         <div
-          class="c13 rdt_TableBody"
+          class="c14 rdt_TableBody"
           offset="250px"
           role="rowgroup"
         >
           <div
-            class="c14 rdt_TableRow"
+            class="c15 rdt_TableRow"
             id="row-oasis1qpc4ze5zzq3aa5mu5ttu4ku4ctp5t6x0asemymfz"
             role="row"
           >
             <div
-              class="c15 c7 c16 rdt_TableCell"
+              class="c16 c8 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-icon-oasis1qpc4ze5zzq3aa5mu5ttu4ku4ctp5t6x0asemymfz"
               role="gridcell"
             />
             <div
-              class="c15 c7 c16 rdt_TableCell"
+              class="c16 c8 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-status-oasis1qpc4ze5zzq3aa5mu5ttu4ku4ctp5t6x0asemymfz"
               role="gridcell"
             >
               <svg
                 aria-label="Status is okay"
-                class="c17"
+                class="c18"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -674,7 +726,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               </svg>
             </div>
             <div
-              class="c15 c8 c16 rdt_TableCell"
+              class="c16 c9 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-name-oasis1qpc4ze5zzq3aa5mu5ttu4ku4ctp5t6x0asemymfz"
               role="gridcell"
@@ -682,7 +734,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               test-validator1
             </div>
             <div
-              class="c15 c11 c16 rdt_TableCell"
+              class="c16 c12 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-escrow-oasis1qpc4ze5zzq3aa5mu5ttu4ku4ctp5t6x0asemymfz"
               role="gridcell"
@@ -690,14 +742,14 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               <span>
                 0
                 <span
-                  class="c18"
+                  class="c19"
                 >
                   TEST
                 </span>
               </span>
             </div>
             <div
-              class="c15 c12 c16 rdt_TableCell"
+              class="c16 c13 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-fee-oasis1qpc4ze5zzq3aa5mu5ttu4ku4ctp5t6x0asemymfz"
               role="gridcell"
@@ -706,25 +758,25 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="c14 rdt_TableRow"
+            class="c15 rdt_TableRow"
             id="row-oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe"
             role="row"
           >
             <div
-              class="c15 c7 c16 rdt_TableCell"
+              class="c16 c8 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-icon-oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe"
               role="gridcell"
             />
             <div
-              class="c15 c7 c16 rdt_TableCell"
+              class="c16 c8 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-status-oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe"
               role="gridcell"
             >
               <svg
                 aria-label="Status is critical"
-                class="c19"
+                class="c20"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -736,7 +788,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               </svg>
             </div>
             <div
-              class="c15 c8 c16 rdt_TableCell"
+              class="c16 c9 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-name-oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe"
               role="gridcell"
@@ -744,7 +796,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               test-validator2
             </div>
             <div
-              class="c15 c11 c16 rdt_TableCell"
+              class="c16 c12 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-escrow-oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe"
               role="gridcell"
@@ -752,14 +804,14 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               <span>
                 0
                 <span
-                  class="c18"
+                  class="c19"
                 >
                   TEST
                 </span>
               </span>
             </div>
             <div
-              class="c15 c12 c16 rdt_TableCell"
+              class="c16 c13 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-fee-oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe"
               role="gridcell"
@@ -768,25 +820,25 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="c14 rdt_TableRow"
+            class="c15 rdt_TableRow"
             id="row-oasis1qrfe9n26nq3t6vc9hlu9gnupwf4rm6wr0uglh3r7"
             role="row"
           >
             <div
-              class="c15 c7 c16 rdt_TableCell"
+              class="c16 c8 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-icon-oasis1qrfe9n26nq3t6vc9hlu9gnupwf4rm6wr0uglh3r7"
               role="gridcell"
             />
             <div
-              class="c15 c7 c16 rdt_TableCell"
+              class="c16 c8 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-status-oasis1qrfe9n26nq3t6vc9hlu9gnupwf4rm6wr0uglh3r7"
               role="gridcell"
             >
               <svg
                 aria-label="Status is unknown"
-                class="c19"
+                class="c20"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -798,7 +850,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               </svg>
             </div>
             <div
-              class="c15 c8 c16 rdt_TableCell"
+              class="c16 c9 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-name-oasis1qrfe9n26nq3t6vc9hlu9gnupwf4rm6wr0uglh3r7"
               role="gridcell"
@@ -806,7 +858,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               test-validator3
             </div>
             <div
-              class="c15 c11 c16 rdt_TableCell"
+              class="c16 c12 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-escrow-oasis1qrfe9n26nq3t6vc9hlu9gnupwf4rm6wr0uglh3r7"
               role="gridcell"
@@ -814,14 +866,14 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
               <span>
                 0
                 <span
-                  class="c18"
+                  class="c19"
                 >
                   TEST
                 </span>
               </span>
             </div>
             <div
-              class="c15 c12 c16 rdt_TableCell"
+              class="c16 c13 c17 rdt_TableCell"
               data-tag="allowRowEvents"
               id="cell-fee-oasis1qrfe9n26nq3t6vc9hlu9gnupwf4rm6wr0uglh3r7"
               role="gridcell"

--- a/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
@@ -4,6 +4,7 @@
  *
  */
 import { AmountFormatter } from 'app/components/AmountFormatter'
+import { Header } from 'app/components/Header'
 import { ErrorFormatter } from 'app/components/ErrorFormatter'
 import { ShortAddress } from 'app/components/ShortAddress'
 import { ValidatorStatus } from 'app/pages/StakingPage/Features/ValidatorList/ValidatorStatus'
@@ -106,7 +107,7 @@ export const ValidatorList = memo((props: Props) => {
 
   return (
     <Box pad="medium" background="background-front">
-      {t('common.validators', 'Validators')}
+      <Header>{t('common.validators', 'Validators')}</Header>
       {updateValidatorsError && (
         <p>
           {t('account.validator.loadingError', "Couldn't load validators.")}{' '}


### PR DESCRIPTION
- new popup dimensions
- responsive headers, unify usage of main and modal headers. Headers were not responsive because they were using sanitize.css not Grommet rules because of wrong syntax like `<Heading size="1"> `
- fixes: unify Box paddings in main pages a little bit, change alignment of buttons in modal windows, AccountPage sub menu nav, PrivateKey input width

current ext
![Screenshot 2022-09-26 at 12 54 41](https://user-images.githubusercontent.com/891392/192261157-97627b1d-e7dd-4e92-ba1f-27d2c803c6a2.png)

updated
![Screenshot 2022-09-26 at 12 48 38](https://user-images.githubusercontent.com/891392/192261153-dabfd397-5227-4500-90e4-d4c467d870c1.png)

current desktop (just 1 sample, but most of current headers look differently)
![Screenshot 2022-09-26 at 13 05 09](https://user-images.githubusercontent.com/891392/192261213-61f9be47-cf56-4c79-9030-e83061659aef.png)

updated
![Screenshot 2022-09-26 at 13 05 13](https://user-images.githubusercontent.com/891392/192261210-945431f5-8207-47ea-b1d3-6d63e25a255a.png)
