### PR TITLE
Remove obsolete mnemonic field from account import state

### DIFF
--- a/src/app/state/importaccounts/types.ts
+++ b/src/app/state/importaccounts/types.ts
@@ -22,7 +22,6 @@ export enum ImportAccountsStep {
 export interface ImportAccountsState {
   accounts: ImportAccountsListAccount[]
   error?: ErrorPayload
-  mnemonic?: string
   showAccountsSelectionModal: boolean
   step?: ImportAccountsStep
 }


### PR DESCRIPTION
This is just a left-over field, which was unused;
there ware no security concern, since the data was not stored here anyway.