### PR TITLE
Ensure top-level permissions are not set to write-all

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [stable, master]
 
+# disable secrets.GITHUB_TOKEN permissions
+permissions: {}
+
 jobs:
   yarn_cache:
     runs-on: ubuntu-latest

--- a/.github/workflows/dump-validators.yml
+++ b/.github/workflows/dump-validators.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '0 0 1 * *'
 
+permissions: # Limit secrets.GITHUB_TOKEN permissions
+  contents: write
+  pull-requests: write
+
 jobs:
   dump-validators:
     if: github.repository == 'oasisprotocol/oasis-wallet-web'

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [stable, master]
 
+permissions: # Limit secrets.GITHUB_TOKEN permissions
+  contents: write
+  pull-requests: write
+
 env: # Comment env block if you do not want to apply fixes
   # Apply linter fixes configuration
   APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)


### PR DESCRIPTION
Fix MegaLinter error. Currently CI is failing due to  (default `write-all`?) 

```  Check: CKV2_GHA_1: "Ensure top-level permissions are not set to write-all"
  	FAILED for resource: on(Mega-Linter)
  	File: /.github/workflows/mega-linter.yml:0-1
  Check: CKV2_GHA_1: "Ensure top-level permissions are not set to write-all"
  	FAILED for resource: on(dump-validators)
  	File: /.github/workflows/dump-validators.yml:0-1
  Check: CKV2_GHA_1: "Ensure top-level permissions are not set to write-all"
  	FAILED for resource: on(Build and test)
  	File: /.github/workflows/build-test.yaml:0-1```
