### PR TITLE
Refactor password field validation and restyle

### DIFF
--- a/src/app/components/PasswordField/__tests__/index.test.tsx
+++ b/src/app/components/PasswordField/__tests__/index.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Form, FormField, TextInput } from 'grommet'
+import * as React from 'react'
+import { PasswordField } from '..'
+
+interface FormValue {
+  name: string
+  privateKey: string
+}
+
+describe('<PasswordField />', () => {
+  it('with `name` and `validate`: validation error blocks submitting', async () => {
+    function Example(props: { onSubmit: (value: FormValue) => void }) {
+      return (
+        <Form<FormValue>
+          onSubmit={({ value }) => {
+            expect(value.privateKey.length).toBeGreaterThanOrEqual(5)
+            props.onSubmit(value)
+          }}
+        >
+          <FormField name="name">
+            <TextInput name="name" value="name" />
+          </FormField>
+          <PasswordField<FormValue>
+            inputElementId="privateKey"
+            name="privateKey"
+            label="privateKey"
+            autoComplete="current-password"
+            validate={(privateKey, form) => {
+              return privateKey.length < 5 ? 'invalid' : undefined
+            }}
+            showTip="show"
+            hideTip="hide"
+          />
+          <input type="submit" />
+        </Form>
+      )
+    }
+    const onSubmit = jest.fn()
+    render(<Example onSubmit={onSubmit}></Example>)
+
+    await userEvent.type(screen.getByLabelText('privateKey'), 'a {Enter}')
+    expect(await screen.findByText('invalid')).toBeInTheDocument()
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    await userEvent.type(screen.getByLabelText('privateKey'), 'privateKey{Enter}')
+    expect(screen.queryByText('invalid')).not.toBeInTheDocument()
+    expect(onSubmit).toHaveBeenLastCalledWith({ name: 'name', privateKey: 'a privateKey' })
+  })
+
+  it('with `value`, `onChange`, and `error`: validation error does NOT block submitting', async () => {
+    function Example(props: { onSubmit: (value: FormValue) => void }) {
+      const [privateKey, setPrivateKey] = React.useState('')
+      const [name, setName] = React.useState('name')
+      return (
+        <Form
+          onSubmit={() => {
+            // Error doesn't block onSubmit
+            // expect(privateKey.length).toBeGreaterThanOrEqual(5)
+            props.onSubmit({ name, privateKey })
+          }}
+        >
+          <FormField name="name">
+            <TextInput name="name" value={name} onChange={event => setName(event.target.value)} />
+          </FormField>
+          <PasswordField
+            inputElementId="privateKey"
+            name="privateKey"
+            label="privateKey"
+            autoComplete="off"
+            value={privateKey}
+            onChange={event => setPrivateKey(event.target.value)}
+            error={privateKey.length < 5 ? 'invalid' : undefined}
+            showTip="show"
+            hideTip="hide"
+          />
+          <input type="submit" />
+        </Form>
+      )
+    }
+    const onSubmit = jest.fn()
+    render(<Example onSubmit={onSubmit}></Example>)
+
+    await userEvent.type(screen.getByLabelText('privateKey'), 'a {Enter}')
+    expect(await screen.findByText('invalid')).toBeInTheDocument()
+    // Error doesn't block onSubmit
+    expect(onSubmit).toHaveBeenLastCalledWith({ name: 'name', privateKey: 'a ' })
+
+    await userEvent.type(screen.getByLabelText('privateKey'), 'privateKey{Enter}')
+    expect(screen.queryByText('invalid')).not.toBeInTheDocument()
+    expect(onSubmit).toHaveBeenLastCalledWith({ name: 'name', privateKey: 'a privateKey' })
+  })
+})

