### PR TITLE
Remove IE11 and Android 4.4.x from the list of supported browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
       ">0.2%",
       "not dead",
       "not op_mini all",
-      "not ios_saf < 13"
+      "not ios_saf < 13",
+      "not android <= 4.4.4",
+      "not ie <= 11"
     ],
     "development": [
       "last 1 chrome version",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,6 @@
  * code.
  */
 
-import 'react-app-polyfill/ie11'
 import 'react-app-polyfill/stable'
 
 import * as React from 'react'

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,7 +3,6 @@
 // this adds jest-dom's custom assertions
 import '@testing-library/jest-dom/extend-expect'
 
-import 'react-app-polyfill/ie11'
 import 'react-app-polyfill/stable'
 import 'portable-fetch'
 


### PR DESCRIPTION
Workaround for a transpiler issue with bigints/bigintegers after switching to `@ethereumjs/util` package. After removing these two browsers from `browserlist` extension works correctly.

Related to https://github.com/oasisprotocol/oasis-wallet-web/pull/1111#issuecomment-1293603751