### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:base", ":disableDependencyDashboard"],
   "packageRules": [
     {
       "groupName": "lint dependencies",
@@ -30,5 +30,6 @@
       "groupName": "CI github-actions",
       "matchManagers": ["github-actions"]
     }
-  ]
+  ],
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
Sync with Explorer config
 - turn off dashboard in Issues
 - bump the range even if the new version satisfies the existing range, e.g. ^1.0.0 -> ^1.1.0 