--- a/src/app/components/PasswordField/__tests__/type-only.test.tsx
+++ b/src/app/components/PasswordField/__tests__/type-only.test.tsx
@@ -1,0 +1,96 @@
+import { Form, FormField, TextInput } from 'grommet'
+import * as React from 'react'
+import { PasswordField } from '..'
+
+interface FormValue {
+  name: string
+  privateKey: string
+}
+describe('type-only test', () => {
+  describe('<PasswordField /> with `name`, `validate`, and `FormValue`', () => {
+    it('is strictly typed', () => {
+      expect(
+        <Form<FormValue>
+          onSubmit={({ value }) => {
+            // @ts-expect-error Detect incorrect type
+            expect(value.privateKey !== 5).toBeTruthy()
+            expect(value.privateKey !== '5').toBeTruthy()
+          }}
+        >
+          <FormField name="name">
+            <TextInput name="name" value="name" />
+          </FormField>
+          <PasswordField<FormValue>
+            inputElementId="privateKey"
+            name="privateKey"
+            label="privateKey"
+            // @ts-expect-error Detect incorrect value
+            autoComplete="password"
+            validate={(privateKey, form) => {
+              // @ts-expect-error Detect incorrect type
+              expect(privateKey !== 5).toBeTruthy()
+              expect(privateKey !== '5').toBeTruthy()
+
+              // @ts-expect-error Detect missing field
+              expect(form.privateKey2 !== '5').toBeTruthy()
+              // @ts-expect-error Detect incorrect type
+              expect(form.privateKey !== 5).toBeTruthy()
+              expect(form.privateKey !== '5').toBeTruthy()
+              expect(form.name !== '5').toBeTruthy()
+
+              return privateKey.length < 5 ? 'invalid' : undefined
+            }}
+            showTip="show"
+            hideTip="hide"
+          />
+          <PasswordField<FormValue>
+            inputElementId="privateKey3"
+            // @ts-expect-error Detect missing field
+            name="privateKey3"
+            autoComplete="current-password"
+            showTip="show"
+            hideTip="hide"
+          />
+          <input type="submit" />
+        </Form>,
+      ).toBeDefined()
+    })
+
+    it('less type-safe without `FormValue`', () => {
+      expect(
+        <Form
+          onSubmit={({ value }) => {
+            // @ts-expect-error Doesn't know about any fields
+            expect(value.privateKey !== '5').toBeTruthy()
+          }}
+        >
+          <FormField name="name">
+            <TextInput name="name" value="name" />
+          </FormField>
+          <PasswordField
+            inputElementId="privateKey"
+            name="privateKey"
+            label="privateKey"
+            autoComplete="off"
+            validate={(privateKey, form) => {
+              // @ts-expect-error Detect incorrect type
+              expect(privateKey !== 5).toBeTruthy()
+              expect(privateKey !== '5').toBeTruthy()
+
+              // @ts-expect-error Detect missing field
+              expect(form.privateKey2 !== '5').toBeTruthy()
+              expect(form.privateKey !== '5').toBeTruthy()
+              // @ts-expect-error Doesn't know about other fields
+              expect(form.name !== '5').toBeTruthy()
+
+              return privateKey.length < 5 ? 'invalid' : undefined
+            }}
+            showTip="show"
+            hideTip="hide"
+          />
+          <input type="submit" />
+        </Form>,
+      ).toBeDefined()
+    })
+  })
+})

--- a/src/app/components/PasswordField/index.tsx
+++ b/src/app/components/PasswordField/index.tsx
@@ -2,36 +2,45 @@ import { Box, FormField, Button, TextInput, Tip } from 'grommet'
 import { View, Hide } from 'grommet-icons'
 import * as React from 'react'
 
