### PR TITLE
i18n: Make ParaTime terms consistent with docs and Oasis CLI

### DIFF
--- a/src/app/components/Transaction/InfoBox.tsx
+++ b/src/app/components/Transaction/InfoBox.tsx
@@ -48,7 +48,7 @@ export function InfoBox({ copyToClipboard, icon: IconComponent, label, trimValue
         <Notification
           toast
           status={'normal'}
-          title={t('infoBox.valueCopied', '{{ label }} copied.', { label })}
+          title={t('infoBox.valueCopied', '{{label}} copied.', { label })}
           onClose={hideNotification}
         />
       )}

--- a/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
+++ b/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
@@ -114,7 +114,7 @@ export function AccountSummary({ address, balance, walletAddress, walletIsOpen }
               t={t}
               components={{ HomeLink: <AnchorLink to="/" /> }}
               values={{ ticker }}
-              defaults="To send, receive, stake and swap {{ ticker }} tokens, <HomeLink>open your wallet!</HomeLink>"
+              defaults="To send, receive, stake and swap {{ticker}} tokens, <HomeLink>open your wallet!</HomeLink>"
             />
           </AlertBox>
         )}

--- a/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/index.tsx
@@ -107,7 +107,7 @@ export function ImportAccountsSelectionModal(props: ImportAccountsSelectionModal
       <Form<FormValue> onSubmit={openAccounts} {...preventSavingInputsToUserData}>
         <Box width="800px" pad="medium">
           <ModalSplitHeader
-            side={t('openWallet.importAccounts.accountCounter', '{{ count }} accounts selected', {
+            side={t('openWallet.importAccounts.accountCounter', '{{count}} accounts selected', {
               count: selectedAccounts.length,
             })}
           >
@@ -142,7 +142,7 @@ export function ImportAccountsSelectionModal(props: ImportAccountsSelectionModal
             />
             <Box>
               <span>
-                {t('openWallet.importAccounts.pageNumber', 'Page {{ pageNum }} of {{ totalPages }}', {
+                {t('openWallet.importAccounts.pageNumber', 'Page {{pageNum}} of {{totalPages}}', {
                   pageNum: importAccounts.accountsSelectionPageNumber + 1,
                   totalPages: numberOfAccountPages,
                 })}

--- a/src/app/pages/ParaTimesPage/ParaTimeFormFooter/index.tsx
+++ b/src/app/pages/ParaTimesPage/ParaTimeFormFooter/index.tsx
@@ -39,7 +39,7 @@ export const ParaTimeFormFooter = ({
 
         {secondaryAction && (
           <Button
-            label={secondaryLabel || t('paraTimes.footer.previous', 'Previous')}
+            label={secondaryLabel || t('paraTimes.footer.back', 'Back')}
             onClick={secondaryAction}
             plain
             style={{ textAlign: 'center', fontSize: '14px', textDecoration: 'underline', color: 'brand' }}
@@ -49,7 +49,7 @@ export const ParaTimeFormFooter = ({
 
       {withNotice && (
         <Text size="small">
-          {t('paraTimes.footer.notice', '* EVMc - Ethereum Virtual Machine compatible')}
+          {t('paraTimes.footer.notice', '* EVMc - compatible with Ethereum Virtual Machine')}
         </Text>
       )}
     </>

--- a/src/app/pages/ParaTimesPage/ParaTimeSelection/index.tsx
+++ b/src/app/pages/ParaTimesPage/ParaTimeSelection/index.tsx
@@ -43,14 +43,14 @@ export const ParaTimeSelection = () => {
         isDepositing
           ? t(
               'paraTimes.selection.depositDescription',
-              'Please select which ParaTime you wish to transfer your {{ticker}} tokens to and then click "Next".',
+              'Please select which ParaTime you wish to deposit your {{ticker}} to and then click "Next".',
               {
                 ticker,
               },
             )
           : t(
               'paraTimes.selection.withdrawDescription',
-              'Please select which ParaTime you wish to withdraw your {{ticker}} tokens from and then click "Next".',
+              'Please select which ParaTime you wish to withdraw your {{ticker}} from and then click "Next".',
               {
                 ticker,
               },

--- a/src/app/pages/ParaTimesPage/ParaTimeTransferType/index.tsx
+++ b/src/app/pages/ParaTimesPage/ParaTimeTransferType/index.tsx
@@ -13,10 +13,10 @@ export const ParaTimeTransferType = () => {
 
   return (
     <ParaTimeContent
-      header={t('paraTimes.common.header', 'ParaTimes Transfers')}
+      header={t('paraTimes.common.header', 'ParaTime Transfers')}
       description={t(
         'paraTimes.transfers.description',
-        'Use the "Deposit" option to transfer your {{ticker}} tokens from Consensus to a ParaTime of your choosing or "Withdraw" option to transfer your {{ticker}} tokens from a ParaTime back to Consensus.',
+        'Click on the "Deposit" button to deposit your {{ticker}} from consensus to a ParaTime of your choice or "Withdraw" to withdraw your {{ticker}} from a ParaTime back to consensus.',
         {
           ticker,
         },

--- a/src/app/pages/ParaTimesPage/ParaTimesPageInaccessible/index.tsx
+++ b/src/app/pages/ParaTimesPage/ParaTimesPageInaccessible/index.tsx
@@ -7,7 +7,7 @@ export const ParaTimesPageInaccessible = () => {
 
   return (
     <ParaTimeContent
-      header={t('paraTimes.common.header', 'ParaTimes Transfers')}
+      header={t('paraTimes.common.header', 'ParaTime Transfers')}
       description={t('paraTimes.pageInaccessible', 'Transfers are not available.')}
     />
   )

--- a/src/app/pages/ParaTimesPage/TransactionAmount/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/ParaTimesPage/TransactionAmount/__tests__/__snapshots__/index.test.tsx.snap
@@ -48,15 +48,7 @@ exports[`<TransactionAmount /> should render EVMc withdraw variant component 1`]
   data-testid="paraTime-content-description"
 >
   <span>
-    Please enter the amount of ROSE tokens you wish to transfer from the withdrawing wallet on the 
-  </span>
-  <strong>
-    <span>
-      Emerald
-    </span>
-  </strong>
-  <span>
-     (EVMc) ParaTime and then click "Next"
+    Please enter the amount of ROSE to withdraw and then click "Next"
   </span>
 </span>
 `;
@@ -625,15 +617,7 @@ exports[`<TransactionAmount /> should render component 1`] = `
         data-testid="paraTime-content-description"
       >
         <span>
-          Please enter the amount of ROSE tokens you wish to transfer to the receiving wallet on the 
-        </span>
-        <strong>
-          <span>
-            Cipher
-          </span>
-        </strong>
-        <span>
-            ParaTime and then click "Next"
+          Please enter the amount of ROSE to deposit and then click "Next"
         </span>
       </span>
     </div>

--- a/src/app/pages/ParaTimesPage/TransactionAmount/__tests__/index.test.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionAmount/__tests__/index.test.tsx
@@ -79,7 +79,7 @@ describe('<TransactionAmount />', () => {
     } as ParaTimesHook)
     render(<TransactionAmount />)
 
-    expect(screen.getByText('The wallet is empty. There is nothing to withdraw.')).toBeInTheDocument()
+    expect(screen.getByText('The account is empty. There is nothing to withdraw.')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('0')).toBeDisabled()
     expect(screen.getByRole('button', { name: 'MAX' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()

--- a/src/app/pages/ParaTimesPage/TransactionAmount/index.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionAmount/index.tsx
@@ -74,25 +74,35 @@ export const TransactionAmount = () => {
   return (
     <ParaTimeContent
       description={
-        <Trans
-          i18nKey="paraTimes.amount.description"
-          t={t}
-          values={{
-            actionType: isDepositing
-              ? t('paraTimes.amount.receiving', 'to the receiving')
-              : t('paraTimes.amount.withdrawing', 'from the withdrawing'),
-            paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
-            paraTime: paraTimeName,
-            ticker,
-          }}
-          defaults='Please enter the amount of {{ticker}} tokens you wish to transfer {{actionType}} wallet on the <strong>{{paraTime}}</strong> {{paratimeType}} ParaTime and then click "Next"'
-        />
+        isDepositing ? (
+          <Trans
+            i18nKey="paraTimes.amount.depositDescription"
+            t={t}
+            values={{
+              paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
+              paraTime: paraTimeName,
+              ticker,
+            }}
+            defaults='Please enter the amount of {{ticker}} to deposit and then click "Next"'
+          />
+        ) : (
+          <Trans
+            i18nKey="paraTimes.amount.withdrawDescription"
+            t={t}
+            values={{
+              paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
+              paraTime: paraTimeName,
+              ticker,
+            }}
+            defaults='Please enter the amount of {{ticker}} to withdraw and then click "Next"'
+          />
+        )
       }
       isLoading={isLoading}
     >
       {disabled && (
         <AlertBox color="status-warning">
-          {t('paraTimes.amount.emptyWallet', 'The wallet is empty. There is nothing to withdraw.')}
+          {t('paraTimes.amount.emptyAccount', 'The account is empty. There is nothing to withdraw.')}
         </AlertBox>
       )}
 

--- a/src/app/pages/ParaTimesPage/TransactionConfirmation/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/ParaTimesPage/TransactionConfirmation/__tests__/__snapshots__/index.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`<TransactionConfirmation /> should render EVMc withdraw variant compone
   data-testid="paraTime-content-description"
 >
   <span>
-    You are about to transfer 
+    You are about to withdraw 
   </span>
   <strong>
     <span>
@@ -72,7 +72,7 @@ exports[`<TransactionConfirmation /> should render EVMc withdraw variant compone
     </span>
   </strong>
   <span>
-     tokens from the withdrawing wallet on the 
+     from 
   </span>
   <strong>
     <span>
@@ -80,7 +80,7 @@ exports[`<TransactionConfirmation /> should render EVMc withdraw variant compone
     </span>
   </strong>
   <span>
-     (EVMc) ParaTime to: 
+     (EVMc) to 
   </span>
   <strong>
     <span>
@@ -530,7 +530,7 @@ exports[`<TransactionConfirmation /> should render component 1`] = `
         data-testid="paraTime-content-description"
       >
         <span>
-          You are about to transfer 
+          You are about to deposit 
         </span>
         <strong>
           <span>
@@ -538,7 +538,15 @@ exports[`<TransactionConfirmation /> should render component 1`] = `
           </span>
         </strong>
         <span>
-           tokens into the receiving wallet on the 
+           to 
+        </span>
+        <strong>
+          <span>
+            dummyAddress
+          </span>
+        </strong>
+        <span>
+           on 
         </span>
         <strong>
           <span>
@@ -546,13 +554,8 @@ exports[`<TransactionConfirmation /> should render component 1`] = `
           </span>
         </strong>
         <span>
-            ParaTime to: 
+           
         </span>
-        <strong>
-          <span>
-            dummyAddress
-          </span>
-        </strong>
       </span>
     </div>
     <div
@@ -575,7 +578,7 @@ exports[`<TransactionConfirmation /> should render component 1`] = `
                 <span
                   class="c3"
                 >
-                  Please confirm the transferring amount and the receiving wallet's address are correct and then click "Deposit" to make the transfer.
+                  Please confirm the deposit amount and the recipient address are correct and then click "Deposit".
                 </span>
               </span>
             </div>

--- a/src/app/pages/ParaTimesPage/TransactionConfirmation/__tests__/index.test.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionConfirmation/__tests__/index.test.tsx
@@ -90,7 +90,7 @@ describe('<TransactionConfirmation />', () => {
       .mockReturnValue([{ address: 'validatorAddress' }])
     render(<TransactionConfirmation />)
 
-    expect(screen.getByText('I confirm I want to transfer tokens to a validator address')).toBeInTheDocument()
+    expect(screen.getByText('I confirm I want to transfer ROSE to a validator address')).toBeInTheDocument()
   })
 
   it('should render additional confirmation checkbox when transferring tokens to foreign account', async () => {
@@ -99,7 +99,9 @@ describe('<TransactionConfirmation />', () => {
       .mockReturnValue(['addressInAccount'])
     render(<TransactionConfirmation />)
 
-    expect(screen.getByText('I confirm I want to transfer tokens to a foreign account')).toBeInTheDocument()
+    expect(
+      screen.getByText('I confirm I want to directly withdraw to an external account'),
+    ).toBeInTheDocument()
   })
 
   it('should submit transaction', async () => {
@@ -129,7 +131,7 @@ describe('<TransactionConfirmation />', () => {
     })
     render(<TransactionConfirmation />)
 
-    await userEvent.click(screen.getByRole('button', { name: 'Previous' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Back' }))
 
     expect(navigateToAmount).toHaveBeenCalled()
   })

--- a/src/app/pages/ParaTimesPage/TransactionConfirmation/index.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionConfirmation/index.tsx
@@ -67,21 +67,33 @@ export const TransactionConfirmation = () => {
   return (
     <ParaTimeContent
       description={
-        <Trans
-          i18nKey="paraTimes.confirmation.description"
-          t={t}
-          values={{
-            actionType: isDepositing
-              ? t('paraTimes.confirmation.receiving', 'into the receiving')
-              : t('paraTimes.confirmation.withdrawing', 'from the withdrawing'),
-            address: transactionForm.recipient,
-            paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
-            paraTime: paraTimeName,
-            ticker,
-            value: transactionForm.amount,
-          }}
-          defaults="You are about to transfer <strong>{{value}} {{ticker}}</strong> tokens {{actionType}} wallet on the <strong>{{paraTime}}</strong> {{paratimeType}} ParaTime to: <strong>{{address}}</strong>"
-        />
+        isDepositing ? (
+          <Trans
+            i18nKey="paraTimes.confirmation.depositDescription"
+            t={t}
+            values={{
+              address: transactionForm.recipient,
+              paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
+              paraTime: paraTimeName,
+              ticker,
+              value: transactionForm.amount,
+            }}
+            defaults="You are about to deposit <strong>{{value}} {{ticker}}</strong> to <strong>{{address}}</strong> on <strong>{{paraTime}}</strong> {{paratimeType}}"
+          />
+        ) : (
+          <Trans
+            i18nKey="paraTimes.confirmation.withdrawDescription"
+            t={t}
+            values={{
+              address: transactionForm.recipient,
+              paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
+              paraTime: paraTimeName,
+              ticker,
+              value: transactionForm.amount,
+            }}
+            defaults="You are about to withdraw <strong>{{value}} {{ticker}}</strong> from <strong>{{paraTime}}</strong> {{paratimeType}} to <strong>{{address}}</strong>"
+          />
+        )
       }
       isLoading={isLoading}
     >
@@ -96,11 +108,14 @@ export const TransactionConfirmation = () => {
             checked={transactionForm.confirmTransferToValidator}
             description={t(
               'paraTimes.confirmation.confirmTransferToValidatorDescription',
-              'This is a validator wallet address. Transfers to this address do not stake your funds with the validator.',
+              'This is a validator wallet address. Transfers to this address do not stake your funds to the validator.',
             )}
             label={t(
               'paraTimes.confirmation.confirmTransferToValidatorLabel',
-              'I confirm I want to transfer tokens to a validator address',
+              'I confirm I want to transfer {{ticker}} to a validator address',
+              {
+                ticker,
+              },
             )}
             name="confirmTransferToValidator"
           />
@@ -113,16 +128,22 @@ export const TransactionConfirmation = () => {
               isDepositing
                 ? t(
                     'paraTimes.confirmation.confirmDepositToForeignAccountDescription',
-                    'Destination account is not in your wallet! We recommend you always deposit into your own ParaTime account, then transfer from there.',
+                    'Destination address does not match any of the accounts in your wallet! Some services such as exchanges, may not support direct deposits to fund your account. For better compatibility, we strongly recommend that you first deposit to your ParaTime account and then transfer {{ticker}} to the destination address.',
+                    {
+                      ticker,
+                    },
                   )
                 : t(
                     'paraTimes.confirmation.confirmWithdrawToForeignAccountDescription',
-                    'Destination account is not in your wallet! Some automated systems, e.g., those used for tracking exchange deposits, may be unable to accept funds through ParaTime withdrawals. For better compatibility, cancel, withdraw into your own account, and transfer from there.',
+                    'Destination address does not match any of the accounts in your wallet! Some services such as exchanges, may not support direct withdrawals to fund the account. For better compatibility, we strongly recommend that you first withdraw to your consensus account and then transfer {{ticker}} to the destination address.',
+                    {
+                      ticker,
+                    },
                   )
             }
             label={t(
               'paraTimes.confirmation.confirmTransferToForeignAccount',
-              'I confirm I want to transfer tokens to a foreign account',
+              'I confirm I want to directly withdraw to an external account',
             )}
             name="confirmTransferToForeignAccount"
           />
@@ -134,11 +155,11 @@ export const TransactionConfirmation = () => {
             isDepositing
               ? t(
                   'paraTimes.confirmation.confirmDepositDescription',
-                  'Please confirm the transferring amount and the receiving wallet\'s address are correct and then click "Deposit" to make the transfer.',
+                  'Please confirm the deposit amount and the recipient address are correct and then click "Deposit".',
                 )
               : t(
                   'paraTimes.confirmation.confirmWithdrawDescription',
-                  'Please confirm the withdrawing amount and the withdrawing wallet\'s address are correct and then click "Withdraw" to make the transfer.',
+                  'Please confirm the withdrawal amount and the recipient address are correct and then click "Withdraw".',
                 )
           }
           label={t(

--- a/src/app/pages/ParaTimesPage/TransactionError/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/ParaTimesPage/TransactionError/__tests__/__snapshots__/index.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`<TransactionError /> should render EVMc withdraw variant component 1`] 
   data-testid="paraTime-content-description"
 >
   <span>
-    Transaction failed. We were not able to transfer 
+    Transaction failed. We were not able to complete withdrawal of 
   </span>
   <strong>
     <span>
@@ -60,7 +60,7 @@ exports[`<TransactionError /> should render EVMc withdraw variant component 1`] 
     </span>
   </strong>
   <span>
-     tokens from the following wallet on the 
+     from 
   </span>
   <strong>
     <span>
@@ -68,7 +68,7 @@ exports[`<TransactionError /> should render EVMc withdraw variant component 1`] 
     </span>
   </strong>
   <span>
-     (EVMc) ParaTime: 
+     (EVMc) to 
   </span>
   <strong>
     <span>
@@ -430,7 +430,7 @@ exports[`<TransactionError /> should render component 1`] = `
         data-testid="paraTime-content-description"
       >
         <span>
-          Transaction failed. We were not able to transfer 
+          Transaction failed. We were not able to complete deposit of 
         </span>
         <strong>
           <span>
@@ -438,7 +438,15 @@ exports[`<TransactionError /> should render component 1`] = `
           </span>
         </strong>
         <span>
-           tokens into the following wallet on the 
+           to 
+        </span>
+        <strong>
+          <span>
+            dummyAddress
+          </span>
+        </strong>
+        <span>
+           on 
         </span>
         <strong>
           <span>
@@ -446,13 +454,8 @@ exports[`<TransactionError /> should render component 1`] = `
           </span>
         </strong>
         <span>
-            ParaTime: 
+           
         </span>
-        <strong>
-          <span>
-            dummyAddress
-          </span>
-        </strong>
       </span>
     </div>
     <div
@@ -500,7 +503,7 @@ exports[`<TransactionError /> should render component 1`] = `
             class="c13"
             type="button"
           >
-            Navigate to ParaTimes Transfers
+            Navigate to ParaTime Transfers
           </button>
         </div>
       </div>

--- a/src/app/pages/ParaTimesPage/TransactionError/__tests__/index.test.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionError/__tests__/index.test.tsx
@@ -59,7 +59,7 @@ describe('<TransactionError />', () => {
     })
     render(<TransactionError />)
 
-    await userEvent.click(screen.getByRole('button', { name: 'Navigate to ParaTimes Transfers' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Navigate to ParaTime Transfers' }))
 
     expect(clearTransactionForm).toHaveBeenCalled()
   })
@@ -72,7 +72,7 @@ describe('<TransactionError />', () => {
     })
     render(<TransactionError />)
 
-    await userEvent.click(screen.getByRole('button', { name: 'Previous' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Back' }))
 
     expect(navigateToConfirmation).toHaveBeenCalled()
   })

--- a/src/app/pages/ParaTimesPage/TransactionError/index.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionError/index.tsx
@@ -25,21 +25,33 @@ export const TransactionError = () => {
   return (
     <ParaTimeContent
       description={
-        <Trans
-          i18nKey="paraTimes.error.description"
-          t={t}
-          values={{
-            address: transactionForm.recipient,
-            paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
-            paraTime: paraTimeName,
-            preposition: isDepositing
-              ? t('paraTimes.summary.into', 'into')
-              : t('paraTimes.summary.from', 'from'),
-            ticker,
-            value: transactionForm.amount,
-          }}
-          defaults="Transaction failed. We were not able to transfer <strong>{{value}} {{ticker}}</strong> tokens {{preposition}} the following wallet on the <strong>{{paraTime}}</strong> {{paratimeType}} ParaTime: <strong>{{address}}</strong>"
-        />
+        isDepositing ? (
+          <Trans
+            i18nKey="paraTimes.error.depositDescription"
+            t={t}
+            values={{
+              address: transactionForm.recipient,
+              paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
+              paraTime: paraTimeName,
+              ticker,
+              value: transactionForm.amount,
+            }}
+            defaults="Transaction failed. We were not able to complete deposit of <strong>{{value}} {{ticker}}</strong> to <strong>{{address}}</strong> on <strong>{{paraTime}}</strong> {{paratimeType}}"
+          />
+        ) : (
+          <Trans
+            i18nKey="paraTimes.error.withdrawDescription"
+            t={t}
+            values={{
+              address: transactionForm.recipient,
+              paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
+              paraTime: paraTimeName,
+              ticker,
+              value: transactionForm.amount,
+            }}
+            defaults="Transaction failed. We were not able to complete withdrawal of <strong>{{value}} {{ticker}}</strong> from <strong>{{paraTime}}</strong> {{paratimeType}} to <strong>{{address}}</strong>"
+          />
+        )
       }
     >
       {transactionError && (
@@ -52,7 +64,7 @@ export const TransactionError = () => {
       )}
 
       <ParaTimeFormFooter
-        primaryLabel={t('paraTimes.summary.navigate', 'Navigate to ParaTimes Transfers')}
+        primaryLabel={t('paraTimes.summary.navigate', 'Navigate to ParaTime Transfers')}
         primaryAction={clearTransactionForm}
         secondaryAction={navigateToConfirmation}
         withNotice={isEvmcParaTime}

--- a/src/app/pages/ParaTimesPage/TransactionRecipient/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/ParaTimesPage/TransactionRecipient/__tests__/__snapshots__/index.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`<TransactionRecipient /> should render EVMc withdraw variant component 
   class="c0"
   data-testid="paraTime-content-description"
 >
-  Please enter the private key of the withdrawing wallet and the receiving address on Consensus, and then click "Next"
+  Please enter the private key of the account on ParaTime, the recipient address on consensus and click "Next"
 </span>
 `;
 
@@ -357,7 +357,7 @@ exports[`<TransactionRecipient /> should render component 1`] = `
         data-testid="paraTime-content-description"
       >
         <span>
-          Please enter the address of the receiving wallet on the 
+          Please enter the recipient address on 
         </span>
         <strong>
           <span>
@@ -365,7 +365,7 @@ exports[`<TransactionRecipient /> should render component 1`] = `
           </span>
         </strong>
         <span>
-            ParaTime and then click "Next"
+            and then click "Next"
         </span>
       </span>
     </div>
@@ -461,6 +461,6 @@ exports[`<TransactionRecipient /> should render withdraw variant component 1`] =
   class="c0"
   data-testid="paraTime-content-description"
 >
-  Please enter the receiving address on Consensus and then click "Next"
+  Please enter the recipient address on consensus and click "Next"
 </span>
 `;

--- a/src/app/pages/ParaTimesPage/TransactionRecipient/index.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionRecipient/index.tsx
@@ -37,17 +37,17 @@ export const TransactionRecipient = () => {
               paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
               paraTime: paraTimeName,
             }}
-            defaults='Please enter the address of the receiving wallet on the <strong>{{paraTime}}</strong> {{paratimeType}} ParaTime and then click "Next"'
+            defaults='Please enter the recipient address on <strong>{{paraTime}}</strong> {{paratimeType}} and then click "Next"'
           />
         ) : isEvmcParaTime ? (
           t(
             'paraTimes.recipient.evmcWithdrawDescription',
-            'Please enter the private key of the withdrawing wallet and the receiving address on Consensus, and then click "Next"',
+            'Please enter the private key of the account on ParaTime, the recipient address on consensus and click "Next"',
           )
         ) : (
           t(
             'paraTimes.recipient.withdrawDescription',
-            'Please enter the receiving address on Consensus and then click "Next"',
+            'Please enter the recipient address on consensus and click "Next"',
           )
         )
       }

--- a/src/app/pages/ParaTimesPage/TransactionSummary/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/ParaTimesPage/TransactionSummary/__tests__/__snapshots__/index.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`<TransactionSummary /> should render EVMc withdraw variant component 1`
   data-testid="paraTime-content-description"
 >
   <span>
-    You have successfully transferred 
+    You have successfully withdrawn 
   </span>
   <strong>
     <span>
@@ -40,7 +40,7 @@ exports[`<TransactionSummary /> should render EVMc withdraw variant component 1`
     </span>
   </strong>
   <span>
-     tokens from the following wallet on the 
+     from 
   </span>
   <strong>
     <span>
@@ -48,7 +48,7 @@ exports[`<TransactionSummary /> should render EVMc withdraw variant component 1`
     </span>
   </strong>
   <span>
-     (EVMc) ParaTime: 
+     (EVMc) to 
   </span>
   <strong>
     <span>
@@ -323,7 +323,7 @@ exports[`<TransactionSummary /> should render component 1`] = `
         data-testid="paraTime-content-description"
       >
         <span>
-          You have successfully transferred 
+          You have successfully deposited 
         </span>
         <strong>
           <span>
@@ -331,7 +331,15 @@ exports[`<TransactionSummary /> should render component 1`] = `
           </span>
         </strong>
         <span>
-           tokens into the following wallet on the 
+           to 
+        </span>
+        <strong>
+          <span>
+            dummyAddress
+          </span>
+        </strong>
+        <span>
+           on 
         </span>
         <strong>
           <span>
@@ -339,13 +347,8 @@ exports[`<TransactionSummary /> should render component 1`] = `
           </span>
         </strong>
         <span>
-            ParaTime: 
+           
         </span>
-        <strong>
-          <span>
-            dummyAddress
-          </span>
-        </strong>
       </span>
     </div>
     <div
@@ -380,7 +383,7 @@ exports[`<TransactionSummary /> should render component 1`] = `
             class="c9"
             type="button"
           >
-            Navigate to ParaTimes Transfers
+            Navigate to ParaTime Transfers
           </button>
         </div>
       </div>

--- a/src/app/pages/ParaTimesPage/TransactionSummary/index.tsx
+++ b/src/app/pages/ParaTimesPage/TransactionSummary/index.tsx
@@ -14,21 +14,33 @@ export const TransactionSummary = () => {
   return (
     <ParaTimeContent
       description={
-        <Trans
-          i18nKey="paraTimes.summary.description"
-          t={t}
-          values={{
-            address: transactionForm.recipient,
-            paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
-            paraTime: paraTimeName,
-            preposition: isDepositing
-              ? t('paraTimes.summary.into', 'into')
-              : t('paraTimes.summary.from', 'from'),
-            ticker,
-            value: transactionForm.amount,
-          }}
-          defaults="You have successfully transferred <strong>{{value}} {{ticker}}</strong> tokens {{preposition}} the following wallet on the <strong>{{paraTime}}</strong> {{paratimeType}} ParaTime: <strong>{{address}}</strong>"
-        />
+        isDepositing ? (
+          <Trans
+            i18nKey="paraTimes.summary.depositDescription"
+            t={t}
+            values={{
+              address: transactionForm.recipient,
+              paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
+              paraTime: paraTimeName,
+              ticker,
+              value: transactionForm.amount,
+            }}
+            defaults="You have successfully deposited <strong>{{value}} {{ticker}}</strong> to <strong>{{address}}</strong> on <strong>{{paraTime}}</strong> {{paratimeType}}"
+          />
+        ) : (
+          <Trans
+            i18nKey="paraTimes.summary.withdrawDescription"
+            t={t}
+            values={{
+              address: transactionForm.recipient,
+              paratimeType: isEvmcParaTime ? t('paraTimes.common.evmcType', '(EVMc)') : '',
+              paraTime: paraTimeName,
+              ticker,
+              value: transactionForm.amount,
+            }}
+            defaults="You have successfully withdrawn <strong>{{value}} {{ticker}}</strong> from <strong>{{paraTime}}</strong> {{paratimeType}} to <strong>{{address}}</strong>"
+          />
+        )
       }
     >
       <Box margin={{ bottom: 'medium' }}>
@@ -36,7 +48,7 @@ export const TransactionSummary = () => {
       </Box>
 
       <ParaTimeFormFooter
-        primaryLabel={t('paraTimes.summary.navigate', 'Navigate to ParaTimes Transfers')}
+        primaryLabel={t('paraTimes.summary.navigate', 'Navigate to ParaTime Transfers')}
         primaryAction={clearTransactionForm}
         withNotice={isEvmcParaTime}
       />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -45,7 +45,7 @@
         "total": "Total"
       },
       "noTransactionFound": "No transactions found.",
-      "noWalletIsOpen": "To send, receive, stake and swap {{ ticker }} tokens, <HomeLink>open your wallet!</HomeLink>",
+      "noWalletIsOpen": "To send, receive, stake and swap {{ticker}} tokens, <HomeLink>open your wallet!</HomeLink>",
       "notYourAccount": "This is not your account.",
       "yourAccount": "This is your account."
     },
@@ -179,7 +179,7 @@
     }
   },
   "infoBox": {
-    "valueCopied": "{{ label }} copied."
+    "valueCopied": "{{label}} copied."
   },
   "ledger": {
     "extension": {
@@ -217,13 +217,13 @@
     },
     "header": "How do you want to open your wallet?",
     "importAccounts": {
-      "accountCounter": "{{ count }} accounts selected",
+      "accountCounter": "{{count}} accounts selected",
       "accountCounter_one": "One account selected",
-      "accountCounter_plural": "{{ count }} accounts selected",
+      "accountCounter_plural": "{{count}} accounts selected",
       "accountCounter_zero": "No account selected",
       "next": "Next",
       "openWallets": "Open",
-      "pageNumber": "Page {{ pageNum }} of {{ totalPages }}",
+      "pageNumber": "Page {{pageNum}} of {{totalPages}}",
       "prev": "Prev",
       "selectWallets": "Select accounts to open"
     },
@@ -255,72 +255,70 @@
     "amount": {
       "advanced": "Advanced",
       "available": "Available:",
-      "description": "Please enter the amount of {{ticker}} tokens you wish to transfer {{actionType}} wallet on the <strong>{{paraTime}}</strong> {{paratimeType}} ParaTime and then click \"Next\"",
-      "emptyWallet": "The wallet is empty. There is nothing to withdraw.",
+      "depositDescription": "Please enter the amount of {{ticker}} to deposit and then click \"Next\"",
+      "emptyAccount": "The account is empty. There is nothing to withdraw.",
       "feeAmountPlaceholder": "Fee Amount (nano {{ticker}})",
       "feeGasPlaceholder": "Fee Gas",
       "max": "MAX",
-      "receiving": "to the receiving",
       "tooltip": "Max value may be decreased by the fee",
-      "withdrawing": "from the withdrawing"
+      "withdrawDescription": "Please enter the amount of {{ticker}} to withdraw and then click \"Next\""
     },
     "common": {
       "cipher": "Cipher",
       "depositHeader": "Deposit to ParaTime",
       "emerald": "Emerald",
       "evmcType": "(EVMc)",
-      "header": "ParaTimes Transfers",
+      "header": "ParaTime Transfers",
       "sapphire": "Sapphire",
       "withdrawHeader": "Withdraw from ParaTime"
     },
     "confirmation": {
-      "confirmDepositDescription": "Please confirm the transferring amount and the receiving wallet's address are correct and then click \"Deposit\" to make the transfer.",
-      "confirmDepositToForeignAccountDescription": "Destination account is not in your wallet! We recommend you always deposit into your own ParaTime account, then transfer from there.",
+      "confirmDepositDescription": "Please confirm the deposit amount and the recipient address are correct and then click \"Deposit\".",
+      "confirmDepositToForeignAccountDescription": "Destination address does not match any of the accounts in your wallet! Some services such as exchanges, may not support direct deposits to fund your account. For better compatibility, we strongly recommend that you first deposit to your ParaTime account and then transfer {{ticker}} to the destination address.",
       "confirmTransferLabel": "I confirm the amount and the address are correct",
-      "confirmTransferToForeignAccount": "I confirm I want to transfer tokens to a foreign account",
-      "confirmTransferToValidatorDescription": "This is a validator wallet address. Transfers to this address do not stake your funds with the validator.",
-      "confirmTransferToValidatorLabel": "I confirm I want to transfer tokens to a validator address",
-      "confirmWithdrawDescription": "Please confirm the withdrawing amount and the withdrawing wallet's address are correct and then click \"Withdraw\" to make the transfer.",
-      "confirmWithdrawToForeignAccountDescription": "Destination account is not in your wallet! Some automated systems, e.g., those used for tracking exchange deposits, may be unable to accept funds through ParaTime withdrawals. For better compatibility, cancel, withdraw into your own account, and transfer from there.",
+      "confirmTransferToForeignAccount": "I confirm I want to directly withdraw to an external account",
+      "confirmTransferToValidatorDescription": "This is a validator wallet address. Transfers to this address do not stake your funds to the validator.",
+      "confirmTransferToValidatorLabel": "I confirm I want to transfer {{ticker}} to a validator address",
+      "confirmWithdrawDescription": "Please confirm the withdrawal amount and the recipient address are correct and then click \"Withdraw\".",
+      "confirmWithdrawToForeignAccountDescription": "Destination address does not match any of the accounts in your wallet! Some services such as exchanges, may not support direct withdrawals to fund the account. For better compatibility, we strongly recommend that you first withdraw to your consensus account and then transfer {{ticker}} to the destination address.",
+      "depositDescription": "You are about to deposit <strong>{{value}} {{ticker}}</strong> to <strong>{{address}}</strong> on <strong>{{paraTime}}</strong> {{paratimeType}}",
       "depositLabel": "Deposit",
-      "description": "You are about to transfer <strong>{{value}} {{ticker}}</strong> tokens {{actionType}} wallet on the <strong>{{paraTime}}</strong> {{paratimeType}} ParaTime to: <strong>{{address}}</strong>",
-      "receiving": "into the receiving",
-      "withdrawLabel": "Withdraw",
-      "withdrawing": "from the withdrawing"
+      "withdrawDescription": "You are about to withdraw <strong>{{value}} {{ticker}}</strong> from <strong>{{paraTime}}</strong> {{paratimeType}} to <strong>{{address}}</strong>",
+      "withdrawLabel": "Withdraw"
     },
     "error": {
-      "description": "Transaction failed. We were not able to transfer <strong>{{value}} {{ticker}}</strong> tokens {{preposition}} the following wallet on the <strong>{{paraTime}}</strong> {{paratimeType}} ParaTime: <strong>{{address}}</strong>"
+      "depositDescription": "Transaction failed. We were not able to complete deposit of <strong>{{value}} {{ticker}}</strong> to <strong>{{address}}</strong> on <strong>{{paraTime}}</strong> {{paratimeType}}",
+      "withdrawDescription": "Transaction failed. We were not able to complete withdrawal of <strong>{{value}} {{ticker}}</strong> from <strong>{{paraTime}}</strong> {{paratimeType}} to <strong>{{address}}</strong>"
     },
     "footer": {
+      "back": "Back",
       "next": "Next",
-      "notice": "* EVMc - Ethereum Virtual Machine compatible",
-      "previous": "Previous"
+      "notice": "* EVMc - compatible with Ethereum Virtual Machine"
     },
     "pageInaccessible": "Transfers are not available.",
     "recipient": {
-      "depositDescription": "Please enter the address of the receiving wallet on the <strong>{{paraTime}}</strong> {{paratimeType}} ParaTime and then click \"Next\"",
-      "evmcWithdrawDescription": "Please enter the private key of the withdrawing wallet and the receiving address on Consensus, and then click \"Next\"",
+      "depositDescription": "Please enter the recipient address on <strong>{{paraTime}}</strong> {{paratimeType}} and then click \"Next\"",
+      "evmcWithdrawDescription": "Please enter the private key of the account on ParaTime, the recipient address on consensus and click \"Next\"",
       "placeholder": "0x...",
       "privateKeyPlaceholder": "Enter Ethereum-compatible private key",
-      "withdrawDescription": "Please enter the receiving address on Consensus and then click \"Next\""
+      "withdrawDescription": "Please enter the recipient address on consensus and click \"Next\""
     },
     "selection": {
       "cancel": "Cancel transfer",
-      "depositDescription": "Please select which ParaTime you wish to transfer your {{ticker}} tokens to and then click \"Next\".",
+      "depositDescription": "Please select which ParaTime you wish to deposit your {{ticker}} to and then click \"Next\".",
       "evmc": "EVMc",
       "select": "Select a ParaTime",
-      "withdrawDescription": "Please select which ParaTime you wish to withdraw your {{ticker}} tokens from and then click \"Next\"."
+      "withdrawDescription": "Please select which ParaTime you wish to withdraw your {{ticker}} from and then click \"Next\"."
     },
     "summary": {
-      "description": "You have successfully transferred <strong>{{value}} {{ticker}}</strong> tokens {{preposition}} the following wallet on the <strong>{{paraTime}}</strong> {{paratimeType}} ParaTime: <strong>{{address}}</strong>",
-      "from": "from",
-      "into": "into",
-      "navigate": "Navigate to ParaTimes Transfers"
+      "depositDescription": "You have successfully deposited <strong>{{value}} {{ticker}}</strong> to <strong>{{address}}</strong> on <strong>{{paraTime}}</strong> {{paratimeType}}",
+      "navigate": "Navigate to ParaTime Transfers",
+      "withdrawDescription": "You have successfully withdrawn <strong>{{value}} {{ticker}}</strong> from <strong>{{paraTime}}</strong> {{paratimeType}} to <strong>{{address}}</strong>"
     },
     "transfers": {
       "deposit": "Deposit to ParaTime",
       "depositDisabled": "You don't have any {{ticker}} tokens to transfer",
-      "description": "Use the \"Deposit\" option to transfer your {{ticker}} tokens from Consensus to a ParaTime of your choosing or \"Withdraw\" option to transfer your {{ticker}} tokens from a ParaTime back to Consensus.",
+      "description": "Click on the \"Deposit\" button to deposit your {{ticker}} from consensus to a ParaTime of your choice or \"Withdraw\" to withdraw your {{ticker}} from a ParaTime back to consensus.",
       "withdraw": "Withdraw from ParaTime"
     },
     "unsupportedFormStep": "Unsupported form step",


### PR DESCRIPTION
This PR fixes inconsistencies of typical ParaTime terms and operations. Also adopts strings for easier translation:
- correctly use terms "account" and "wallet". Wallet = collection of accounts. Empty wallet means there are no accounts in it. Empty account means the balance is zero.
- try to avoid terms "ParaTime" and "token" where possible. e.g. Emerald Paratime -> Emerald or Oasis Emerald. Withdraw 200 ROSE tokens -> Withdraw 200 ROSE.
- there are three types of token transactions currently: transfer (consensus->consensus, ParaTime->ParaTime), deposit (consensus->ParaTime) and withdrawal (ParaTime->consensus). Do not use term "transfer" in the context of deposits/withdrawals.
- for placeholders react-i18next uses {{someTerm}} [without surrounding spaces](https://www.i18next.com/translation-function/interpolation). The wallet actually compiled and worked, but it's a mess in Transifex then which doesn't recognize it.
- consensus is lower-case
- use standard Next/Back verbs in the wizzard instead of Next/Previous