### PR TITLE
Ignore temporary / editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ stats.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*~
+\#*
+.\#*
 
 # Docker
 /node


### PR DESCRIPTION
These are various temp files that are sometimes used by Emacs and other editors.