### PR TITLE
Add failing test for privateToEthAddress

### DIFF
--- a/src/app/lib/__tests__/helpers.test.ts
+++ b/src/app/lib/__tests__/helpers.test.ts
@@ -6,7 +6,7 @@ import {
   addressToPublicKey,
   isValidAddress,
   parseRpcBalance,
-} from './helpers'
+} from '../helpers'
 
 describe('parseRoseStringToBaseUnitString', () => {
   it('should parse stringified number of ROSEs to stringified base units', () => {

--- a/src/app/lib/__tests__/ledger.test.ts
+++ b/src/app/lib/__tests__/ledger.test.ts
@@ -1,4 +1,4 @@
-import { Ledger, LedgerSigner, requestDevice } from './ledger'
+import { Ledger, LedgerSigner, requestDevice } from '../ledger'
 import OasisApp from '@oasisprotocol/ledger'
 import { WalletError, WalletErrors } from 'types/errors'
 import { Wallet, WalletType } from 'app/state/wallet/types'

--- a/src/app/lib/__tests__/privateToEthAddress.test.ts
+++ b/src/app/lib/__tests__/privateToEthAddress.test.ts
@@ -1,0 +1,9 @@
+import { privateToEthAddress } from '../eth-helpers'
+
+// TODO: enable when jest fixes `instanceof Uint8Array`. This throws "TypeError: Expected valid private key".
+// https://github.com/facebook/jest/issues/4422
+test.skip('privateToEthAddress', () => {
+  expect(privateToEthAddress('414bba7f242e9054f9fc119fe32d322a7d9bbe0cb8c75173a6826cc8b1af1370')).toEqual(
+    '0xFed5547859F9948d2C85F0516E3944377F88046f',
+  )
+})


### PR DESCRIPTION
Related to https://github.com/oasisprotocol/explorer/commit/dbdabe6c56bdfc0866e4a86908a65bda551c72c4

Apparently none of our existing jest tests touch multiple imports from `@ethereumjs/util` that check `instanceof Uint8Array` internally. Otherwise we would have odd failures. Added a skipped test as a reminder