### PR TITLE
Before transaction validate if ledger device still derives same account

### DIFF
--- a/src/app/components/ErrorFormatter/index.tsx
+++ b/src/app/components/ErrorFormatter/index.tsx
@@ -76,6 +76,10 @@ export function ErrorFormatter(props: Props) {
       'errors.LedgerOasisAppIsNotOpen',
       'Oasis App on Ledger is closed.',
     ),
+    [WalletErrors.LedgerDerivedDifferentAccount]: t(
+      'errors.LedgerDerivedDifferentAccount',
+      'This account does not belong to the currently connected Ledger.',
+    ),
     [WalletErrors.LedgerUnknownError]: t('errors.unknownLedgerError', 'Unknown ledger error: {{message}}', {
       message,
     }),

--- a/src/app/lib/__tests__/ledger.test.ts
+++ b/src/app/lib/__tests__/ledger.test.ts
@@ -139,13 +139,6 @@ describe('Ledger Library', () => {
     })
 
     it('Should return the public key', () => {
-      const sign = jest.mocked(OasisApp.prototype.sign)
-      sign.mockResolvedValueOnce({
-        return_code: 0x9000,
-        signature: Buffer.from(new Uint8Array([1, 2, 3])),
-        error_message: '',
-      })
-
       const signer = new LedgerSigner({
         type: WalletType.Ledger,
         path: [44, 474, 0, 0, 0],
@@ -157,6 +150,12 @@ describe('Ledger Library', () => {
     })
 
     it('Should throw if the transaction was rejected', async () => {
+      const pubKey = jest.mocked(OasisApp.prototype.publicKey)
+      pubKey.mockResolvedValueOnce({
+        return_code: 0x9000,
+        pk: Buffer.from(new Uint8Array([0])),
+        error_message: '',
+      })
       const sign = jest.mocked(OasisApp.prototype.sign)
       sign.mockResolvedValueOnce({ return_code: 0x6986, error_message: '' })
 
@@ -174,6 +173,12 @@ describe('Ledger Library', () => {
     })
 
     it('Should return the signature', async () => {
+      const pubKey = jest.mocked(OasisApp.prototype.publicKey)
+      pubKey.mockResolvedValueOnce({
+        return_code: 0x9000,
+        pk: Buffer.from(new Uint8Array([0])),
+        error_message: '',
+      })
       const sign = jest.mocked(OasisApp.prototype.sign)
       sign.mockResolvedValueOnce({
         return_code: 0x9000,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -135,6 +135,7 @@
     "reclaimedAmount": "Amount to reclaim"
   },
   "errors": {
+    "LedgerDerivedDifferentAccount": "This account does not belong to the currently connected Ledger.",
     "LedgerOasisAppIsNotOpen": "Oasis App on Ledger is closed.",
     "cannotSendToSelf": "Cannot send to yourself",
     "disconnectedError": "Lost connection.",

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -26,6 +26,7 @@ export enum WalletErrors {
   LedgerNoDeviceSelected = 'no_device_selected',
   LedgerTransactionRejected = 'transaction_rejected',
   LedgerAppVersionNotSupported = 'ledger_version_not_supported',
+  LedgerDerivedDifferentAccount = 'ledger_derived_different_account',
   IndexerAPIError = 'indexer_api_error',
   DisconnectedError = 'disconnected_error',
   ParaTimesUnknownError = 'para_times_unknown_error',


### PR DESCRIPTION
This improves the error message for users mixing up multiple ledger devices.

E.g.:
- user has two ledgers with different mnemonics
- imports account1 from ledger1 and saves it
- later
- plugs in ledger2 and tries to transfer from saved account1
- see error:

| Before | After |
| --- | --- |
| ![Screenshot from 2023-08-26 00-46-45](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/d70b557b-9e24-4b21-ac2d-b7f6c24abe7e)  | ![Screenshot from 2023-08-26 00-46-50](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/305f7b4e-9557-4a56-873b-e1122c06a696)  |