### PR TITLE
Hide banner in published extension

### DIFF
--- a/src/app/components/BuildBanner/index.tsx
+++ b/src/app/components/BuildBanner/index.tsx
@@ -6,6 +6,7 @@ import { AlertBox } from 'app/components/AlertBox'
 import { buildBannerZIndex } from '../../../styles/theme/elementSizes'
 import { AnchorLink } from '../AnchorLink'
 import styled from 'styled-components'
+import { deploys } from '../../../config'
 
 const StickyBanner = styled(Box)`
   position: sticky;
@@ -16,7 +17,7 @@ const StickyBanner = styled(Box)`
 export const BuildBanner = () => {
   const { t } = useTranslation()
 
-  if (window.location.host === 'wallet.oasis.io') {
+  if (window.location.origin === deploys.production) {
     return (
       <StickyBanner>
         <AlertBox status="ok" center icon={<Info size="20px" color="currentColor" />}>
@@ -35,7 +36,7 @@ export const BuildBanner = () => {
     )
   }
 
-  if (window.location.host === 'wallet.stg.oasis.io') {
+  if (window.location.origin === deploys.staging) {
     return (
       <StickyBanner>
         <AlertBox status="warning" center icon={<Alert size="20px" color="currentColor" />}>

--- a/src/app/components/BuildBanner/index.tsx
+++ b/src/app/components/BuildBanner/index.tsx
@@ -17,6 +17,10 @@ const StickyBanner = styled(Box)`
 export const BuildBanner = () => {
   const { t } = useTranslation()
 
+  if (window.location.origin === deploys.extension) {
+    return null
+  }
+
   if (window.location.origin === deploys.production) {
     return (
       <StickyBanner>

--- a/src/config.ts
+++ b/src/config.ts
@@ -172,3 +172,8 @@ export const paraTimesConfig: ParaTimesConfig = {
 
 // https://github.com/mozilla/webextension-polyfill/blob/6e3e26c/src/browser-polyfill.js#L9
 export const runtimeIs = (window as any).chrome?.runtime?.id ? 'extension' : 'webapp'
+
+export const deploys = {
+  production: 'https://wallet.oasis.io',
+  staging: 'https://wallet.stg.oasis.io',
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -176,4 +176,5 @@ export const runtimeIs = (window as any).chrome?.runtime?.id ? 'extension' : 'we
 export const deploys = {
   production: 'https://wallet.oasis.io',
   staging: 'https://wallet.stg.oasis.io',
+  extension: 'chrome-extension://ppdadbejkmjnefldpcdjhnkpbjkikoip',
 }


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-wallet-web/issues/1459

To preview this, you can add currently-published-extension's public key to manifest.json:
```json
"key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAybK17ag+0PwHWbYEE36o+SmN35mcXj3RoM8ZBIlOjetdV3uqG8vdzv0YZ2Td21Y0il+1IKt/d9kslRT67C/S2fZ3XKAf96o+j+9/mgdOBwkL7m8XeALzBCYI3sSPnHf36iZu0w9FM9enUFHmq4HPNsT7BqTTEkdtDRRU4JHb+GGLjWvpyB1WIuv7UIJu64zUcZXsGVWZojRG2eISBJZxaItTuFS1210PebsS85++eeHLPWwMMp7d3UXOZpDYoyS07orZJd4c54hZaMNCKKZ5zbupwEuDvSANvEiuxpXe+hHLRnxOlpmhnj+XqkMBTgTFC57b75vhnvOCNbZ/ylW9xwIDAQAB"
```

then remove dev extension and reinstall build-dev extension