### PR TITLE
Avoid playwright's buggy test.fail() skipping tests

### DIFF
--- a/playwright/tests/fiat.spec.ts
+++ b/playwright/tests/fiat.spec.ts
@@ -78,8 +78,6 @@ test.describe('Fiat on-ramp', () => {
 
   test('Sandbox should block top-navigation from iframe and fail', async ({ page, baseURL }) => {
     test.fail()
-    expect(baseURL).toBe('http://localhost:5000')
-    expect((await page.request.head('/')).headers()).toHaveProperty('content-security-policy')
     await page.route('https://global.transak.com/*', route =>
       route.fulfill({
         body: `<script>window.top.location = 'https://phishing-wallet.com/';</script>`,

--- a/playwright/tests/fiat.spec.ts
+++ b/playwright/tests/fiat.spec.ts
@@ -62,7 +62,7 @@ test.describe('Fiat on-ramp', () => {
     test.fail()
     expect(baseURL).toBe('http://localhost:5000')
     expect((await page.request.head('/')).headers()).toHaveProperty('content-security-policy')
-    await expectNoErrorsInConsole(page)
+    // await expectNoErrorsInConsole(page) // TODO: revert when playwright doesn't skip other tests because of this
     await setup(page)
     await page.route('https://global.transak.com/*', route =>
       route.fulfill({
@@ -74,16 +74,19 @@ test.describe('Fiat on-ramp', () => {
     )
     await page.route('https://phishing-transak.com/', route => route.fulfill({ body: `phishing` }))
 
-    await page
-      .getByText(
-        'I understand that I’m using a third-party solution and Oasis* does not carry any responsibility over the usage of this solution.',
-      )
-      .click()
+    await Promise.all([
+      page
+        .getByText(
+          'I understand that I’m using a third-party solution and Oasis* does not carry any responsibility over the usage of this solution.',
+        )
+        .click(),
+      page.waitForRequest('https://phishing-transak.com/'),
+    ])
   })
 
   test('Sandbox should block top-navigation from iframe and fail', async ({ page, baseURL }) => {
     test.fail()
-    await expectNoErrorsInConsole(page)
+    // await expectNoErrorsInConsole(page) // TODO: revert when playwright doesn't skip other tests because of this
     await setup(page)
     await page.route('https://global.transak.com/*', route =>
       route.fulfill({
@@ -92,11 +95,14 @@ test.describe('Fiat on-ramp', () => {
     )
     await page.route('https://phishing-wallet.com/', route => route.fulfill({ body: `phishing` }))
 
-    await page
-      .getByText(
-        'I understand that I’m using a third-party solution and Oasis* does not carry any responsibility over the usage of this solution.',
-      )
-      .click()
+    await Promise.all([
+      page
+        .getByText(
+          'I understand that I’m using a third-party solution and Oasis* does not carry any responsibility over the usage of this solution.',
+        )
+        .click(),
+      page.waitForRequest('https://phishing-wallet.com/'),
+    ])
     await expect(page).toHaveURL('https://phishing-wallet.com/')
   })
 

--- a/playwright/tests/fiat.spec.ts
+++ b/playwright/tests/fiat.spec.ts
@@ -1,14 +1,13 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
 import { privateKey, privateKeyAddress } from '../utils/test-inputs'
 import { fillPrivateKeyWithoutPassword } from '../utils/fillPrivateKey'
 import { warnSlowApi } from '../utils/warnSlowApi'
 import { mockApi } from '../utils/mockApi'
 import { expectNoErrorsInConsole } from '../utils/expectNoErrorsInConsole'
 
-test.beforeEach(async ({ page }) => {
+async function setup(page: Page) {
   await warnSlowApi(page)
   await mockApi(page, 500000000000)
-  await expectNoErrorsInConsole(page)
 
   await page.goto('/open-wallet/private-key')
   await fillPrivateKeyWithoutPassword(page, {
@@ -20,12 +19,14 @@ test.beforeEach(async ({ page }) => {
   await expect(page.getByTestId('account-selector')).toBeVisible()
   await page.getByRole('link', { name: 'Buy' }).click()
   await expect(page.getByRole('heading', { name: 'Buy ROSE' })).toBeVisible()
-})
+}
 
 test.describe('Fiat on-ramp', () => {
   test('Content-Security-Policy should allow embedded Transak widget', async ({ page, baseURL }) => {
     expect(baseURL).toBe('http://localhost:5000')
     expect((await page.request.head('/')).headers()).toHaveProperty('content-security-policy')
+    await expectNoErrorsInConsole(page)
+    await setup(page)
     await page
       .getByText(
         'I understand that I’m using a third-party solution and Oasis* does not carry any responsibility over the usage of this solution.',
@@ -39,6 +40,8 @@ test.describe('Fiat on-ramp', () => {
   test('Content-Security-Policy should also allow Transak staging iframe', async ({ page, baseURL }) => {
     expect(baseURL).toBe('http://localhost:5000')
     expect((await page.request.head('/')).headers()).toHaveProperty('content-security-policy')
+    await expectNoErrorsInConsole(page)
+    await setup(page)
     await page.route('https://global.transak.com/*', route =>
       route.fulfill({
         status: 301,
@@ -59,6 +62,8 @@ test.describe('Fiat on-ramp', () => {
     test.fail()
     expect(baseURL).toBe('http://localhost:5000')
     expect((await page.request.head('/')).headers()).toHaveProperty('content-security-policy')
+    await expectNoErrorsInConsole(page)
+    await setup(page)
     await page.route('https://global.transak.com/*', route =>
       route.fulfill({
         status: 301,
@@ -78,6 +83,8 @@ test.describe('Fiat on-ramp', () => {
 
   test('Sandbox should block top-navigation from iframe and fail', async ({ page, baseURL }) => {
     test.fail()
+    await expectNoErrorsInConsole(page)
+    await setup(page)
     await page.route('https://global.transak.com/*', route =>
       route.fulfill({
         body: `<script>window.top.location = 'https://phishing-wallet.com/';</script>`,
@@ -96,6 +103,8 @@ test.describe('Fiat on-ramp', () => {
   test('Permissions-Policy should contain Transak permissions', async ({ page, baseURL }) => {
     expect(baseURL).toBe('http://localhost:5000')
     expect((await page.request.head('/')).headers()).toHaveProperty('permissions-policy')
+    await expectNoErrorsInConsole(page)
+    await setup(page)
     const permissionsPolicy = (await page.request.head('/'))
       .headers()
       ['permissions-policy'].split(',')

--- a/playwright/tests/fiat.spec.ts
+++ b/playwright/tests/fiat.spec.ts
@@ -111,12 +111,11 @@ test.describe('Fiat on-ramp', () => {
     expect(transakPermissions).toBeTruthy()
 
     for (const permission of transakPermissions!.split(';').map(permission => permission.trim())) {
-      expect(permissionsPolicy.find(rule => rule.startsWith(`${permission}=`))).toContain(
-        'https://global.transak.com',
-      )
-      expect(permissionsPolicy.find(rule => rule.startsWith(`${permission}=`))).toContain(
-        'https://global-stg.transak.com',
-      )
+      const rule = permissionsPolicy.find(rule => rule.startsWith(`${permission}=`))!
+      expect(
+        rule.endsWith('=*') ||
+          (rule.includes('https://global.transak.com') && rule.includes('https://global-stg.transak.com')),
+      ).toBeTruthy()
     }
   })
 })


### PR DESCRIPTION
A lot of playwright tests on master are being skipped, and CI doesn't fail
https://github.com/oasisprotocol/oasis-wallet-web/actions/runs/5826329626/job/15800051758#step:10:19
> ![image](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/b20c4358-8970-4e18-a2ab-c421f57f0675)

This has been happening since https://github.com/oasisprotocol/oasis-wallet-web/pull/1570.
Additionally, https://github.com/oasisprotocol/oasis-wallet-web/pull/1583/commits/84b30f3c5270843d525ae8bb83dcea518fe572ad broke a test, and it wasn't caught.

Skipped tests seem to be an upstream issue. Reported to: https://github.com/microsoft/playwright/issues/26435