### PR TITLE
Disable spellcheck in sensitive inputs

### DIFF
--- a/src/app/lib/preventSavingInputsToUserData.ts
+++ b/src/app/lib/preventSavingInputsToUserData.ts
@@ -5,7 +5,8 @@
  * Browsers write visible input fields from any website to user data to enable
  * restoring sessions. Browsers exclude inputs with autocomplete="off" from
  * cached form data in the session history (even though they ignore it and still
- * offer autofill from saved passwords).
+ * offer autofill from saved passwords). Browsers with enhanced spellcheck also
+ * send it to the cloud.
  *
  * To ensure this fixes vulnerability:
  * - Manually checked
@@ -17,5 +18,11 @@
  * - https://coinyuppie.com/slow-mist-a-brief-analysis-of-the-metamask-wallet-demonic-vulnerability/
  * - https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
  * - https://nvd.nist.gov/vuln/detail/CVE-2022-0167
+ * - https://www.otto-js.com/news/article/spell-jacking-enhanced-spellcheck-features-send-pii-even-passwords
  */
-export const preventSavingInputsToUserData = { autoComplete: 'off' }
+export const preventSavingInputsToUserData = {
+  autoComplete: 'off',
+  autoCapitalize: 'off',
+  autoCorrect: 'off',
+  spellCheck: false,
+}

--- a/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromMnemonic/__tests__/__snapshots__/index.test.tsx.snap
@@ -405,7 +405,10 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
       class="c2"
     >
       <form
+        autocapitalize="off"
         autocomplete="off"
+        autocorrect="off"
+        spellcheck="false"
       >
         <h1
           class="c3"
@@ -424,11 +427,14 @@ exports[`<FromMnemonic/> should match snapshot 1`] = `
             class="c6 "
           >
             <textarea
+              autocapitalize="off"
               autocomplete="off"
+              autocorrect="off"
               class="c7"
               id="mnemonic"
               placeholder="openWallet.mnemonic.enterPhraseHere"
               rows="5"
+              spellcheck="false"
             />
           </div>
         </div>

--- a/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/FromPrivateKey/__tests__/__snapshots__/index.test.tsx.snap
@@ -440,7 +440,10 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
     class="c1"
   >
     <form
+      autocapitalize="off"
       autocomplete="off"
+      autocorrect="off"
+      spellcheck="false"
     >
       <h1
         class="c2"
@@ -472,11 +475,14 @@ exports[`<FromPrivateKey  /> should match snapshot 1`] = `
                 class="c8"
               >
                 <input
+                  autocapitalize="off"
                   autocomplete="off"
+                  autocorrect="off"
                   class="c9"
                   id="privatekey"
                   name="privateKey"
                   placeholder="openWallet.privateKey.enterPrivateKeyHere"
+                  spellcheck="false"
                   type="password"
                   value=""
                 />

--- a/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/__tests__/__snapshots__/index.test.tsx.snap
@@ -617,7 +617,10 @@ exports[`<ImportAccountsSelectionModal  /> should match snapshot 1`] = `
           />
           <div>
             <form
+              autocapitalize="off"
               autocomplete="off"
+              autocorrect="off"
+              spellcheck="false"
             >
               <div
                 class="c5"

--- a/src/app/pages/ParaTimesPage/TransactionRecipient/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/ParaTimesPage/TransactionRecipient/__tests__/__snapshots__/index.test.tsx.snap
@@ -367,7 +367,10 @@ exports[`<TransactionRecipient /> should render component 1`] = `
       class="c4"
     >
       <form
+        autocapitalize="off"
         autocomplete="off"
+        autocorrect="off"
+        spellcheck="false"
         style="width: 465px;"
       >
         <div


### PR DESCRIPTION
Prevent https://www.otto-js.com/news/article/spell-jacking-enhanced-spellcheck-features-send-pii-even-passwords
Related to https://github.com/oasisprotocol/oasis-wallet-web/pull/1171