### PR TITLE
Downgrade to latest playwright (ledger window doesn't crash Chromium)

### DIFF
--- a/playwright/package.json
+++ b/playwright/package.json
@@ -5,6 +5,6 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.32.0-alpha-mar-15-2023"
+    "@playwright/test": "1.31.2"
   }
 }

--- a/playwright/yarn.lock
+++ b/playwright/yarn.lock
@@ -2,13 +2,13 @@
 # yarn lockfile v1
 
 
-"@playwright/test@1.32.0-alpha-mar-15-2023":
-  version "1.32.0-alpha-mar-15-2023"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.32.0-alpha-mar-15-2023.tgz#eff86c546458ea807b5ed0c0898baef9d6a6d28b"
-  integrity sha512-4V9dPWvpYW2zC4lMd+nreFYN62xtBU4JrbgiXsydVt9v31afBXByim+yEgx5W8DLXLp4869SqC/qDDDbFzc/fw==
+"@playwright/test@1.31.2":
+  version "1.31.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.31.2.tgz#426d8545143a97a6fed250a2a27aa1c8e5e2548e"
+  integrity sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.32.0-alpha-mar-15-2023"
+    playwright-core "1.31.2"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -22,7 +22,7 @@ fsevents@2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
-playwright-core@1.32.0-alpha-mar-15-2023:
-  version "1.32.0-alpha-mar-15-2023"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.32.0-alpha-mar-15-2023.tgz#27d3e63b53dcfa5aad03519420a682a1dda4354f"
-  integrity sha512-Uml7QyKsskEr7/OXUv/ZukuDNhTZj6wZ/FBJx2QPicCWBJhvjSgS2Ek1AFQsqdz6TknndaL0QdAMT29ch1EdUg==
+playwright-core@1.31.2:
+  version "1.31.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.31.2.tgz#debf4b215d14cb619adb7e511c164d068075b2ed"
+  integrity sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==


### PR DESCRIPTION
During https://github.com/oasisprotocol/oasis-wallet-web/pull/1321 I needed playwright prerelease to test if popup would ask for permissions after it no longer crashed Chromium.

It did not ask for permissions, so as a workaround I open a normal window instead of a popup. This asks for permissions and doesn't crash Chromium 110.x/111.x. With this workaround we no longer need prerelease, and we can test against latest browsers instead.