### PR TITLE
Fix continuously refreshing balances in wallet slice

### DIFF
--- a/playwright/tests/refreshing-balance.spec.ts
+++ b/playwright/tests/refreshing-balance.spec.ts
@@ -32,3 +32,14 @@ test('Account selector should refresh balances on network change', async ({ page
   await expect(page.getByTestId('account-choice')).toContainText('456.0')
   await page.getByRole('button', { name: /Select/ }).click()
 })
+
+test('Accounts page should continuously refresh balance', async ({ page }) => {
+  await page.getByTestId('account-selector').click()
+  await expect(page.getByTestId('account-balance-summary')).toContainText('123.0')
+  await expect(page.getByTestId('account-choice')).toContainText('123.0')
+  await mockApi(page, 456)
+  await page.waitForRequest('**/chain/account/info/*', { timeout: 60_000 })
+  await expect(page.getByTestId('account-balance-summary')).toContainText('456.0')
+  await expect(page.getByTestId('account-choice')).toContainText('456.0')
+  // If balance in AccountSelector is not refreshed then making transactions with new balance will fail.
+})

--- a/src/app/state/account/saga.ts
+++ b/src/app/state/account/saga.ts
@@ -13,7 +13,7 @@ import { selectAddress } from '../wallet/selectors'
 import { selectAccountAddress, selectAccountAvailableBalance } from './selectors'
 import { getAccountBalanceWithFallback } from '../../lib/getAccountBalanceWithFallback'
 
-const ACCOUNT_REFETCHING_INTERVAL = 30 * 1000
+const ACCOUNT_REFETCHING_INTERVAL = process.env.REACT_APP_E2E_TEST ? 5 * 1000 : 30 * 1000
 const TRANSACTIONS_LIMIT = 20
 
 export function* fetchAccount(action: PayloadAction<string>) {

--- a/src/app/state/account/saga.ts
+++ b/src/app/state/account/saga.ts
@@ -7,6 +7,7 @@ import { getExplorerAPIs } from '../network/saga'
 import { takeLatestCancelable } from '../takeLatestCancelable'
 import { stakingActions } from '../staking'
 import { fetchAccount as stakingFetchAccount } from '../staking/saga'
+import { refreshAccount as walletRefreshAccount } from '../wallet/saga'
 import { transactionActions } from '../transaction'
 import { selectAddress } from '../wallet/selectors'
 import { selectAccountAddress, selectAccountAvailableBalance } from './selectors'
@@ -124,6 +125,7 @@ export function* fetchingOnAccountPage() {
           if (staleAvailableBalance !== refreshedAccount.available) {
             yield* call(fetchAccount, startAction)
             yield* call(stakingFetchAccount, startAction)
+            yield* call(walletRefreshAccount, address)
           }
         }
       } finally {

--- a/src/app/state/wallet/saga.ts
+++ b/src/app/state/wallet/saga.ts
@@ -156,7 +156,7 @@ function* refreshAccountOnParaTimeTransaction() {
   }
 }
 
-function* refreshAccount(address: string) {
+export function* refreshAccount(address: string) {
   const from = yield* select(selectAddress)
   const wallets = yield* select(selectWallets)
   const matchingWallets = Object.values(wallets).filter(


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-wallet-web/issues/1673

Fixes making transactions with the refreshed balance and displays new balance in AccountSelector.