### PR TITLE
Adjust the min-height of the import account dialog

### DIFF
--- a/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/__tests__/__snapshots__/index.test.tsx.snap
@@ -523,7 +523,7 @@ exports[`<ImportAccountsSelectionModal  /> should match snapshot 1`] = `
               </h2>
               <div
                 class="c7"
-                style="min-height: 336px;"
+                style="min-height: 362px;"
               >
                 <div
                   class="c7"

--- a/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/index.tsx
@@ -98,7 +98,7 @@ export function ImportAccountsSelectionModal(props: ImportAccountsSelectionModal
     <ResponsiveLayer onEsc={props.abort} onClickOutside={props.abort} modal background="background-front">
       <Box width="800px" pad="medium">
         <ModalHeader>{t('openWallet.importAccounts.selectWallets', 'Select accounts to open')}</ModalHeader>
-        <Box style={{ minHeight: '336px' }}>
+        <Box style={{ minHeight: '362px' }}>
           <ImportAccountsSelector accounts={accounts} />
           {![ImportAccountsStep.Idle, ImportAccountsStep.LoadingBalances].includes(importAccounts.step) && (
             <Box direction="row" gap="medium" alignContent="center" pad={{ top: 'small' }}>


### PR DESCRIPTION
The purpose of setting the min-height was to avoid the buttons jumping while enumerating the accounts.

Unfortunately the previously set value (336px) was not enough in extension mode, so some jumping remained. Adjusting it (to 362px) takes care of this.