### PR TITLE
Update Oasis Scan OperationsRow swagger spec

### DIFF
--- a/src/app/components/Transaction/index.tsx
+++ b/src/app/components/Transaction/index.tsx
@@ -294,6 +294,10 @@ export function Transaction(props: TransactionProps) {
       [TransactionSide.Received]: genericTransaction,
       [TransactionSide.Sent]: genericTransaction,
     },
+    [transactionTypes.TransactionType.RegistryDeregisterEntity]: {
+      [TransactionSide.Received]: genericTransaction,
+      [TransactionSide.Sent]: genericTransaction,
+    },
     [transactionTypes.TransactionType.RegistryRegisterEntity]: {
       [TransactionSide.Received]: genericTransaction,
       [TransactionSide.Sent]: genericTransaction,

--- a/src/app/state/transaction/types.ts
+++ b/src/app/state/transaction/types.ts
@@ -10,6 +10,7 @@ export enum TransactionType {
   StakingWithdraw = 'staking.Withdraw',
   RoothashExecutorCommit = 'roothash.ExecutorCommit',
   RoothashExecutorProposerTimeout = 'roothash.ExecutorProposerTimeout',
+  RegistryDeregisterEntity = 'registry.DeregisterEntity',
   RegistryRegisterEntity = 'registry.RegisterEntity',
   RegistryRegisterNode = 'registry.RegisterNode',
   RegistryRegisterRuntime = 'registry.RegisterRuntime',

--- a/src/vendors/oasisscan.ts
+++ b/src/vendors/oasisscan.ts
@@ -132,6 +132,7 @@ export const transactionMethodMap: {
   [OperationsRowMethodEnum.StakingWithdraw]: TransactionType.StakingWithdraw,
   [OperationsRowMethodEnum.RoothashExecutorCommit]: TransactionType.RoothashExecutorCommit,
   [OperationsRowMethodEnum.RoothashExecutorProposerTimeout]: TransactionType.RoothashExecutorProposerTimeout,
+  [OperationsRowMethodEnum.RegistryDeregisterEntity]: TransactionType.RegistryDeregisterEntity,
   [OperationsRowMethodEnum.RegistryRegisterEntity]: TransactionType.RegistryRegisterEntity,
   [OperationsRowMethodEnum.RegistryRegisterNode]: TransactionType.RegistryRegisterNode,
   [OperationsRowMethodEnum.RegistryRegisterRuntime]: TransactionType.RegistryRegisterRuntime,

--- a/src/vendors/oasisscan/models/OperationsRow.ts
+++ b/src/vendors/oasisscan/models/OperationsRow.ts
@@ -112,6 +112,7 @@ export enum OperationsRowMethodEnum {
     StakingWithdraw = 'staking.Withdraw',
     RoothashExecutorCommit = 'roothash.ExecutorCommit',
     RoothashExecutorProposerTimeout = 'roothash.ExecutorProposerTimeout',
+    RegistryDeregisterEntity = 'registry.DeregisterEntity',
     RegistryRegisterEntity = 'registry.RegisterEntity',
     RegistryRegisterNode = 'registry.RegisterNode',
     RegistryRegisterRuntime = 'registry.RegisterRuntime',

--- a/src/vendors/oasisscan/swagger3.yml
+++ b/src/vendors/oasisscan/swagger3.yml
@@ -439,6 +439,7 @@ components:
             - staking.Withdraw
             - roothash.ExecutorCommit
             - roothash.ExecutorProposerTimeout
+            - registry.DeregisterEntity
             - registry.RegisterEntity
             - registry.RegisterNode
             - registry.RegisterRuntime


### PR DESCRIPTION
CI/CD is failing currently
```
   1) by comparing list of methods from oasisscan
      AssertionError: expected [ Array(17) ] to have a length of 16 but got 17
```