-interface Props {
-  placeholder: string
+interface Props<TFormValue> {
+  name: Extract<keyof TFormValue, string>
+  label?: string
+  placeholder?: string
   inputElementId: string
 
   autoComplete: 'on' | 'off' | 'new-password' | 'current-password'
-  value: string
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
-  error: string | false
+  value?: string
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  validate?: (password: string, form: TFormValue) => string | undefined
+  error?: string | false
+  required?: boolean
   showTip: string
   hideTip: string
 
   width: string
 }
 
-export function PasswordField(props: Props) {
+export function PasswordField<TFormValue = any>(props: Props<TFormValue>) {
   const [passwordIsVisible, setPasswordIsVisible] = React.useState(false)
 
   return (
     <FormField
+      name={props.name}
       htmlFor={props.inputElementId}
+      label={props.label}
+      validate={props.validate}
       error={props.error ? props.error : ''}
       width={props.width}
     >
       <Box direction="row" align="center">
         <TextInput
           id={props.inputElementId}
+          name={props.name}
           placeholder={props.placeholder}
           value={props.value}
           onChange={props.onChange}
           type={passwordIsVisible ? 'text' : 'password'}
+          required={props.required}
           autoComplete={props.autoComplete}
           plain
         />

--- a/src/app/components/PasswordField/index.tsx
+++ b/src/app/components/PasswordField/index.tsx
@@ -23,9 +23,6 @@ export function PasswordField(props: Props) {
     <FormField
       htmlFor={props.inputElementId}
       error={props.error ? props.error : ''}
-      border
-      contentProps={{ border: props.error ? 'bottom' : false }}
-      round="small"
       width={props.width}
     >
       <Box direction="row" align="center">

--- a/src/app/components/PasswordField/index.tsx
+++ b/src/app/components/PasswordField/index.tsx
@@ -17,7 +17,7 @@ interface Props<TFormValue> {
   showTip: string
   hideTip: string
 
-  width: string
+  width?: string
 }
 
 export function PasswordField<TFormValue = any>(props: Props<TFormValue>) {

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -61,14 +61,12 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   margin-bottom: 12px;
-  border: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   width: auto;
-  border-radius: 12px;
 }
 
 .c5 {
@@ -78,6 +76,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -387,14 +386,8 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
-    border: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    border-radius: 6px;
+  .c5 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -456,6 +456,7 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
                 autocomplete="off"
                 class="c8"
                 id="privatekey"
+                name="privateKey"
                 placeholder="openWallet.privateKey.enterPrivateKeyHere"
                 type="password"
                 value=""

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/index.tsx
@@ -21,22 +21,25 @@ const parseKey = (key: string) => {
   return OasisKey.fromPrivateKey(key_bytes)
 }
 
+const isValidKey = (privateKey: string) => {
+  try {
+    parseKey(privateKey)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
 export function FromPrivateKey(props: Props) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
 
   const [privateKey, setPrivateKey] = React.useState('')
-  const [privateKeyIsValid, setPrivateKeyIsValid] = React.useState(true)
 
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => setPrivateKey(event.target.value)
   const onSubmit = () => {
-    try {
-      const secret = parseKey(privateKey)
-      setPrivateKeyIsValid(true)
-      dispatch(walletActions.openWalletFromPrivateKey(uint2hex(secret)))
-    } catch (e) {
-      setPrivateKeyIsValid(false)
-    }
+    const secret = parseKey(privateKey)
+    dispatch(walletActions.openWalletFromPrivateKey(uint2hex(secret)))
   }
 
   return (
@@ -57,11 +60,14 @@ export function FromPrivateKey(props: Props) {
 
         <PasswordField
           inputElementId="privatekey"
+          name="privateKey"
           placeholder={t('openWallet.privateKey.enterPrivateKeyHere', 'Enter your private key here')}
           autoComplete="off"
           value={privateKey}
           onChange={onChange}
-          error={privateKeyIsValid ? false : t('openWallet.privateKey.error', 'Invalid private key')}
+          validate={privateKey =>
+            isValidKey(privateKey) ? undefined : t('openWallet.privateKey.error', 'Invalid private key')
+          }
           showTip={t('openWallet.privateKey.showPrivateKey', 'Show private key')}
           hideTip={t('openWallet.privateKey.hidePrivateKey', 'Hide private key')}
           width="auto"


### PR DESCRIPTION
I tried to make validation part of the input field, so that onSubmit doesn't need to re-check validity of every input field. But then error-specific-styling doesn't work `contentProps={{ border: props.error ? 'bottom' : false }}`.

| Before | After |
| --- | --- |
|  ![localhost_3000_open-wallet_private-key (2)](https://user-images.githubusercontent.com/3758846/195467451-f714d627-61fa-4a38-9925-5c31ac22e8e1.png) | ![localhost_3000_open-wallet_private-key](https://user-images.githubusercontent.com/3758846/195467450-b9a415f1-2a33-4f30-b544-95e98a81744f.png)  |


