### PR TITLE
Restrict Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,9 @@
     "store": "./src/store",
     "vendors": "./src/vendors"
   },
+  "engines": {
+    "node": ">=14 <18"
+  },
   "targets": {
     "// see also .parcelrc and .terserrc": {},
     "web": {


### PR DESCRIPTION
... to exclude at least Node.js v18, since currently our cypress tests behave differently with that version