### PR TITLE
Fix actions syncing between tabs before state is synced

### DIFF
--- a/src/app/state/persist/syncTabs.ts
+++ b/src/app/state/persist/syncTabs.ts
@@ -37,6 +37,9 @@ export function receiveInitialTabSyncState(
 
 /**
  * When interacting with a second tab it syncs these actions.
+ *
+ * See caveat in {@link walletActions.updateBalance} about actions being synced
+ * before {@link receiveInitialTabSyncState}!
  */
 export const whitelistTabSyncActions = [
   themeActions.changeTheme.type,


### PR DESCRIPTION
This fixes flaky e2e test switching account should not sync > persisted.

Requires https://github.com/oasisprotocol/oasis-wallet-web/pull/1596 for tests to pass