### PR TITLE
Refactor selecting network initially to avoid sync timing issues

### DIFF
--- a/playwright/tests/persist.spec.ts
+++ b/playwright/tests/persist.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
 import { mockApi } from '../utils/mockApi'
 import { warnSlowApi } from '../utils/warnSlowApi'
 import { expectNoFatal } from '../utils/expectNoFatal'

--- a/playwright/utils/expectShell.ts
+++ b/playwright/utils/expectShell.ts
@@ -5,7 +5,7 @@ export function expectShell(cmd: string) {
   let output: string
   try {
     output = execSync(cmd, { encoding: 'utf-8' })
-  } catch (e) {
+  } catch (e: any) {
     output = `exit code ${e.status}: ${e.message}`
   }
   return expect(output)

--- a/src/app/state/network/index.ts
+++ b/src/app/state/network/index.ts
@@ -14,7 +14,11 @@ const slice = createSlice({
   name: 'network',
   initialState,
   reducers: {
+    initializeNetwork() {},
     selectNetwork(state, action: PayloadAction<NetworkType>) {},
+    initialNetworkSelected(state, action: PayloadAction<NetworkState>) {
+      Object.assign(state, action.payload)
+    },
     networkSelected(state, action: PayloadAction<NetworkState>) {
       Object.assign(state, action.payload)
     },

--- a/src/app/state/network/saga.ts
+++ b/src/app/state/network/saga.ts
@@ -1,13 +1,13 @@
 import * as oasis from '@oasisprotocol/client'
-import { PayloadAction } from '@reduxjs/toolkit'
 import { persistActions } from 'app/state/persist'
 import { selectSkipUnlockingOnInit } from 'app/state/persist/selectors'
 import { config } from 'config'
 import { RECEIVE_INIT_STATE } from 'redux-state-sync'
-import { all, call, delay, put, race, select, take, takeLatest } from 'typed-redux-saga'
+import { all, call, put, select, takeLatest } from 'typed-redux-saga'
 import { backend, backendApi } from 'vendors/backend'
 
 import { networkActions } from '.'
+import { SyncedRootState } from '../persist/types'
 import { selectSelectedNetwork } from './selectors'
 import { NetworkType } from './types'
 
@@ -24,40 +24,71 @@ export function* getOasisNic(network?: NetworkType) {
 }
 
 /**
- * Return the explorer APIs for the specified network
- * or by default, for the currently selected network
+ * Return the explorer APIs for the currently selected network
  */
-export function* getExplorerAPIs(network?: NetworkType) {
+export function* getExplorerAPIs() {
   const selectedNetwork = yield* select(selectSelectedNetwork)
   const url = config[selectedNetwork][backend()].explorer
   return backendApi(url)
 }
 
-export function* selectNetwork({ payload: network }: PayloadAction<NetworkType>) {
+export function* selectNetwork({
+  network,
+  isInitializing,
+}: {
+  network: NetworkType
+  isInitializing: boolean
+}) {
   const nic = yield* call(getOasisNic, network)
   const { epoch, chainContext } = yield* all({
     epoch: call([nic, nic.beaconGetEpoch], oasis.consensus.HEIGHT_LATEST),
     chainContext: call([nic, nic.consensusGetChainContext]),
   })
+  const networkState = {
+    chainContext: chainContext,
+    ticker: config[network].ticker,
+    epoch: Number(epoch), // TODO: numeric precision
+    selectedNetwork: network,
+    minimumStakingAmount: config[network].min_delegation,
+  }
 
-  yield* put(
-    networkActions.networkSelected({
-      chainContext: chainContext,
-      ticker: config[network].ticker,
-      epoch: Number(epoch), // TODO: numeric precision
-      selectedNetwork: network,
-      minimumStakingAmount: config[network].min_delegation,
-    }),
-  )
+  if (isInitializing) {
+    yield* put(networkActions.initialNetworkSelected(networkState))
+  } else {
+    yield* put(networkActions.networkSelected(networkState))
+  }
 }
 
 export function* networkSaga() {
-  yield* takeLatest(networkActions.selectNetwork, selectNetwork)
-  yield* takeLatest(persistActions.setUnlockedRootState, ({ payload }) =>
-    put(networkActions.selectNetwork(payload.persistedRootState.network.selectedNetwork)),
-  )
-  yield* takeLatest(persistActions.skipUnlocking, () =>
-    put(networkActions.selectNetwork(process.env.REACT_APP_LOCALNET ? 'local' : 'mainnet')),
+  yield* takeLatest(
+    [
+      networkActions.initializeNetwork,
+      networkActions.selectNetwork,
+      persistActions.setUnlockedRootState,
+      persistActions.resetRootState,
+      RECEIVE_INIT_STATE,
+    ],
+    function* (action) {
+      const currentNetworkType = yield* select(selectSelectedNetwork)
+
+      if (networkActions.initializeNetwork.match(action)) {
+        yield* call(selectNetwork, { network: currentNetworkType, isInitializing: true })
+      }
+      if (networkActions.selectNetwork.match(action)) {
+        yield* call(selectNetwork, { network: action.payload, isInitializing: false })
+      }
+      if (persistActions.setUnlockedRootState.match(action)) {
+        const rootState = action.payload.persistedRootState
+        yield* call(selectNetwork, { network: rootState.network.selectedNetwork, isInitializing: false })
+      }
+      if (persistActions.resetRootState.match(action)) {
+        yield* call(selectNetwork, { network: currentNetworkType, isInitializing: false })
+      }
+      if (action.type === RECEIVE_INIT_STATE) {
+        const rootState = (action as any).payload as SyncedRootState
+        yield* call(selectNetwork, { network: rootState.network.selectedNetwork, isInitializing: false })
+      }
+    },
   )
   yield* takeLatest(persistActions.resetRootState, function* () {
     const skipUnlockOnInit = yield* select(selectSkipUnlockingOnInit)
@@ -66,14 +97,5 @@ export function* networkSaga() {
     }
   })
 
-  // Wait for tabs to sync state.
-  // TODO: seems to take longer than 100ms when using multiple tabs
-  const maybeSynced = yield* race({
-    tabsSynced: take(RECEIVE_INIT_STATE),
-    thereAreNoOtherTabs: delay(50),
-  })
-  const skipUnlockOnInit = yield* select(selectSkipUnlockingOnInit)
-  if (!maybeSynced.tabsSynced && skipUnlockOnInit) {
-    yield* put(persistActions.skipUnlocking())
-  }
+  yield* put(networkActions.initializeNetwork())
 }

--- a/src/app/state/network/saga.ts
+++ b/src/app/state/network/saga.ts
@@ -66,7 +66,8 @@ export function* networkSaga() {
     }
   })
 
-  // Wait for tabs to sync state. >5ms should be enough.
+  // Wait for tabs to sync state.
+  // TODO: seems to take longer than 100ms when using multiple tabs
   const maybeSynced = yield* race({
     tabsSynced: take(RECEIVE_INIT_STATE),
     thereAreNoOtherTabs: delay(50),

--- a/src/app/state/persist/index.ts
+++ b/src/app/state/persist/index.ts
@@ -26,7 +26,7 @@ export function getInitialState(): PersistState {
     // Disable persistence if tabs would override each other.
     isPersistenceUnsupported: needsSyncingTabs && !isSyncingTabsSupported,
     loading: false,
-    stringifiedEncryptionKey: undefined,
+    stringifiedEncryptionKey: localStorage.getItem(STORAGE_FIELD) ? undefined : 'skipped',
     enteredWrongPassword: false,
   }
 }

--- a/src/app/state/persist/syncTabs.ts
+++ b/src/app/state/persist/syncTabs.ts
@@ -42,6 +42,7 @@ export const whitelistTabSyncActions = [
   themeActions.changeTheme.type,
   walletActions.walletOpened.type,
   walletActions.updateBalance.type,
+  // NOT networkActions.initialNetworkSelected.type,
   networkActions.networkSelected.type,
   persistActions.setUnlockedRootState.type,
   persistActions.resetRootState.type,


### PR DESCRIPTION
Related to https://github.com/oasisprotocol/oasis-wallet-web/issues/792#issuecomment-1269273318

Reverts part of c125984a415bd1a3fd9dd61c9ce6f2634e8ef8eb and re-fixes https://github.com/oasisprotocol/oasis-wallet-web/pull/975#discussion_r1012328608

Instead of waiting for tabs to be synced before selecting network initially:
- initialize selecting network without syncing that action
- using takeLatest cancel initialization task if tabs sync during selectNetwork
