### PR TITLE
ParaTimes: fix Consensus amount not representable bug

### DIFF
--- a/src/app/pages/ParaTimesPage/TransactionAmount/index.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionAmount/index.tsx
@@ -24,7 +24,7 @@ export const TransactionAmount = () => {
   const {
     balance,
     balanceInBaseUnit,
-    decimals,
+    consensusDecimals,
     isDepositing,
     isEvmcParaTime,
     isLoading,
@@ -92,12 +92,12 @@ export const TransactionAmount = () => {
                 required
                 validate={[
                   (amount: string) =>
-                    !new RegExp(`^\\d*(?:[.][0-9]{0,${decimals}})?$`).test(amount)
+                    !new RegExp(`^\\d*(?:[.][0-9]{0,${consensusDecimals}})?$`).test(amount)
                       ? {
                           message: t(
                             'paraTimes.validation.invalidDecimalValue',
-                            'Maximum of {{token}} decimal places is allowed',
-                            { token: decimals },
+                            'Maximum of {{decimals}} decimal places is allowed',
+                            { decimals: consensusDecimals },
                           ),
                           status: 'error',
                         }

--- a/src/app/pages/ParaTimesPage/useParaTimes.ts
+++ b/src/app/pages/ParaTimesPage/useParaTimes.ts
@@ -28,6 +28,7 @@ export type ParaTimesHook = {
   balance: StringifiedBigInt | null
   balanceInBaseUnit: boolean
   clearTransactionForm: () => void
+  consensusDecimals: number
   decimals: number
   isDepositing: boolean
   isEvmcParaTime: boolean
@@ -99,6 +100,7 @@ export const useParaTimes = (): ParaTimesHook => {
     balance: walletBalance,
     balanceInBaseUnit,
     clearTransactionForm,
+    consensusDecimals,
     decimals,
     isDepositing,
     isEvmcParaTime,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -323,7 +323,7 @@
     },
     "unsupportedFormStep": "Unsupported form step",
     "validation": {
-      "invalidDecimalValue": "Maximum of {{token}} decimal places is allowed",
+      "invalidDecimalValue": "Maximum of {{decimals}} decimal places is allowed",
       "invalidEthPrivateKey": "Ethereum-compatible private key is invalid",
       "invalidEthPrivateKeyLength": "Private key should be 64 characters long",
       "invalidFee": "Value must be integer greater than or equal to 0",


### PR DESCRIPTION
Currently bug `Unknown gRPC error: client: transaction check failed: runtime error: module: consensus code: 5 message: consensus: amount not representable` can occur during withdraws from EVM ParaTimes.

In both cases, deposit to ParaTime from Consensus and withdraw from ParaTime to Consensus, we need valid Consensus amounts.