### PR TITLE
ParaTimes: cancel transfer instead of navigating back to ParaTime selection

### DIFF
--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -19,7 +19,7 @@ const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 3000,
+    timeout: 8000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/playwright/tests/paraTimes.spec.ts
+++ b/playwright/tests/paraTimes.spec.ts
@@ -1,0 +1,30 @@
+// Uncomment when ParaTimes are released
+// import { test, expect } from '@playwright/test'
+// import { privateKey, privateKeyAddress } from '../utils/test-inputs'
+// import { fillPrivateKeyWithoutPassword } from '../utils/fillPrivateKey'
+
+// test.describe('ParaTimes', () => {
+//   test('should clear form data on cancel transfer', async ({ page }) => {
+//     await page.goto('/open-wallet/private-key')
+//     await fillPrivateKeyWithoutPassword(page, {
+//       privateKey: privateKey,
+//       privateKeyAddress: privateKeyAddress,
+//       persistenceCheckboxChecked: false,
+//       persistenceCheckboxDisabled: false,
+//     })
+//     await page.getByTestId('nav-paratime').click()
+//     await page.getByRole('button', { name: /Deposit/i }).click()
+//     await page.getByRole('button', { name: /Select/i }).click()
+//     await expect(page.getByRole('listbox')).toBeVisible()
+//     await page.getByRole('listbox').locator('button', { hasText: 'Cipher' }).click()
+//     await page.getByRole('button', { name: /Next/i }).click()
+//     await page.getByPlaceholder(privateKeyAddress).fill(privateKeyAddress)
+//     await page.getByRole('button', { name: /Cancel transfer/i }).click()
+//     await page.getByRole('button', { name: /Deposit/i }).click()
+//     await page.getByRole('button', { name: /Select/i }).click()
+//     await expect(page.getByRole('listbox')).toBeVisible()
+//     await page.getByRole('listbox').locator('button', { hasText: 'Emerald' }).click()
+//     await page.getByRole('button', { name: /Next/i }).click()
+//     await expect(page.getByPlaceholder('0x...')).toHaveValue('')
+//   })
+// })

--- a/src/app/pages/ParaTimesPage/TransactionRecipient/__tests__/index.test.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionRecipient/__tests__/index.test.tsx
@@ -166,33 +166,17 @@ describe('<TransactionRecipient />', () => {
     expect(navigateToAmount).toHaveBeenCalled()
   })
 
-  it('should navigate back to deposit', async () => {
-    const navigateToDeposit = jest.fn()
-    jest.mocked(useParaTimesNavigation).mockReturnValue({
-      ...mockUseParaTimesNavigationResult,
-      navigateToDeposit,
-    })
-    render(<TransactionRecipient />)
-
-    await userEvent.click(screen.getByRole('button', { name: 'Previous' }))
-
-    expect(navigateToDeposit).toHaveBeenCalled()
-  })
-
-  it('should navigate back to withdraw', async () => {
-    const navigateToWithdraw = jest.fn()
+  it('should cancel transfer', async () => {
+    const clearTransactionForm = jest.fn()
     jest.mocked(useParaTimes).mockReturnValue({
       ...mockUseParaTimesResult,
+      clearTransactionForm,
       isDepositing: false,
     } as ParaTimesHook)
-    jest.mocked(useParaTimesNavigation).mockReturnValue({
-      ...mockUseParaTimesNavigationResult,
-      navigateToWithdraw,
-    })
     render(<TransactionRecipient />)
 
-    await userEvent.click(screen.getByRole('button', { name: 'Previous' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel transfer' }))
 
-    expect(navigateToWithdraw).toHaveBeenCalled()
+    expect(clearTransactionForm).toHaveBeenCalled()
   })
 })

--- a/src/app/pages/ParaTimesPage/TransactionRecipient/index.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionRecipient/index.tsx
@@ -15,6 +15,7 @@ export const TransactionRecipient = () => {
   const isMobile = useContext(ResponsiveContext) === 'small'
   const {
     accountAddress,
+    clearTransactionForm,
     isDepositing,
     isEvmcParaTime,
     paraTimeName,
@@ -22,7 +23,7 @@ export const TransactionRecipient = () => {
     transactionForm,
     usesOasisAddress,
   } = useParaTimes()
-  const { navigateToAmount, navigateToDeposit, navigateToWithdraw } = useParaTimesNavigation()
+  const { navigateToAmount } = useParaTimesNavigation()
   const addressValidator = usesOasisAddress ? isValidAddress : isValidEthAddress
 
   return (
@@ -104,7 +105,8 @@ export const TransactionRecipient = () => {
           </FormField>
         </Box>
         <ParaTimeFormFooter
-          secondaryAction={isDepositing ? navigateToDeposit : navigateToWithdraw}
+          secondaryAction={clearTransactionForm}
+          secondaryLabel={t('paraTimes.selection.cancel', 'Cancel transfer')}
           submitButton
           withNotice={isEvmcParaTime}
         />


### PR DESCRIPTION
Currently user can navigate back to ParaTime selector step which can lead to weird experience as we keep data for next steps.

sample: fill in Cipher recipient go back to the first step, select emerald, click next and we have Oasis addr in recipient input where we need eth addr.