### PR TITLE
Remove `yarn build-preview` (no longer needed after a53a8ef)

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,7 +4,7 @@
 
 Staging:
 - checkout `master` branch
-- `yarn install --frozen-lockfile && yarn build-preview`
+- `yarn install --frozen-lockfile && yarn build`
 - deploy to <https://wallet.stg.oasis.io/>
 
 Production:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "scripts": {
     "build": "node ./internals/scripts/build-web.js",
-    "build-preview": "yarn run build",
     "build:ext": "node ./internals/scripts/build-ext.js",
     "clean": "rm -rf build/ .parcel-cache",
     "clean:ext": "rm -rf build-ext/ .parcel-cache",


### PR DESCRIPTION
Related to https://github.com/oasisprotocol/oasis-wallet-web/pull/1447

(Cloudflare configuration needs to be updated)