### PR TITLE
Validate mnemonic words in MnemonicGrid

### DIFF
--- a/src/app/components/MnemonicGrid/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/MnemonicGrid/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,183 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FromMnemonic/> should match snapshot 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 6px;
+  background: #33333310;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 6px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-right: 12px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c0 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-columns: repeat( auto-fill,minmax(14ch,1fr) );
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-right: 6px;
+  }
+}
+
+<span
+  class="notranslate"
+  translate="no"
+>
+  <div
+    class="c0"
+    data-testid="mnemonic-grid"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <span
+          class="c3"
+          style="user-select: none;"
+        >
+          1
+          .
+        </span>
+      </div>
+      <div
+        class="c4"
+      >
+        <span
+          class="notranslate"
+          translate="no"
+        >
+          <strong
+            style="white-space: pre;"
+          >
+            planet
+          </strong>
+        </span>
+      </div>
+    </div>
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <span
+          class="c3"
+          style="user-select: none;"
+        >
+          2
+          .
+        </span>
+      </div>
+      <div
+        class="c4"
+      >
+        <span
+          class="notranslate"
+          translate="no"
+        >
+          <strong
+            style="white-space: pre; text-decoration: red wavy underline;"
+          >
+            beelieve
+          </strong>
+        </span>
+      </div>
+    </div>
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <span
+          class="c3"
+          style="user-select: none;"
+        >
+          3
+          .
+        </span>
+      </div>
+      <div
+        class="c4"
+      >
+        <span
+          class="notranslate"
+          translate="no"
+        >
+          <strong
+            style="white-space: pre;"
+          >
+            session
+          </strong>
+        </span>
+      </div>
+    </div>
+  </div>
+</span>
+`;

--- a/src/app/components/MnemonicGrid/__tests__/index.test.tsx
+++ b/src/app/components/MnemonicGrid/__tests__/index.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import { MnemonicGrid } from '..'
+
+describe('<FromMnemonic/>', () => {
+  it('should match snapshot', () => {
+    const page = render(
+      <MnemonicGrid
+        mnemonic={[
+          'planet',
+          'beelieve', // Should mark typo
+          'session',
+        ]}
+      />,
+    )
+    expect(page.container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/app/components/MnemonicGrid/index.tsx
+++ b/src/app/components/MnemonicGrid/index.tsx
@@ -2,6 +2,9 @@ import { NoTranslate } from 'app/components/NoTranslate'
 import { Box, Grid, ResponsiveContext, Text } from 'grommet'
 import * as React from 'react'
 import { useContext } from 'react'
+import { getDefaultWordlist, wordlists } from 'bip39'
+
+const validWords = new Set(wordlists[getDefaultWordlist()])
 
 /**
  *
@@ -20,12 +23,9 @@ const noSelect: React.CSSProperties = {
   userSelect: 'none',
 }
 
-// Make typos obvious e.g. if user has pasted mnemonic containing a newline
-const keepWhitespace: React.CSSProperties = {
-  whiteSpace: 'pre',
-}
-
 function MnemonicWord(props: WordProp) {
+  const isWordValid = validWords.has(props.word)
+
   return (
     <Box
       background="background-contrast"
@@ -39,7 +39,14 @@ function MnemonicWord(props: WordProp) {
       </Box>
       <Box>
         <NoTranslate>
-          <strong style={keepWhitespace}>{props.word}</strong>
+          <strong
+            style={{
+              whiteSpace: 'pre',
+              textDecoration: isWordValid ? undefined : 'red wavy underline',
+            }}
+          >
+            {props.word}
+          </strong>
         </NoTranslate>
       </Box>
     </Box>

--- a/src/app/components/MnemonicGrid/index.tsx
+++ b/src/app/components/MnemonicGrid/index.tsx
@@ -11,8 +11,6 @@ import { useContext } from 'react'
 interface WordProp {
   id: number
   word: string
-  hidden?: boolean
-  higlighted?: boolean
 }
 
 const noSelect: React.CSSProperties = {
@@ -30,7 +28,7 @@ const keepWhitespace: React.CSSProperties = {
 function MnemonicWord(props: WordProp) {
   return (
     <Box
-      background={props.higlighted ? 'brand' : 'background-contrast'}
+      background="background-contrast"
       margin="xsmall"
       direction="row"
       pad="xsmall"
@@ -41,7 +39,7 @@ function MnemonicWord(props: WordProp) {
       </Box>
       <Box>
         <NoTranslate>
-          <strong style={keepWhitespace}>{props.hidden ? '' : props.word}</strong>
+          <strong style={keepWhitespace}>{props.word}</strong>
         </NoTranslate>
       </Box>
     </Box>
@@ -51,15 +49,9 @@ function MnemonicWord(props: WordProp) {
 interface Props {
   // List of words
   mnemonic: string[]
-
-  /** Indexes of hidden words, used for mnemonic validation */
-  hiddenWords?: number[]
-
-  /** Highlighted word indexes, used for mnemonic validation */
-  highlightedIndex?: number
 }
 
-export function MnemonicGrid({ mnemonic, highlightedIndex: hilightedIndex, hiddenWords }: Props) {
+export function MnemonicGrid({ mnemonic }: Props) {
   const size = useContext(ResponsiveContext)
   const maxEnglishLength = 8
   const numberDotSpaceLength = 4
@@ -70,13 +62,7 @@ export function MnemonicGrid({ mnemonic, highlightedIndex: hilightedIndex, hidde
     <NoTranslate>
       <Grid columns={columnSize} data-testid="mnemonic-grid">
         {mnemonic.map((word, index) => (
-          <MnemonicWord
-            key={index + 1}
-            id={index + 1}
-            word={word}
-            higlighted={index === hilightedIndex}
-            hidden={hiddenWords && hiddenWords.indexOf(index) !== -1}
-          />
+          <MnemonicWord key={index + 1} id={index + 1} word={word} />
         ))}
       </Grid>
     </NoTranslate>

--- a/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/__snapshots__/index.test.tsx.snap
@@ -482,7 +482,7 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
                   translate="no"
                 >
                   <strong
-                    style="white-space: pre;"
+                    style="white-space: pre; text-decoration: red wavy underline;"
                   />
                 </span>
               </div>


### PR DESCRIPTION
Quick improvement since https://github.com/oasisprotocol/oasis-wallet-web/pull/1181 disables spell-checking mnemonic

| Before 1181 | After 1181 + this |
| --- | --- |
|  ![localhost_3000_open-wallet_mnemonic (1)](https://user-images.githubusercontent.com/3758846/204437830-17477963-8d7e-4d39-87a8-df1c598ae4ca.png) |  ![localhost_3000_open-wallet_mnemonic](https://user-images.githubusercontent.com/3758846/204437827-6b2fa8a9-4638-4197-adc2-7a2c28793d73.png) |


