### PR TITLE
Named Accounts

### DIFF
--- a/src/app/components/AddressBox/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/AddressBox/__tests__/__snapshots__/index.test.tsx.snap
@@ -33,6 +33,38 @@ exports[`<AddressBox /> should render address properly 1`] = `
   stroke: none;
 }
 
+.c5 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  fill: link;
+  stroke: link;
+}
+
+.c5 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c5 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c5 *[stroke*='#'],.c5 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c5 *[fill-rule],
+.c5 *[FILL-RULE],
+.c5 *[fill*='#'],.c5 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -49,9 +81,6 @@ exports[`<AddressBox /> should render address properly 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
   padding-right: 12px;
   border-radius: 5px;
 }
@@ -155,6 +184,7 @@ exports[`<AddressBox /> should render address properly 1`] = `
     </button>
     <span
       class="c3"
+      style="flex: 1;"
     >
       <span
         class="c4"
@@ -168,6 +198,23 @@ exports[`<AddressBox /> should render address properly 1`] = `
         </span>
       </span>
     </span>
+    <button
+      class="c1"
+      type="button"
+    >
+      <svg
+        aria-label="Edit"
+        class="c5"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="m14 4 6 6-6-6zm8.294 1.294c.39.39.387 1.025-.008 1.42L9 20l-7 2 2-7L17.286 1.714a1 1 0 0 1 1.42-.008l3.588 3.588zM3 19l2 2m2-4 8-8"
+          fill="none"
+          stroke="#000"
+          stroke-width="2"
+        />
+      </svg>
+    </button>
   </div>
 </div>
 `;

--- a/src/app/components/AddressBox/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/AddressBox/__tests__/__snapshots__/index.test.tsx.snap
@@ -33,38 +33,6 @@ exports[`<AddressBox /> should render address properly 1`] = `
   stroke: none;
 }
 
-.c5 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 16px;
-  height: 16px;
-  fill: link;
-  stroke: link;
-}
-
-.c5 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c5 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c5 *[stroke*='#'],.c5 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c5 *[fill-rule],
-.c5 *[FILL-RULE],
-.c5 *[fill*='#'],.c5 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -198,23 +166,6 @@ exports[`<AddressBox /> should render address properly 1`] = `
         </span>
       </span>
     </span>
-    <button
-      class="c1"
-      type="button"
-    >
-      <svg
-        aria-label="Edit"
-        class="c5"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="m14 4 6 6-6-6zm8.294 1.294c.39.39.387 1.025-.008 1.42L9 20l-7 2 2-7L17.286 1.714a1 1 0 0 1 1.42-.008l3.588 3.588zM3 19l2 2m2-4 8-8"
-          fill="none"
-          stroke="#000"
-          stroke-width="2"
-        />
-      </svg>
-    </button>
   </div>
 </div>
 `;

--- a/src/app/components/AddressBox/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/AddressBox/__tests__/__snapshots__/index.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`<AddressBox /> should render address properly 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin-right: 96px;
+  margin-right: 48px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -71,6 +71,10 @@ exports[`<AddressBox /> should render address properly 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  width: 680px;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
 }
 
 .c4 {
@@ -150,7 +154,7 @@ exports[`<AddressBox /> should render address properly 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    margin-right: 48px;
+    margin-right: 24px;
   }
 }
 
@@ -187,7 +191,7 @@ exports[`<AddressBox /> should render address properly 1`] = `
       </button>
       <span
         class="c4"
-        style="flex: 1;"
+        style="flex: 1; width: 680px;"
       >
         <span
           class="c5"

--- a/src/app/components/AddressBox/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/AddressBox/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<AddressBox /> should render address properly 1`] = `
-.c2 {
+.c3 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,23 +12,23 @@ exports[`<AddressBox /> should render address properly 1`] = `
   stroke: #666666;
 }
 
-.c2 g {
+.c3 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c2 *:not([stroke])[fill='none'] {
+.c3 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c2 *[stroke*='#'],.c2 *[STROKE*='#'] {
+.c3 *[stroke*='#'],.c3 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c2 *[fill-rule],
-.c2 *[FILL-RULE],
-.c2 *[fill*='#'],.c2 *[FILL*='#'] {
+.c3 *[fill-rule],
+.c3 *[FILL-RULE],
+.c3 *[fill*='#'],.c3 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -53,19 +53,39 @@ exports[`<AddressBox /> should render address properly 1`] = `
   border-radius: 5px;
 }
 
-.c3 {
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 96px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 1px background-front-border;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c4 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
   word-break: break-word;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c1 {
+.c2 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -85,40 +105,40 @@ exports[`<AddressBox /> should render address properly 1`] = `
   padding: 12px;
 }
 
-.c1:focus {
+.c2:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c2:focus > circle,
+.c2:focus > ellipse,
+.c2:focus > line,
+.c2:focus > path,
+.c2:focus > polygon,
+.c2:focus > polyline,
+.c2:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c2:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible) > circle,.c2:focus:not(:focus-visible) > ellipse,
+.c2:focus:not(:focus-visible) > line,.c2:focus:not(:focus-visible) > path,
+.c2:focus:not(:focus-visible) > polygon,.c2:focus:not(:focus-visible) > polyline,
+.c2:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -128,44 +148,60 @@ exports[`<AddressBox /> should render address properly 1`] = `
   }
 }
 
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin-right: 48px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    border-bottom: solid 1px background-front-border;
+  }
+}
+
 <div>
   <div
     class="c0"
   >
-    <button
+    <div
       class="c1"
-      data-testid="copy-address"
-      type="button"
     >
-      <svg
-        aria-label="Copy"
+      <button
         class="c2"
-        viewBox="0 0 24 24"
+        data-testid="copy-address"
+        type="button"
       >
-        <path
-          d="M9 15h8-8zm0-4h10H9zm0-4h4-4zm7-6v6h6M6 5H2v18h16v-4m4 0H6V1h11l5 5v13z"
-          fill="none"
-          stroke="#000"
-          stroke-width="2"
-        />
-      </svg>
-    </button>
-    <span
-      class="c3"
-      style="flex: 1;"
-    >
+        <svg
+          aria-label="Copy"
+          class="c3"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M9 15h8-8zm0-4h10H9zm0-4h4-4zm7-6v6h6M6 5H2v18h16v-4m4 0H6V1h11l5 5v13z"
+            fill="none"
+            stroke="#000"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
       <span
         class="c4"
-        style="font-family: Roboto mono; letter-spacing: 0;"
+        style="flex: 1;"
       >
         <span
-          class="notranslate"
-          translate="no"
+          class="c5"
+          style="font-family: Roboto mono; letter-spacing: 0;"
         >
-          oasis1 qqur xkga vtcj jytn eume clx5 9ds3 avja qg7f tqph
+          <span
+            class="notranslate"
+            translate="no"
+          >
+            oasis1 qqur xkga vtcj jytn eume clx5 9ds3 avja qg7f tqph
+          </span>
         </span>
       </span>
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/src/app/components/AddressBox/index.tsx
+++ b/src/app/components/AddressBox/index.tsx
@@ -9,7 +9,8 @@ import { Button } from 'grommet/es6/components/Button'
 import { Text } from 'grommet/es6/components/Text'
 import { Notification } from 'grommet/es6/components/Notification'
 import { Copy } from 'grommet-icons/es6/icons/Copy'
-import React, { memo, useState } from 'react'
+import { Edit } from 'grommet-icons/es6/icons/Edit'
+import { memo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { PrettyAddress } from '../PrettyAddress'
@@ -40,13 +41,13 @@ export const AddressBox = memo((props: Props) => {
       align="center"
       round="5px"
       pad={{ right: 'small' }}
-      width="fit-content"
       border={props.border && { color: 'brand' }}
     >
       <Button onClick={() => copyAddress()} icon={<Copy size="18px" />} data-testid="copy-address" />
-      <Text weight="bold" size="medium" wordBreak="break-word">
+      <Text weight="bold" size="medium" wordBreak="break-word" style={{ flex: 1 }}>
         <PrettyAddress address={address} />
       </Text>
+      <Button onClick={() => {}} icon={<Edit color="link" size="16 px" />} />
       {notificationVisible && (
         <Notification
           toast

--- a/src/app/components/AddressBox/index.tsx
+++ b/src/app/components/AddressBox/index.tsx
@@ -3,11 +3,13 @@
  * AddressBox
  *
  */
+import { useContext } from 'react'
 import copy from 'copy-to-clipboard'
 import { Box } from 'grommet/es6/components/Box'
 import { Button } from 'grommet/es6/components/Button'
 import { Text } from 'grommet/es6/components/Text'
 import { Notification } from 'grommet/es6/components/Notification'
+import { ResponsiveContext } from 'grommet/es6/contexts/ResponsiveContext'
 import { Copy } from 'grommet-icons/es6/icons/Copy'
 import { Edit } from 'grommet-icons/es6/icons/Edit'
 import { memo, useState } from 'react'
@@ -27,7 +29,7 @@ export const AddressBox = memo((props: Props) => {
   const { t } = useTranslation()
   const [notificationVisible, setNotificationVisible] = useState(false)
   const hideNotification = () => setNotificationVisible(false)
-
+  const isMobile = useContext(ResponsiveContext) === 'small'
   const address = props.address
 
   const copyAddress = () => {
@@ -39,11 +41,12 @@ export const AddressBox = memo((props: Props) => {
 
   return (
     <Box
-      direction="row"
+      direction={isMobile ? 'column' : 'row'}
       align="center"
       round="5px"
       pad={{ right: 'small' }}
       border={props.border && { color: 'brand' }}
+      gap={isMobile ? 'medium' : undefined}
     >
       <Box
         direction="row"
@@ -52,7 +55,7 @@ export const AddressBox = memo((props: Props) => {
           color: 'background-front-border',
           side: 'bottom',
         }}
-        margin={{ right: 'large' }}
+        margin={{ right: isMobile ? undefined : 'large' }}
         flex
         width={textWidth}
       >

--- a/src/app/components/AddressBox/index.tsx
+++ b/src/app/components/AddressBox/index.tsx
@@ -12,18 +12,17 @@ import { Copy } from 'grommet-icons/es6/icons/Copy'
 import { Edit } from 'grommet-icons/es6/icons/Edit'
 import { memo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-
 import { PrettyAddress } from '../PrettyAddress'
 
 interface Props {
   address: string
   border?: boolean
+  editHandler?: () => void
 }
 
 export const AddressBox = memo((props: Props) => {
   const { t } = useTranslation()
   const [notificationVisible, setNotificationVisible] = useState(false)
-
   const hideNotification = () => setNotificationVisible(false)
 
   const address = props.address
@@ -47,7 +46,7 @@ export const AddressBox = memo((props: Props) => {
       <Text weight="bold" size="medium" wordBreak="break-word" style={{ flex: 1 }}>
         <PrettyAddress address={address} />
       </Text>
-      <Button onClick={() => {}} icon={<Edit color="link" size="16 px" />} />
+      {props.editHandler && <Button onClick={props.editHandler} icon={<Edit color="link" size="16px" />} />}
       {notificationVisible && (
         <Notification
           toast

--- a/src/app/components/AddressBox/index.tsx
+++ b/src/app/components/AddressBox/index.tsx
@@ -21,6 +21,8 @@ interface Props {
   name?: string
 }
 
+const textWidth = '680px'
+
 export const AddressBox = memo((props: Props) => {
   const { t } = useTranslation()
   const [notificationVisible, setNotificationVisible] = useState(false)
@@ -50,12 +52,14 @@ export const AddressBox = memo((props: Props) => {
           color: 'background-front-border',
           side: 'bottom',
         }}
-        margin={{ right: 'xlarge' }}
+        margin={{ right: 'large' }}
+        flex
+        width={textWidth}
       >
         {!props.name && (
           <Button onClick={() => copyAddress()} icon={<Copy size="18px" />} data-testid="copy-address" />
         )}
-        <Text weight="bold" size="medium" wordBreak="break-word" style={{ flex: 1 }}>
+        <Text weight="bold" size="medium" wordBreak="break-word" style={{ flex: 1, width: textWidth }}>
           {props.name ? <span>{props.name}</span> : <PrettyAddress address={address} />}
         </Text>
         {props.editHandler && <Button onClick={props.editHandler} icon={<Edit color="link" size="16px" />} />}

--- a/src/app/components/AddressBox/index.tsx
+++ b/src/app/components/AddressBox/index.tsx
@@ -18,6 +18,7 @@ interface Props {
   address: string
   border?: boolean
   editHandler?: () => void
+  name?: string
 }
 
 export const AddressBox = memo((props: Props) => {
@@ -42,11 +43,33 @@ export const AddressBox = memo((props: Props) => {
       pad={{ right: 'small' }}
       border={props.border && { color: 'brand' }}
     >
-      <Button onClick={() => copyAddress()} icon={<Copy size="18px" />} data-testid="copy-address" />
-      <Text weight="bold" size="medium" wordBreak="break-word" style={{ flex: 1 }}>
-        <PrettyAddress address={address} />
-      </Text>
-      {props.editHandler && <Button onClick={props.editHandler} icon={<Edit color="link" size="16px" />} />}
+      <Box
+        direction="row"
+        align="center"
+        border={{
+          color: 'background-front-border',
+          side: 'bottom',
+        }}
+        margin={{ right: 'xlarge' }}
+      >
+        {!props.name && (
+          <Button onClick={() => copyAddress()} icon={<Copy size="18px" />} data-testid="copy-address" />
+        )}
+        <Text weight="bold" size="medium" wordBreak="break-word" style={{ flex: 1 }}>
+          {props.name ? <span>{props.name}</span> : <PrettyAddress address={address} />}
+        </Text>
+        {props.editHandler && <Button onClick={props.editHandler} icon={<Edit color="link" size="16px" />} />}
+      </Box>
+      {props.name && (
+        <Button
+          label="oasis1... c6hae7"
+          onClick={() => copyAddress()}
+          icon={<Copy size="18px" />}
+          data-testid="copy-address"
+          reverse
+          style={{ backgroundColor: '#E8F5FF', borderWidth: '1px' }}
+        />
+      )}
       {notificationVisible && (
         <Notification
           toast

--- a/src/app/components/Toolbar/Features/Account/ManageableAccount.tsx
+++ b/src/app/components/Toolbar/Features/Account/ManageableAccount.tsx
@@ -1,7 +1,9 @@
 import { Box } from 'grommet/es6/components/Box'
 import { Button } from 'grommet/es6/components/Button'
+import { FormField } from 'grommet/es6/components/FormField'
 import { Tab } from 'grommet/es6/components/Tab'
 import { Text } from 'grommet/es6/components/Text'
+import { TextInput } from 'grommet/es6/components/TextInput'
 import { ResponsiveContext } from 'grommet/es6/contexts/ResponsiveContext'
 import { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -51,6 +53,25 @@ export const ManageableAccount = ({
           <Box margin="medium" width={isMobile ? 'auto' : '700px'}>
             <Tabs alignControls="start">
               <Tab title={t('toolbar.settings.myAccountsTab', 'My Accounts')}>
+                <Box margin={{ vertical: 'medium' }}>
+                  <FormField
+                    name="name"
+                    required
+                    validate={(name: string) =>
+                      name.trim().length > 16
+                        ? {
+                            message: t('toolbar.settings.nameLengthError', 'No more than 16 characters'),
+                            status: 'error',
+                          }
+                        : undefined
+                    }
+                  >
+                    <TextInput
+                      name="name"
+                      placeholder={t('toolbar.settings.optionalName', 'Name (optional)')}
+                    />
+                  </FormField>
+                </Box>
                 <Box margin={{ vertical: 'medium' }}>
                   <AddressBox address={wallet.address} border />
                   <Text size="small" margin={'small'}>

--- a/src/app/components/Toolbar/Features/Account/ManageableAccount.tsx
+++ b/src/app/components/Toolbar/Features/Account/ManageableAccount.tsx
@@ -12,6 +12,7 @@ import { useContext, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { Account } from './Account'
 import { walletActions } from 'app/state/wallet'
+import { selectProfile } from 'app/state/profile/selectors'
 import { selectUnlockedStatus } from 'app/state/selectUnlockedStatus'
 import { Wallet } from '../../../../state/wallet/types'
 import { ResponsiveLayer } from '../../../ResponsiveLayer'
@@ -19,6 +20,7 @@ import { Tabs } from 'grommet/es6/components/Tabs'
 import { DerivationFormatter } from './DerivationFormatter'
 import { uintToBase64, hex2uint } from '../../../../lib/helpers'
 import { AddressBox } from '../../../AddressBox'
+import { profileActions } from 'app/state/profile'
 
 interface FormValue {
   name: string
@@ -38,11 +40,12 @@ export const ManageableAccount = ({
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const navigate = useNavigate()
-  const [layerVisibility, setLayerVisibility] = useState(false)
+  const { manageAccountModalId } = useSelector(selectProfile)
   const isMobile = useContext(ResponsiveContext) === 'small'
+  const hideLayer = () => dispatch(profileActions.setManageAccountModalId(''))
   const handleSave = (name: string) => {
     dispatch(walletActions.setWalletName({ address: wallet.address, name }))
-    setLayerVisibility(false)
+    hideLayer()
   }
   const unlockedStatus = useSelector(selectUnlockedStatus)
   const hasProfile = unlockedStatus === 'unlockedProfile'
@@ -58,14 +61,14 @@ export const ManageableAccount = ({
         path={wallet.path}
         displayBalance={true}
         displayManageButton={{
-          onClickManage: () => setLayerVisibility(true),
+          onClickManage: () => dispatch(profileActions.setManageAccountModalId(wallet.address)),
         }}
         name={wallet.name}
       />
-      {layerVisibility && (
+      {manageAccountModalId === wallet.address && (
         <ResponsiveLayer
-          onClickOutside={() => setLayerVisibility(false)}
-          onEsc={() => setLayerVisibility(false)}
+          onClickOutside={hideLayer}
+          onEsc={hideLayer}
           animation="none"
           background="background-front"
           modal
@@ -143,11 +146,7 @@ export const ManageableAccount = ({
                     }}
                   />
                   <Box direction="row" justify="between" pad={{ top: 'large' }}>
-                    <Button
-                      secondary
-                      label={t('toolbar.settings.cancel', 'Cancel')}
-                      onClick={() => setLayerVisibility(false)}
-                    />
+                    <Button secondary label={t('toolbar.settings.cancel', 'Cancel')} onClick={hideLayer} />
                     <Button primary label={t('toolbar.settings.save', 'Save')} type="submit" />
                   </Box>
                 </Form>

--- a/src/app/components/Toolbar/Features/Account/ManageableAccount.tsx
+++ b/src/app/components/Toolbar/Features/Account/ManageableAccount.tsx
@@ -1,4 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
 import { Box } from 'grommet/es6/components/Box'
 import { Button } from 'grommet/es6/components/Button'
 import { Form } from 'grommet/es6/components/Form'
@@ -8,9 +9,10 @@ import { Text } from 'grommet/es6/components/Text'
 import { TextInput } from 'grommet/es6/components/TextInput'
 import { ResponsiveContext } from 'grommet/es6/contexts/ResponsiveContext'
 import { useContext, useState } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { Account } from './Account'
 import { walletActions } from 'app/state/wallet'
+import { selectUnlockedStatus } from 'app/state/selectUnlockedStatus'
 import { Wallet } from '../../../../state/wallet/types'
 import { ResponsiveLayer } from '../../../ResponsiveLayer'
 import { Tabs } from 'grommet/es6/components/Tabs'
@@ -23,22 +25,27 @@ interface FormValue {
 }
 
 export const ManageableAccount = ({
+  closeHandler,
   wallet,
   isActive,
   onClick,
 }: {
+  closeHandler: () => void
   wallet: Wallet
   isActive: boolean
   onClick: (address: string) => void
 }) => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
+  const navigate = useNavigate()
   const [layerVisibility, setLayerVisibility] = useState(false)
   const isMobile = useContext(ResponsiveContext) === 'small'
   const handleSave = (name: string) => {
     dispatch(walletActions.setWalletName({ address: wallet.address, name }))
     setLayerVisibility(false)
   }
+  const unlockedStatus = useSelector(selectUnlockedStatus)
+  const hasProfile = unlockedStatus === 'unlockedProfile'
   const [value, setValue] = useState({ name: wallet.name || '' })
 
   return (
@@ -75,6 +82,29 @@ export const ManageableAccount = ({
                 >
                   <Box margin={{ vertical: 'medium' }}>
                     <FormField
+                      disabled={!hasProfile}
+                      info={
+                        !hasProfile ? (
+                          <Box style={{ display: 'block' }}>
+                            <Trans
+                              i18nKey="toolbar.settings.accountNamingNotAvailable"
+                              t={t}
+                              components={{
+                                OpenWalletButton: (
+                                  <Button
+                                    color="link"
+                                    onClick={() => {
+                                      closeHandler()
+                                      navigate('/open-wallet')
+                                    }}
+                                  />
+                                ),
+                              }}
+                              defaults="To name your account create a profile while <OpenWalletButton>opening a wallet</OpenWalletButton>."
+                            />
+                          </Box>
+                        ) : undefined
+                      }
                       name="name"
                       validate={(name: string) =>
                         name.trim().length > 16
@@ -86,8 +116,13 @@ export const ManageableAccount = ({
                       }
                     >
                       <TextInput
+                        disabled={!hasProfile}
                         name="name"
-                        placeholder={t('toolbar.settings.optionalName', 'Name (optional)')}
+                        placeholder={
+                          hasProfile
+                            ? t('toolbar.settings.optionalName', 'Name (optional)')
+                            : t('toolbar.settings.optionalNameDisabled', 'Name (optional)')
+                        }
                       />
                     </FormField>
                   </Box>

--- a/src/app/components/Toolbar/Features/Account/ManageableAccount.tsx
+++ b/src/app/components/Toolbar/Features/Account/ManageableAccount.tsx
@@ -1,5 +1,7 @@
+import { useDispatch, useSelector } from 'react-redux'
 import { Box } from 'grommet/es6/components/Box'
 import { Button } from 'grommet/es6/components/Button'
+import { Form } from 'grommet/es6/components/Form'
 import { FormField } from 'grommet/es6/components/FormField'
 import { Tab } from 'grommet/es6/components/Tab'
 import { Text } from 'grommet/es6/components/Text'
@@ -8,12 +10,17 @@ import { ResponsiveContext } from 'grommet/es6/contexts/ResponsiveContext'
 import { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Account } from './Account'
+import { walletActions } from 'app/state/wallet'
 import { Wallet } from '../../../../state/wallet/types'
 import { ResponsiveLayer } from '../../../ResponsiveLayer'
 import { Tabs } from 'grommet/es6/components/Tabs'
 import { DerivationFormatter } from './DerivationFormatter'
 import { uintToBase64, hex2uint } from '../../../../lib/helpers'
 import { AddressBox } from '../../../AddressBox'
+
+interface FormValue {
+  name: string
+}
 
 export const ManageableAccount = ({
   wallet,
@@ -25,8 +32,15 @@ export const ManageableAccount = ({
   onClick: (address: string) => void
 }) => {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
   const [layerVisibility, setLayerVisibility] = useState(false)
   const isMobile = useContext(ResponsiveContext) === 'small'
+  const handleSave = (name: string) => {
+    dispatch(walletActions.setWalletName({ address: wallet.address, name }))
+    setLayerVisibility(false)
+  }
+  const [value, setValue] = useState({ name: wallet.name || '' })
+
   return (
     <>
       <Account
@@ -39,6 +53,7 @@ export const ManageableAccount = ({
         displayManageButton={{
           onClickManage: () => setLayerVisibility(true),
         }}
+        name={wallet.name}
       />
       {layerVisibility && (
         <ResponsiveLayer
@@ -53,48 +68,54 @@ export const ManageableAccount = ({
           <Box margin="medium" width={isMobile ? 'auto' : '700px'}>
             <Tabs alignControls="start">
               <Tab title={t('toolbar.settings.myAccountsTab', 'My Accounts')}>
-                <Box margin={{ vertical: 'medium' }}>
-                  <FormField
-                    name="name"
-                    required
-                    validate={(name: string) =>
-                      name.trim().length > 16
-                        ? {
-                            message: t('toolbar.settings.nameLengthError', 'No more than 16 characters'),
-                            status: 'error',
-                          }
-                        : undefined
-                    }
-                  >
-                    <TextInput
+                <Form<FormValue>
+                  onSubmit={({ value }) => handleSave(value.name)}
+                  value={value}
+                  onChange={nextValue => setValue(nextValue)}
+                >
+                  <Box margin={{ vertical: 'medium' }}>
+                    <FormField
                       name="name"
-                      placeholder={t('toolbar.settings.optionalName', 'Name (optional)')}
-                    />
-                  </FormField>
-                </Box>
-                <Box margin={{ vertical: 'medium' }}>
-                  <AddressBox address={wallet.address} border />
-                  <Text size="small" margin={'small'}>
-                    <DerivationFormatter pathDisplay={wallet.pathDisplay} type={wallet.type} />
-                  </Text>
-                </Box>
-                <Button
-                  label={t('toolbar.settings.exportPrivateKey', 'Export Private Key')}
-                  disabled={!wallet.privateKey}
-                  onClick={() => {
-                    prompt(
-                      t('toolbar.settings.exportPrivateKey', 'Export Private Key'),
-                      uintToBase64(hex2uint(wallet.privateKey!)),
-                    )
-                  }}
-                />
-                <Box direction="row" justify="between" pad={{ top: 'large' }}>
+                      validate={(name: string) =>
+                        name.trim().length > 16
+                          ? {
+                              message: t('toolbar.settings.nameLengthError', 'No more than 16 characters'),
+                              status: 'error',
+                            }
+                          : undefined
+                      }
+                    >
+                      <TextInput
+                        name="name"
+                        placeholder={t('toolbar.settings.optionalName', 'Name (optional)')}
+                      />
+                    </FormField>
+                  </Box>
+                  <Box margin={{ vertical: 'medium' }}>
+                    <AddressBox address={wallet.address} border />
+                    <Text size="small" margin={'small'}>
+                      <DerivationFormatter pathDisplay={wallet.pathDisplay} type={wallet.type} />
+                    </Text>
+                  </Box>
                   <Button
-                    secondary
-                    label={t('toolbar.settings.cancel', 'Cancel')}
-                    onClick={() => setLayerVisibility(false)}
+                    label={t('toolbar.settings.exportPrivateKey', 'Export Private Key')}
+                    disabled={!wallet.privateKey}
+                    onClick={() => {
+                      prompt(
+                        t('toolbar.settings.exportPrivateKey', 'Export Private Key'),
+                        uintToBase64(hex2uint(wallet.privateKey!)),
+                      )
+                    }}
                   />
-                </Box>
+                  <Box direction="row" justify="between" pad={{ top: 'large' }}>
+                    <Button
+                      secondary
+                      label={t('toolbar.settings.cancel', 'Cancel')}
+                      onClick={() => setLayerVisibility(false)}
+                    />
+                    <Button primary label={t('toolbar.settings.save', 'Save')} type="submit" />
+                  </Box>
+                </Form>
               </Tab>
             </Tabs>
           </Box>

--- a/src/app/components/Toolbar/Features/Account/ManageableAccount.tsx
+++ b/src/app/components/Toolbar/Features/Account/ManageableAccount.tsx
@@ -21,6 +21,7 @@ import { DerivationFormatter } from './DerivationFormatter'
 import { uintToBase64, hex2uint } from '../../../../lib/helpers'
 import { AddressBox } from '../../../AddressBox'
 import { profileActions } from 'app/state/profile'
+import { layerOverlayMinHeight } from '../layer'
 
 interface FormValue {
   name: string
@@ -78,78 +79,80 @@ export const ManageableAccount = ({
           <Box margin="medium" width={isMobile ? 'auto' : '700px'}>
             <Tabs alignControls="start">
               <Tab title={t('toolbar.settings.myAccountsTab', 'My Accounts')}>
-                <Form<FormValue>
-                  onSubmit={({ value }) => handleSave(value.name)}
-                  value={value}
-                  onChange={nextValue => setValue(nextValue)}
-                >
-                  <Box margin={{ vertical: 'medium' }}>
-                    <FormField
-                      disabled={!hasProfile}
-                      info={
-                        !hasProfile ? (
-                          <Box style={{ display: 'block' }}>
-                            <Trans
-                              i18nKey="toolbar.settings.accountNamingNotAvailable"
-                              t={t}
-                              components={{
-                                OpenWalletButton: (
-                                  <Button
-                                    color="link"
-                                    onClick={() => {
-                                      closeHandler()
-                                      navigate('/open-wallet')
-                                    }}
-                                  />
-                                ),
-                              }}
-                              defaults="To name your account create a profile while <OpenWalletButton>opening a wallet</OpenWalletButton>."
-                            />
-                          </Box>
-                        ) : undefined
-                      }
-                      name="name"
-                      validate={(name: string) =>
-                        name.trim().length > 16
-                          ? {
-                              message: t('toolbar.settings.nameLengthError', 'No more than 16 characters'),
-                              status: 'error',
-                            }
-                          : undefined
-                      }
-                    >
-                      <TextInput
+                <Box height={{ min: isMobile ? 'auto' : layerOverlayMinHeight }}>
+                  <Form<FormValue>
+                    onSubmit={({ value }) => handleSave(value.name)}
+                    value={value}
+                    onChange={nextValue => setValue(nextValue)}
+                  >
+                    <Box margin={{ vertical: 'medium' }}>
+                      <FormField
                         disabled={!hasProfile}
-                        name="name"
-                        placeholder={
-                          hasProfile
-                            ? t('toolbar.settings.optionalName', 'Name (optional)')
-                            : t('toolbar.settings.optionalNameDisabled', 'Name (optional)')
+                        info={
+                          !hasProfile ? (
+                            <Box style={{ display: 'block' }}>
+                              <Trans
+                                i18nKey="toolbar.settings.accountNamingNotAvailable"
+                                t={t}
+                                components={{
+                                  OpenWalletButton: (
+                                    <Button
+                                      color="link"
+                                      onClick={() => {
+                                        closeHandler()
+                                        navigate('/open-wallet')
+                                      }}
+                                    />
+                                  ),
+                                }}
+                                defaults="To name your account create a profile while <OpenWalletButton>opening a wallet</OpenWalletButton>."
+                              />
+                            </Box>
+                          ) : undefined
                         }
-                      />
-                    </FormField>
-                  </Box>
-                  <Box margin={{ vertical: 'medium' }}>
-                    <AddressBox address={wallet.address} border />
-                    <Text size="small" margin={'small'}>
-                      <DerivationFormatter pathDisplay={wallet.pathDisplay} type={wallet.type} />
-                    </Text>
-                  </Box>
-                  <Button
-                    label={t('toolbar.settings.exportPrivateKey', 'Export Private Key')}
-                    disabled={!wallet.privateKey}
-                    onClick={() => {
-                      prompt(
-                        t('toolbar.settings.exportPrivateKey', 'Export Private Key'),
-                        uintToBase64(hex2uint(wallet.privateKey!)),
-                      )
-                    }}
-                  />
-                  <Box direction="row" justify="between" pad={{ top: 'large' }}>
-                    <Button secondary label={t('toolbar.settings.cancel', 'Cancel')} onClick={hideLayer} />
-                    <Button primary label={t('toolbar.settings.save', 'Save')} type="submit" />
-                  </Box>
-                </Form>
+                        name="name"
+                        validate={(name: string) =>
+                          name.trim().length > 16
+                            ? {
+                                message: t('toolbar.settings.nameLengthError', 'No more than 16 characters'),
+                                status: 'error',
+                              }
+                            : undefined
+                        }
+                      >
+                        <TextInput
+                          disabled={!hasProfile}
+                          name="name"
+                          placeholder={
+                            hasProfile
+                              ? t('toolbar.settings.optionalName', 'Name (optional)')
+                              : t('toolbar.settings.optionalNameDisabled', 'Name (optional)')
+                          }
+                        />
+                      </FormField>
+                    </Box>
+                    <Box margin={{ vertical: 'medium' }}>
+                      <AddressBox address={wallet.address} border />
+                      <Text size="small" margin={'small'}>
+                        <DerivationFormatter pathDisplay={wallet.pathDisplay} type={wallet.type} />
+                      </Text>
+                    </Box>
+                    <Button
+                      label={t('toolbar.settings.exportPrivateKey', 'Export Private Key')}
+                      disabled={!wallet.privateKey}
+                      onClick={() => {
+                        prompt(
+                          t('toolbar.settings.exportPrivateKey', 'Export Private Key'),
+                          uintToBase64(hex2uint(wallet.privateKey!)),
+                        )
+                      }}
+                    />
+                    <Box direction="row" justify="between" pad={{ top: 'large' }}>
+                      <Button secondary label={t('toolbar.settings.cancel', 'Cancel')} onClick={hideLayer} />
+                      <Button primary label={t('toolbar.settings.save', 'Save')} type="submit" />
+                    </Box>
+                  </Form>
+                </Box>
               </Tab>
             </Tabs>
           </Box>

--- a/src/app/components/Toolbar/Features/AccountSelector/__tests__/index.test.tsx
+++ b/src/app/components/Toolbar/Features/AccountSelector/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { WalletType } from 'app/state/wallet/types'
 import * as React from 'react'
 import { Provider } from 'react-redux'
@@ -10,9 +11,11 @@ import { AccountSelector } from '..'
 const renderComponent = (store: any) =>
   render(
     <Provider store={store}>
-      <ThemeProvider>
-        <AccountSelector closeHandler={() => {}} />
-      </ThemeProvider>
+      <MemoryRouter>
+        <ThemeProvider>
+          <AccountSelector closeHandler={() => {}} />
+        </ThemeProvider>
+      </MemoryRouter>
     </Provider>,
   )
 

--- a/src/app/components/Toolbar/Features/AccountSelector/index.tsx
+++ b/src/app/components/Toolbar/Features/AccountSelector/index.tsx
@@ -31,6 +31,7 @@ export const AccountSelector = memo((props: Props) => {
   const accounts = Object.values(wallets).map(wallet => (
     <ManageableAccount
       key={wallet.address}
+      closeHandler={props.closeHandler}
       wallet={wallet}
       onClick={switchAccount}
       isActive={wallet.address === activeAddress}

--- a/src/app/components/Toolbar/Features/ProfileModalButton/index.tsx
+++ b/src/app/components/Toolbar/Features/ProfileModalButton/index.tsx
@@ -10,10 +10,12 @@ import { ResponsiveContext } from 'grommet/es6/contexts/ResponsiveContext'
 import { Close } from 'grommet-icons/es6/icons/Close'
 import { Lock } from 'grommet-icons/es6/icons/Lock'
 import { Logout } from 'grommet-icons/es6/icons/Logout'
-import React, { memo, useState } from 'react'
+import React, { memo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { selectProfile } from 'app/state/profile/selectors'
 import { selectAddress, selectHasAccounts } from 'app/state/wallet/selectors'
 import { selectIsLockableOrCloseable } from 'app/state/selectIsLockableOrCloseable'
+import { profileActions } from 'app/state/profile'
 import { persistActions } from 'app/state/persist'
 import { AccountSelector } from '../AccountSelector'
 import { JazzIcon } from '../../../JazzIcon'
@@ -35,9 +37,9 @@ export const ProfileModalButton = memo(() => {
   const isLockableOrCloseable = useSelector(selectIsLockableOrCloseable)
   const walletHasAccounts = useSelector(selectHasAccounts)
   const address = useSelector(selectAddress)
-  const [layerVisibility, setLayerVisibility] = useState(false)
+  const { profileModalOpen } = useSelector(selectProfile)
   const isMobile = React.useContext(ResponsiveContext) === 'small'
-  const hideLayer = () => setLayerVisibility(false)
+  const hideLayer = () => dispatch(profileActions.setProfileModalOpen(false))
   const closeWallet = () => {
     navigate('/')
     dispatch(persistActions.lockAsync())
@@ -52,7 +54,10 @@ export const ProfileModalButton = memo(() => {
 
   return (
     <>
-      <Button onClick={() => setLayerVisibility(true)} data-testid="account-selector">
+      <Button
+        onClick={() => dispatch(profileActions.setProfileModalOpen(true))}
+        data-testid="account-selector"
+      >
         {address ? (
           <JazzIcon
             diameter={isMobile ? sidebarSmallSizeLogo : sidebarMediumSizeLogo}
@@ -62,7 +67,7 @@ export const ProfileModalButton = memo(() => {
           <UserSettings />
         )}
       </Button>
-      {layerVisibility && (
+      {profileModalOpen && (
         <ResponsiveLayer
           onClickOutside={hideLayer}
           onEsc={hideLayer}

--- a/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
+++ b/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
@@ -89,6 +89,7 @@ export interface AccountSummaryProps {
   address: string
   balance: BalanceDetails
   editHandler: () => void
+  hasProfile: boolean
   walletHasAccounts?: boolean
   walletAddress?: string
   walletName?: string
@@ -98,6 +99,7 @@ export function AccountSummary({
   address,
   balance,
   editHandler,
+  hasProfile,
   walletAddress,
   walletHasAccounts,
   walletName,
@@ -137,7 +139,11 @@ export function AccountSummary({
       >
         <Box pad="small" direction="row-responsive" flex>
           <Box width={{ max: isMobile ? '100%' : '75%' }}>
-            <AddressBox address={address} editHandler={editHandler} name={walletName} />
+            <AddressBox
+              address={address}
+              editHandler={hasProfile ? editHandler : undefined}
+              name={walletName}
+            />
 
             <StyledDescriptionList data-testid="account-balance-summary">
               <dt>

--- a/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
+++ b/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
@@ -137,7 +137,7 @@ export function AccountSummary({
         border={{ color: 'background-front-border', size: '1px' }}
         background="background-front"
       >
-        <Box pad="small" direction="row-responsive" flex>
+        <Box pad="small" direction="row-responsive" flex justify="between">
           <Box width={{ max: isMobile ? '100%' : '75%' }}>
             <AddressBox
               address={address}
@@ -173,7 +173,7 @@ export function AccountSummary({
           </Box>
 
           {!isMobile && (
-            <Box align="end" flex>
+            <Box align="end">
               <QRCodeCanvas value={address} fgColor={dark ? '#e8e8e8' : '#333333'} bgColor="#00000000" />
             </Box>
           )}

--- a/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
+++ b/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
@@ -87,11 +87,18 @@ const StyledDescriptionList = styled.dl`
 export interface AccountSummaryProps {
   address: string
   balance: BalanceDetails
+  editHandler: () => void
   walletHasAccounts?: boolean
   walletAddress?: string
 }
 
-export function AccountSummary({ address, balance, walletAddress, walletHasAccounts }: AccountSummaryProps) {
+export function AccountSummary({
+  address,
+  balance,
+  editHandler,
+  walletAddress,
+  walletHasAccounts,
+}: AccountSummaryProps) {
   const { t } = useTranslation()
   const { dark } = React.useContext<any>(ThemeContext)
   const isMobile = React.useContext(ResponsiveContext) === 'small'
@@ -127,7 +134,7 @@ export function AccountSummary({ address, balance, walletAddress, walletHasAccou
       >
         <Box pad="small" direction="row-responsive" flex>
           <Box width={{ max: isMobile ? '100%' : '75%' }}>
-            <AddressBox address={address} />
+            <AddressBox address={address} editHandler={editHandler} />
 
             <StyledDescriptionList data-testid="account-balance-summary">
               <dt>

--- a/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
+++ b/src/app/pages/AccountPage/Features/AccountSummary/index.tsx
@@ -19,8 +19,9 @@ const StyledDescriptionList = styled.dl`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  border-top: solid
-    ${({ theme }) => `${theme.global?.edgeSize?.hair} ${normalizeColor('background-front-border', theme)}`};
+  /* border-top: solid
+    ${({ theme }) =>
+    `${theme.global?.edgeSize?.hair} ${normalizeColor('background-front-border', theme)}`}; */
   margin: ${({ theme }) => theme.global?.edgeSize?.xsmall} 0 0;
   padding: ${({ theme }) =>
     `${theme.global?.edgeSize?.small} ${theme.global?.edgeSize?.small} ${theme.global?.edgeSize?.xsmall}`};
@@ -90,6 +91,7 @@ export interface AccountSummaryProps {
   editHandler: () => void
   walletHasAccounts?: boolean
   walletAddress?: string
+  walletName?: string
 }
 
 export function AccountSummary({
@@ -98,6 +100,7 @@ export function AccountSummary({
   editHandler,
   walletAddress,
   walletHasAccounts,
+  walletName,
 }: AccountSummaryProps) {
   const { t } = useTranslation()
   const { dark } = React.useContext<any>(ThemeContext)
@@ -134,7 +137,7 @@ export function AccountSummary({
       >
         <Box pad="small" direction="row-responsive" flex>
           <Box width={{ max: isMobile ? '100%' : '75%' }}>
-            <AddressBox address={address} editHandler={editHandler} />
+            <AddressBox address={address} editHandler={editHandler} name={walletName} />
 
             <StyledDescriptionList data-testid="account-balance-summary">
               <dt>

--- a/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -33,6 +33,38 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   stroke: none;
 }
 
+.c14 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  fill: #0092f6;
+  stroke: #0092f6;
+}
+
+.c14 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c14 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c14 *[stroke*='#'],.c14 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c14 *[fill-rule],
+.c14 *[FILL-RULE],
+.c14 *[fill*='#'],.c14 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
 .c0 {
   font-family: Rubik;
   font-size: 18px;
@@ -169,14 +201,11 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
   padding-right: 12px;
   border-radius: 5px;
 }
 
-.c22 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -204,7 +233,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   border-radius: 24px;
 }
 
-.c25 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -218,7 +247,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-direction: row;
 }
 
-.c26 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -238,7 +267,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-basis: 25%;
 }
 
-.c27 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -255,7 +284,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   padding: 24px;
 }
 
-.c29 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -270,7 +299,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c33 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -289,7 +318,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c36 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -308,7 +337,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-basis: 75%;
 }
 
-.c37 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -323,7 +352,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c38 {
+.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -357,7 +386,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c16 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -385,7 +414,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-wrap: wrap;
 }
 
-.c32 {
+.c33 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -395,7 +424,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   height: 24px;
 }
 
-.c35 {
+.c36 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -423,21 +452,21 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   line-height: 24px;
 }
 
-.c15 {
+.c16 {
   font-size: 12px;
   line-height: 18px;
   color: #a3a3a3;
   font-weight: 600;
 }
 
-.c24 {
+.c25 {
   font-size: 14px;
   line-height: 20px;
   color: #FFFFFF;
   font-weight: normal;
 }
 
-.c28 {
+.c29 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -446,7 +475,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   line-height: 24px;
 }
 
-.c39 {
+.c40 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
@@ -454,22 +483,22 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   overflow-wrap: break-word;
 }
 
-.c19 {
+.c20 {
   position: relative;
 }
 
-.c20 {
+.c21 {
   position: relative;
   display: block;
 }
 
-.c21 {
+.c22 {
   position: absolute;
   top: 0;
   right: 0;
 }
 
-.c23 {
+.c24 {
   margin-top: -10px;
   margin-right: -10px;
 }
@@ -531,7 +560,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   border: 0;
 }
 
-.c18 {
+.c19 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -549,44 +578,44 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   text-align: inherit;
 }
 
-.c18:focus {
+.c19:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus > circle,
-.c18:focus > ellipse,
-.c18:focus > line,
-.c18:focus > path,
-.c18:focus > polygon,
-.c18:focus > polyline,
-.c18:focus > rect {
+.c19:focus > circle,
+.c19:focus > ellipse,
+.c19:focus > line,
+.c19:focus > path,
+.c19:focus > polygon,
+.c19:focus > polyline,
+.c19:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c18:focus::-moz-focus-inner {
+.c19:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c18:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c18:focus:not(:focus-visible) > circle,.c18:focus:not(:focus-visible) > ellipse,
-.c18:focus:not(:focus-visible) > line,.c18:focus:not(:focus-visible) > path,
-.c18:focus:not(:focus-visible) > polygon,.c18:focus:not(:focus-visible) > polyline,
-.c18:focus:not(:focus-visible) > rect {
+.c19:focus:not(:focus-visible) > circle,.c19:focus:not(:focus-visible) > ellipse,
+.c19:focus:not(:focus-visible) > line,.c19:focus:not(:focus-visible) > path,
+.c19:focus:not(:focus-visible) > polygon,.c19:focus:not(:focus-visible) > polyline,
+.c19:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c18:focus:not(:focus-visible)::-moz-focus-inner {
+.c19:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c34 {
+.c35 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -615,48 +644,48 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   font-weight: bold;
 }
 
-.c34:hover {
+.c35:hover {
   box-shadow: 0px 0px 0px 2px #0092f6;
 }
 
-.c34:focus {
+.c35:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c34:focus > circle,
-.c34:focus > ellipse,
-.c34:focus > line,
-.c34:focus > path,
-.c34:focus > polygon,
-.c34:focus > polyline,
-.c34:focus > rect {
+.c35:focus > circle,
+.c35:focus > ellipse,
+.c35:focus > line,
+.c35:focus > path,
+.c35:focus > polygon,
+.c35:focus > polyline,
+.c35:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c34:focus::-moz-focus-inner {
+.c35:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c34:focus:not(:focus-visible) {
+.c35:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c34:focus:not(:focus-visible) > circle,.c34:focus:not(:focus-visible) > ellipse,
-.c34:focus:not(:focus-visible) > line,.c34:focus:not(:focus-visible) > path,
-.c34:focus:not(:focus-visible) > polygon,.c34:focus:not(:focus-visible) > polyline,
-.c34:focus:not(:focus-visible) > rect {
+.c35:focus:not(:focus-visible) > circle,.c35:focus:not(:focus-visible) > ellipse,
+.c35:focus:not(:focus-visible) > line,.c35:focus:not(:focus-visible) > path,
+.c35:focus:not(:focus-visible) > polygon,.c35:focus:not(:focus-visible) > polyline,
+.c35:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c34:focus:not(:focus-visible)::-moz-focus-inner {
+.c35:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -672,29 +701,29 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   padding: 12px 12px 6px;
 }
 
-.c14 dt,
-.c14 dd {
+.c15 dt,
+.c15 dd {
   margin: 0;
 }
 
-.c14 dt:first-of-type,
-.c14 dd:first-of-type {
+.c15 dt:first-of-type,
+.c15 dd:first-of-type {
   font-weight: bold;
 }
 
-.c17 {
+.c18 {
   padding: 12px;
 }
 
-.c17:hover {
+.c18:hover {
   background-color: #11111108;
 }
 
-.c17.active {
+.c18.active {
   background-color: #EFEFEF;
 }
 
-.c31 {
+.c32 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -712,33 +741,33 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   border: none;
 }
 
-.c31::-webkit-input-placeholder {
+.c32::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c31::-moz-placeholder {
+.c32::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c31:-ms-input-placeholder {
+.c32:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c31::-webkit-search-decoration {
+.c32::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c31::-moz-focus-inner {
+.c32::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c31:-moz-placeholder,
-.c31::-moz-placeholder {
+.c32:-moz-placeholder,
+.c32::-moz-placeholder {
   opacity: 1;
 }
 
-.c30 {
+.c31 {
   position: relative;
   width: 100%;
 }
@@ -810,13 +839,13 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c22 {
+  .c23 {
     border-radius: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c25 {
+  .c26 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -835,63 +864,63 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c27 {
+  .c28 {
     padding: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c29 {
+  .c30 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c33 {
+  .c34 {
     margin-top: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c37 {
+  .c38 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c38 {
+  .c39 {
     border: solid 1px #EDEDED;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c38 {
+  .c39 {
     padding: 24px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c17 {
     margin-top: 6px;
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c32 {
+  .c33 {
     height: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c35 {
+  .c36 {
     width: auto;
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c39 {
+  .c40 {
     font-size: 18px;
     line-height: 24px;
     max-width: 432px;
@@ -899,20 +928,20 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (min-width:768px) {
-  .c14 dt {
+  .c15 dt {
     width: 40%;
   }
 
-  .c14 dd {
+  .c15 dd {
     width: 60%;
   }
 
-  .c14 dt:not(:last-of-type),.c14 dd:not(:last-of-type) {
+  .c15 dt:not(:last-of-type),.c15 dd:not(:last-of-type) {
     margin-bottom: 6px;
   }
 
-  .c14 dt:first-of-type,
-  .c14 dd:first-of-type {
+  .c15 dt:first-of-type,
+  .c15 dd:first-of-type {
     font-size: 22px;
     line-height: 28px;
     margin-bottom: 12px;
@@ -920,26 +949,26 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c14 dt {
+  .c15 dt {
     width: 30%;
   }
 
-  .c14 dd {
+  .c15 dd {
     width: 70%;
     text-align: right;
   }
 
-  .c14 dt,
-  .c14 dd {
+  .c15 dt,
+  .c15 dd {
     font-size: 16px;
   }
 
-  .c14 dt:not(:last-of-type),.c14 dd:not(:last-of-type) {
+  .c15 dt:not(:last-of-type),.c15 dd:not(:last-of-type) {
     margin-bottom: 3px;
   }
 
-  .c14 dt:first-of-type,
-  .c14 dd:first-of-type {
+  .c15 dt:first-of-type,
+  .c15 dd:first-of-type {
     font-size: 18px;
     line-height: 24px;
     margin-bottom: 6px;
@@ -947,7 +976,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c18 {
     padding: 6px;
   }
 }
@@ -1009,6 +1038,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
             </button>
             <span
               class="c12"
+              style="flex: 1;"
             >
               <span
                 class="c13"
@@ -1022,9 +1052,26 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                 </span>
               </span>
             </span>
+            <button
+              class="c10"
+              type="button"
+            >
+              <svg
+                aria-label="Edit"
+                class="c14"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m14 4 6 6-6-6zm8.294 1.294c.39.39.387 1.025-.008 1.42L9 20l-7 2 2-7L17.286 1.714a1 1 0 0 1 1.42-.008l3.588 3.588zM3 19l2 2m2-4 8-8"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
           </div>
           <dl
-            class="c14"
+            class="c15"
             data-testid="account-balance-summary"
           >
             <dt>
@@ -1042,7 +1089,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   100.000001111
                 </span>
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   <span
                     class="notranslate"
@@ -1062,7 +1109,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   100.0
                 </span>
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   <span
                     class="notranslate"
@@ -1083,7 +1130,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   0.000001111
                 </span>
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   <span
                     class="notranslate"
@@ -1103,7 +1150,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   0.0
                 </span>
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   <span
                     class="notranslate"
@@ -1119,15 +1166,15 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
       </div>
     </div>
     <nav
-      class="c16"
+      class="c17"
     >
       <a
         aria-current="page"
-        class="c17 active"
+        class="c18 active"
         href="/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk"
       >
         <button
-          class="c18"
+          class="c19"
           tabindex="-1"
           type="button"
         >
@@ -1135,17 +1182,17 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
         </button>
       </a>
       <a
-        class="c17"
+        class="c18"
         href="/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk/active-delegations"
       >
         <div
-          class="c19"
+          class="c20"
         >
           <div
-            class="c20"
+            class="c21"
           >
             <button
-              class="c18"
+              class="c19"
               tabindex="-1"
               type="button"
             >
@@ -1153,15 +1200,15 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
             </button>
           </div>
           <div
-            class="c21"
+            class="c22"
             style="top: 0px; right: 0px; transform: translate(50%, -50%); transform-origin: 100% 0%;"
           >
             <div
-              class="c22 c23"
+              class="c23 c24"
               style="min-height: 20px; min-width: 20px;"
             >
               <span
-                class="c24"
+                class="c25"
               >
                 1
               </span>
@@ -1170,11 +1217,11 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
         </div>
       </a>
       <a
-        class="c17"
+        class="c18"
         href="/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk/debonding-delegations"
       >
         <button
-          class="c18"
+          class="c19"
           tabindex="-1"
           type="button"
         >
@@ -1183,38 +1230,38 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
       </a>
     </nav>
     <div
-      class="c25"
+      class="c26"
     >
       <div
-        class="c26"
+        class="c27"
       >
         <div
           class="c6"
         >
           <form>
             <div
-              class="c27"
+              class="c28"
             >
               <div
                 class="c2 "
               >
                 <label
-                  class="c28"
+                  class="c29"
                   for="recipient-id"
                 >
                   Recipient
                 </label>
                 <div
-                  class="c29 "
+                  class="c30 "
                 >
                   <div
-                    class="c30"
+                    class="c31"
                   >
                     <input
                       aria-autocomplete="list"
                       aria-expanded="false"
                       autocomplete="off"
-                      class="c31"
+                      class="c32"
                       id="recipient-id"
                       name="recipient"
                       placeholder="Enter an address"
@@ -1226,26 +1273,26 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c32"
+                class="c33"
               />
               <div
                 class="c2 "
               >
                 <label
-                  class="c28"
+                  class="c29"
                   for="amount-id"
                 >
                   Amount
                 </label>
                 <div
-                  class="c29 "
+                  class="c30 "
                 >
                   <div
-                    class="c30"
+                    class="c31"
                   >
                     <input
                       autocomplete="off"
-                      class="c31"
+                      class="c32"
                       id="amount-id"
                       min="0"
                       name="amount"
@@ -1259,13 +1306,13 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c32"
+                class="c33"
               />
               <div
-                class="c33"
+                class="c34"
               >
                 <button
-                  class="c34"
+                  class="c35"
                   type="submit"
                 >
                   Send
@@ -1276,19 +1323,19 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="c35"
+        class="c36"
       />
       <div
-        class="c36"
+        class="c37"
       >
         <div
-          class="c37"
+          class="c38"
         >
           <div
-            class="c38"
+            class="c39"
           >
             <h3
-              class="c39"
+              class="c40"
             >
               No transactions found.
             </h3>

--- a/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -150,6 +150,10 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding: 12px;
 }
 
@@ -180,7 +184,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin-right: 96px;
+  margin-right: 48px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -191,6 +195,10 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  width: 680px;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
 }
 
 .c23 {
@@ -823,7 +831,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 
 @media only screen and (max-width:768px) {
   .c10 {
-    margin-right: 48px;
+    margin-right: 24px;
   }
 }
 
@@ -1040,7 +1048,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
               </button>
               <span
                 class="c13"
-                style="flex: 1;"
+                style="flex: 1; width: 680px;"
               >
                 <span
                   class="c14"

--- a/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -157,50 +157,6 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   padding: 12px;
 }
 
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding-right: 12px;
-  border-radius: 5px;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-right: 48px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-bottom: solid 1px #EDEDED;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  width: 680px;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-}
-
 .c23 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -380,6 +336,49 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   max-width: 100%;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-right: 12px;
+  border-radius: 5px;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 1px #EDEDED;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 680px;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
 }
 
 .c17 {
@@ -824,21 +823,15 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
-    padding-right: 6px;
-  }
+
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
-    margin-right: 24px;
-  }
+
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
-    border-bottom: solid 1px #EDEDED;
-  }
+
 }
 
 @media only screen and (max-width:768px) {
@@ -903,6 +896,18 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 @media only screen and (max-width:768px) {
   .c39 {
     padding: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    border-bottom: solid 1px #EDEDED;
   }
 }
 

--- a/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<AccountPage  /> should match snapshot 1`] = `
-.c11 {
+.c12 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,28 +12,28 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   stroke: #666666;
 }
 
-.c11 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c11 *:not([stroke])[fill='none'] {
+.c12 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c11 *[stroke*='#'],.c11 *[STROKE*='#'] {
+.c12 *[stroke*='#'],.c12 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c11 *[fill-rule],
-.c11 *[FILL-RULE],
-.c11 *[fill*='#'],.c11 *[FILL*='#'] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],.c12 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c14 {
+.c15 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -44,23 +44,23 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   stroke: #0092f6;
 }
 
-.c14 g {
+.c15 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill='none'] {
+.c15 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*='#'],.c14 *[STROKE*='#'] {
+.c15 *[stroke*='#'],.c15 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*='#'],.c14 *[FILL*='#'] {
+.c15 *[fill-rule],
+.c15 *[FILL-RULE],
+.c15 *[fill*='#'],.c15 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -205,7 +205,27 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   border-radius: 5px;
 }
 
-.c23 {
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 96px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 1px #EDEDED;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -233,7 +253,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   border-radius: 24px;
 }
 
-.c26 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -247,7 +267,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-direction: row;
 }
 
-.c27 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -267,7 +287,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-basis: 25%;
 }
 
-.c28 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -284,7 +304,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   padding: 24px;
 }
 
-.c30 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -299,7 +319,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c34 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -318,7 +338,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c37 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -337,7 +357,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-basis: 75%;
 }
 
-.c38 {
+.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -352,7 +372,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c39 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -386,7 +406,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -414,7 +434,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-wrap: wrap;
 }
 
-.c33 {
+.c34 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -424,7 +444,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   height: 24px;
 }
 
-.c36 {
+.c37 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -440,33 +460,33 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   font-weight: bold;
 }
 
-.c12 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
   word-break: break-word;
 }
 
-.c13 {
+.c14 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c16 {
+.c17 {
   font-size: 12px;
   line-height: 18px;
   color: #a3a3a3;
   font-weight: 600;
 }
 
-.c25 {
+.c26 {
   font-size: 14px;
   line-height: 20px;
   color: #FFFFFF;
   font-weight: normal;
 }
 
-.c29 {
+.c30 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -475,7 +495,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   line-height: 24px;
 }
 
-.c40 {
+.c41 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
@@ -483,27 +503,27 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   overflow-wrap: break-word;
 }
 
-.c20 {
+.c21 {
   position: relative;
 }
 
-.c21 {
+.c22 {
   position: relative;
   display: block;
 }
 
-.c22 {
+.c23 {
   position: absolute;
   top: 0;
   right: 0;
 }
 
-.c24 {
+.c25 {
   margin-top: -10px;
   margin-right: -10px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -523,44 +543,44 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c19 {
+.c20 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -578,44 +598,44 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   text-align: inherit;
 }
 
-.c19:focus {
+.c20:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c19:focus > circle,
-.c19:focus > ellipse,
-.c19:focus > line,
-.c19:focus > path,
-.c19:focus > polygon,
-.c19:focus > polyline,
-.c19:focus > rect {
+.c20:focus > circle,
+.c20:focus > ellipse,
+.c20:focus > line,
+.c20:focus > path,
+.c20:focus > polygon,
+.c20:focus > polyline,
+.c20:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c19:focus::-moz-focus-inner {
+.c20:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c19:focus:not(:focus-visible) {
+.c20:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c19:focus:not(:focus-visible) > circle,.c19:focus:not(:focus-visible) > ellipse,
-.c19:focus:not(:focus-visible) > line,.c19:focus:not(:focus-visible) > path,
-.c19:focus:not(:focus-visible) > polygon,.c19:focus:not(:focus-visible) > polyline,
-.c19:focus:not(:focus-visible) > rect {
+.c20:focus:not(:focus-visible) > circle,.c20:focus:not(:focus-visible) > ellipse,
+.c20:focus:not(:focus-visible) > line,.c20:focus:not(:focus-visible) > path,
+.c20:focus:not(:focus-visible) > polygon,.c20:focus:not(:focus-visible) > polyline,
+.c20:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c19:focus:not(:focus-visible)::-moz-focus-inner {
+.c20:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c35 {
+.c36 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -644,48 +664,48 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   font-weight: bold;
 }
 
-.c35:hover {
+.c36:hover {
   box-shadow: 0px 0px 0px 2px #0092f6;
 }
 
-.c35:focus {
+.c36:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c35:focus > circle,
-.c35:focus > ellipse,
-.c35:focus > line,
-.c35:focus > path,
-.c35:focus > polygon,
-.c35:focus > polyline,
-.c35:focus > rect {
+.c36:focus > circle,
+.c36:focus > ellipse,
+.c36:focus > line,
+.c36:focus > path,
+.c36:focus > polygon,
+.c36:focus > polyline,
+.c36:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c35:focus::-moz-focus-inner {
+.c36:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c35:focus:not(:focus-visible) {
+.c36:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c35:focus:not(:focus-visible) > circle,.c35:focus:not(:focus-visible) > ellipse,
-.c35:focus:not(:focus-visible) > line,.c35:focus:not(:focus-visible) > path,
-.c35:focus:not(:focus-visible) > polygon,.c35:focus:not(:focus-visible) > polyline,
-.c35:focus:not(:focus-visible) > rect {
+.c36:focus:not(:focus-visible) > circle,.c36:focus:not(:focus-visible) > ellipse,
+.c36:focus:not(:focus-visible) > line,.c36:focus:not(:focus-visible) > path,
+.c36:focus:not(:focus-visible) > polygon,.c36:focus:not(:focus-visible) > polyline,
+.c36:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c35:focus:not(:focus-visible)::-moz-focus-inner {
+.c36:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c15 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -696,34 +716,33 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  border-top: solid 1px #EDEDED;
   margin: 6px 0 0;
   padding: 12px 12px 6px;
 }
 
-.c15 dt,
-.c15 dd {
+.c16 dt,
+.c16 dd {
   margin: 0;
 }
 
-.c15 dt:first-of-type,
-.c15 dd:first-of-type {
+.c16 dt:first-of-type,
+.c16 dd:first-of-type {
   font-weight: bold;
 }
 
-.c18 {
+.c19 {
   padding: 12px;
 }
 
-.c18:hover {
+.c19:hover {
   background-color: #11111108;
 }
 
-.c18.active {
+.c19.active {
   background-color: #EFEFEF;
 }
 
-.c32 {
+.c33 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -741,33 +760,33 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   border: none;
 }
 
-.c32::-webkit-input-placeholder {
+.c33::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c32::-moz-placeholder {
+.c33::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c32:-ms-input-placeholder {
+.c33:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c32::-webkit-search-decoration {
+.c33::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c32::-moz-focus-inner {
+.c33::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c32:-moz-placeholder,
-.c32::-moz-placeholder {
+.c33:-moz-placeholder,
+.c33::-moz-placeholder {
   opacity: 1;
 }
 
-.c31 {
+.c32 {
   position: relative;
   width: 100%;
 }
@@ -835,17 +854,29 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+  .c10 {
+    margin-right: 48px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    border-bottom: solid 1px #EDEDED;
+  }
+}
+
+@media only screen and (max-width:768px) {
 
 }
 
 @media only screen and (max-width:768px) {
-  .c23 {
+  .c24 {
     border-radius: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c26 {
+  .c27 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -864,63 +895,63 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c28 {
+  .c29 {
     padding: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c30 {
+  .c31 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c34 {
+  .c35 {
     margin-top: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c38 {
+  .c39 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c39 {
+  .c40 {
     border: solid 1px #EDEDED;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c39 {
+  .c40 {
     padding: 24px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c18 {
     margin-top: 6px;
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c33 {
+  .c34 {
     height: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c36 {
+  .c37 {
     width: auto;
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c40 {
+  .c41 {
     font-size: 18px;
     line-height: 24px;
     max-width: 432px;
@@ -928,20 +959,20 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (min-width:768px) {
-  .c15 dt {
+  .c16 dt {
     width: 40%;
   }
 
-  .c15 dd {
+  .c16 dd {
     width: 60%;
   }
 
-  .c15 dt:not(:last-of-type),.c15 dd:not(:last-of-type) {
+  .c16 dt:not(:last-of-type),.c16 dd:not(:last-of-type) {
     margin-bottom: 6px;
   }
 
-  .c15 dt:first-of-type,
-  .c15 dd:first-of-type {
+  .c16 dt:first-of-type,
+  .c16 dd:first-of-type {
     font-size: 22px;
     line-height: 28px;
     margin-bottom: 12px;
@@ -949,26 +980,26 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c15 dt {
+  .c16 dt {
     width: 30%;
   }
 
-  .c15 dd {
+  .c16 dd {
     width: 70%;
     text-align: right;
   }
 
-  .c15 dt,
-  .c15 dd {
+  .c16 dt,
+  .c16 dd {
     font-size: 16px;
   }
 
-  .c15 dt:not(:last-of-type),.c15 dd:not(:last-of-type) {
+  .c16 dt:not(:last-of-type),.c16 dd:not(:last-of-type) {
     margin-bottom: 3px;
   }
 
-  .c15 dt:first-of-type,
-  .c15 dd:first-of-type {
+  .c16 dt:first-of-type,
+  .c16 dd:first-of-type {
     font-size: 18px;
     line-height: 24px;
     margin-bottom: 6px;
@@ -976,7 +1007,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c18 {
+  .c19 {
     padding: 6px;
   }
 }
@@ -1018,65 +1049,69 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
           <div
             class="c9"
           >
-            <button
+            <div
               class="c10"
-              data-testid="copy-address"
-              type="button"
             >
-              <svg
-                aria-label="Copy"
+              <button
                 class="c11"
-                viewBox="0 0 24 24"
+                data-testid="copy-address"
+                type="button"
               >
-                <path
-                  d="M9 15h8-8zm0-4h10H9zm0-4h4-4zm7-6v6h6M6 5H2v18h16v-4m4 0H6V1h11l5 5v13z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </button>
-            <span
-              class="c12"
-              style="flex: 1;"
-            >
+                <svg
+                  aria-label="Copy"
+                  class="c12"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M9 15h8-8zm0-4h10H9zm0-4h4-4zm7-6v6h6M6 5H2v18h16v-4m4 0H6V1h11l5 5v13z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </button>
               <span
                 class="c13"
-                style="font-family: Roboto mono; letter-spacing: 0;"
+                style="flex: 1;"
               >
                 <span
-                  class="notranslate"
-                  translate="no"
+                  class="c14"
+                  style="font-family: Roboto mono; letter-spacing: 0;"
                 >
-                  oasis1 qz0k 5q8v jqvu 4s4n wxyj 406y lnfl kc4v rcjg huwk
+                  <span
+                    class="notranslate"
+                    translate="no"
+                  >
+                    oasis1 qz0k 5q8v jqvu 4s4n wxyj 406y lnfl kc4v rcjg huwk
+                  </span>
                 </span>
               </span>
-            </span>
-            <button
-              class="c10"
-              type="button"
-            >
-              <svg
-                aria-label="Edit"
-                class="c14"
-                viewBox="0 0 24 24"
+              <button
+                class="c11"
+                type="button"
               >
-                <path
-                  d="m14 4 6 6-6-6zm8.294 1.294c.39.39.387 1.025-.008 1.42L9 20l-7 2 2-7L17.286 1.714a1 1 0 0 1 1.42-.008l3.588 3.588zM3 19l2 2m2-4 8-8"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-label="Edit"
+                  class="c15"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m14 4 6 6-6-6zm8.294 1.294c.39.39.387 1.025-.008 1.42L9 20l-7 2 2-7L17.286 1.714a1 1 0 0 1 1.42-.008l3.588 3.588zM3 19l2 2m2-4 8-8"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
           <dl
-            class="c15"
+            class="c16"
             data-testid="account-balance-summary"
           >
             <dt>
               <span
-                class="c13"
+                class="c14"
               >
                 Total
               </span>
@@ -1089,7 +1124,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   100.000001111
                 </span>
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <span
                     class="notranslate"
@@ -1109,7 +1144,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   100.0
                 </span>
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <span
                     class="notranslate"
@@ -1130,7 +1165,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   0.000001111
                 </span>
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <span
                     class="notranslate"
@@ -1150,7 +1185,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   0.0
                 </span>
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <span
                     class="notranslate"
@@ -1166,15 +1201,15 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
       </div>
     </div>
     <nav
-      class="c17"
+      class="c18"
     >
       <a
         aria-current="page"
-        class="c18 active"
+        class="c19 active"
         href="/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk"
       >
         <button
-          class="c19"
+          class="c20"
           tabindex="-1"
           type="button"
         >
@@ -1182,17 +1217,17 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
         </button>
       </a>
       <a
-        class="c18"
+        class="c19"
         href="/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk/active-delegations"
       >
         <div
-          class="c20"
+          class="c21"
         >
           <div
-            class="c21"
+            class="c22"
           >
             <button
-              class="c19"
+              class="c20"
               tabindex="-1"
               type="button"
             >
@@ -1200,15 +1235,15 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
             </button>
           </div>
           <div
-            class="c22"
+            class="c23"
             style="top: 0px; right: 0px; transform: translate(50%, -50%); transform-origin: 100% 0%;"
           >
             <div
-              class="c23 c24"
+              class="c24 c25"
               style="min-height: 20px; min-width: 20px;"
             >
               <span
-                class="c25"
+                class="c26"
               >
                 1
               </span>
@@ -1217,11 +1252,11 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
         </div>
       </a>
       <a
-        class="c18"
+        class="c19"
         href="/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk/debonding-delegations"
       >
         <button
-          class="c19"
+          class="c20"
           tabindex="-1"
           type="button"
         >
@@ -1230,38 +1265,38 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
       </a>
     </nav>
     <div
-      class="c26"
+      class="c27"
     >
       <div
-        class="c27"
+        class="c28"
       >
         <div
           class="c6"
         >
           <form>
             <div
-              class="c28"
+              class="c29"
             >
               <div
                 class="c2 "
               >
                 <label
-                  class="c29"
+                  class="c30"
                   for="recipient-id"
                 >
                   Recipient
                 </label>
                 <div
-                  class="c30 "
+                  class="c31 "
                 >
                   <div
-                    class="c31"
+                    class="c32"
                   >
                     <input
                       aria-autocomplete="list"
                       aria-expanded="false"
                       autocomplete="off"
-                      class="c32"
+                      class="c33"
                       id="recipient-id"
                       name="recipient"
                       placeholder="Enter an address"
@@ -1273,26 +1308,26 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c33"
+                class="c34"
               />
               <div
                 class="c2 "
               >
                 <label
-                  class="c29"
+                  class="c30"
                   for="amount-id"
                 >
                   Amount
                 </label>
                 <div
-                  class="c30 "
+                  class="c31 "
                 >
                   <div
-                    class="c31"
+                    class="c32"
                   >
                     <input
                       autocomplete="off"
-                      class="c32"
+                      class="c33"
                       id="amount-id"
                       min="0"
                       name="amount"
@@ -1306,13 +1341,13 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c33"
+                class="c34"
               />
               <div
-                class="c34"
+                class="c35"
               >
                 <button
-                  class="c35"
+                  class="c36"
                   type="submit"
                 >
                   Send
@@ -1323,19 +1358,19 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="c36"
+        class="c37"
       />
       <div
-        class="c37"
+        class="c38"
       >
         <div
-          class="c38"
+          class="c39"
         >
           <div
-            class="c39"
+            class="c40"
           >
             <h3
-              class="c40"
+              class="c41"
             >
               No transactions found.
             </h3>

--- a/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -33,38 +33,6 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   stroke: none;
 }
 
-.c15 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 16px;
-  height: 16px;
-  fill: #0092f6;
-  stroke: #0092f6;
-}
-
-.c15 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c15 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c15 *[stroke*='#'],.c15 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c15 *[fill-rule],
-.c15 *[FILL-RULE],
-.c15 *[fill*='#'],.c15 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
 .c0 {
   font-family: Rubik;
   font-size: 18px;
@@ -225,7 +193,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-direction: row;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -253,7 +221,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   border-radius: 24px;
 }
 
-.c27 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -267,7 +235,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-direction: row;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -287,7 +255,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-basis: 25%;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -304,7 +272,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   padding: 24px;
 }
 
-.c31 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -319,7 +287,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c35 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -338,7 +306,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c38 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -357,7 +325,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-basis: 75%;
 }
 
-.c39 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -372,7 +340,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c40 {
+.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -406,7 +374,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -434,7 +402,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   flex-wrap: wrap;
 }
 
-.c34 {
+.c33 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -444,7 +412,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   height: 24px;
 }
 
-.c37 {
+.c36 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -472,21 +440,21 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   line-height: 24px;
 }
 
-.c17 {
+.c16 {
   font-size: 12px;
   line-height: 18px;
   color: #a3a3a3;
   font-weight: 600;
 }
 
-.c26 {
+.c25 {
   font-size: 14px;
   line-height: 20px;
   color: #FFFFFF;
   font-weight: normal;
 }
 
-.c30 {
+.c29 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -495,7 +463,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   line-height: 24px;
 }
 
-.c41 {
+.c40 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
@@ -503,22 +471,22 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   overflow-wrap: break-word;
 }
 
-.c21 {
+.c20 {
   position: relative;
 }
 
-.c22 {
+.c21 {
   position: relative;
   display: block;
 }
 
-.c23 {
+.c22 {
   position: absolute;
   top: 0;
   right: 0;
 }
 
-.c25 {
+.c24 {
   margin-top: -10px;
   margin-right: -10px;
 }
@@ -580,7 +548,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   border: 0;
 }
 
-.c20 {
+.c19 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -598,44 +566,44 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   text-align: inherit;
 }
 
-.c20:focus {
+.c19:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c19:focus > circle,
+.c19:focus > ellipse,
+.c19:focus > line,
+.c19:focus > path,
+.c19:focus > polygon,
+.c19:focus > polyline,
+.c19:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c19:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c20:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible) > circle,.c20:focus:not(:focus-visible) > ellipse,
-.c20:focus:not(:focus-visible) > line,.c20:focus:not(:focus-visible) > path,
-.c20:focus:not(:focus-visible) > polygon,.c20:focus:not(:focus-visible) > polyline,
-.c20:focus:not(:focus-visible) > rect {
+.c19:focus:not(:focus-visible) > circle,.c19:focus:not(:focus-visible) > ellipse,
+.c19:focus:not(:focus-visible) > line,.c19:focus:not(:focus-visible) > path,
+.c19:focus:not(:focus-visible) > polygon,.c19:focus:not(:focus-visible) > polyline,
+.c19:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible)::-moz-focus-inner {
+.c19:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c36 {
+.c35 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -664,48 +632,48 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   font-weight: bold;
 }
 
-.c36:hover {
+.c35:hover {
   box-shadow: 0px 0px 0px 2px #0092f6;
 }
 
-.c36:focus {
+.c35:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c36:focus > circle,
-.c36:focus > ellipse,
-.c36:focus > line,
-.c36:focus > path,
-.c36:focus > polygon,
-.c36:focus > polyline,
-.c36:focus > rect {
+.c35:focus > circle,
+.c35:focus > ellipse,
+.c35:focus > line,
+.c35:focus > path,
+.c35:focus > polygon,
+.c35:focus > polyline,
+.c35:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c36:focus::-moz-focus-inner {
+.c35:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c36:focus:not(:focus-visible) {
+.c35:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c36:focus:not(:focus-visible) > circle,.c36:focus:not(:focus-visible) > ellipse,
-.c36:focus:not(:focus-visible) > line,.c36:focus:not(:focus-visible) > path,
-.c36:focus:not(:focus-visible) > polygon,.c36:focus:not(:focus-visible) > polyline,
-.c36:focus:not(:focus-visible) > rect {
+.c35:focus:not(:focus-visible) > circle,.c35:focus:not(:focus-visible) > ellipse,
+.c35:focus:not(:focus-visible) > line,.c35:focus:not(:focus-visible) > path,
+.c35:focus:not(:focus-visible) > polygon,.c35:focus:not(:focus-visible) > polyline,
+.c35:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c36:focus:not(:focus-visible)::-moz-focus-inner {
+.c35:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -720,29 +688,29 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   padding: 12px 12px 6px;
 }
 
-.c16 dt,
-.c16 dd {
+.c15 dt,
+.c15 dd {
   margin: 0;
 }
 
-.c16 dt:first-of-type,
-.c16 dd:first-of-type {
+.c15 dt:first-of-type,
+.c15 dd:first-of-type {
   font-weight: bold;
 }
 
-.c19 {
+.c18 {
   padding: 12px;
 }
 
-.c19:hover {
+.c18:hover {
   background-color: #11111108;
 }
 
-.c19.active {
+.c18.active {
   background-color: #EFEFEF;
 }
 
-.c33 {
+.c32 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -760,33 +728,33 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   border: none;
 }
 
-.c33::-webkit-input-placeholder {
+.c32::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c33::-moz-placeholder {
+.c32::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c33:-ms-input-placeholder {
+.c32:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c33::-webkit-search-decoration {
+.c32::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c33::-moz-focus-inner {
+.c32::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c33:-moz-placeholder,
-.c33::-moz-placeholder {
+.c32:-moz-placeholder,
+.c32::-moz-placeholder {
   opacity: 1;
 }
 
-.c32 {
+.c31 {
   position: relative;
   width: 100%;
 }
@@ -870,13 +838,13 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c24 {
+  .c23 {
     border-radius: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c27 {
+  .c26 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -895,63 +863,63 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c29 {
+  .c28 {
     padding: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c31 {
+  .c30 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c35 {
+  .c34 {
     margin-top: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c39 {
+  .c38 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c40 {
+  .c39 {
     border: solid 1px #EDEDED;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c40 {
+  .c39 {
     padding: 24px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c18 {
+  .c17 {
     margin-top: 6px;
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c34 {
+  .c33 {
     height: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c37 {
+  .c36 {
     width: auto;
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c41 {
+  .c40 {
     font-size: 18px;
     line-height: 24px;
     max-width: 432px;
@@ -959,20 +927,20 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (min-width:768px) {
-  .c16 dt {
+  .c15 dt {
     width: 40%;
   }
 
-  .c16 dd {
+  .c15 dd {
     width: 60%;
   }
 
-  .c16 dt:not(:last-of-type),.c16 dd:not(:last-of-type) {
+  .c15 dt:not(:last-of-type),.c15 dd:not(:last-of-type) {
     margin-bottom: 6px;
   }
 
-  .c16 dt:first-of-type,
-  .c16 dd:first-of-type {
+  .c15 dt:first-of-type,
+  .c15 dd:first-of-type {
     font-size: 22px;
     line-height: 28px;
     margin-bottom: 12px;
@@ -980,26 +948,26 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c16 dt {
+  .c15 dt {
     width: 30%;
   }
 
-  .c16 dd {
+  .c15 dd {
     width: 70%;
     text-align: right;
   }
 
-  .c16 dt,
-  .c16 dd {
+  .c15 dt,
+  .c15 dd {
     font-size: 16px;
   }
 
-  .c16 dt:not(:last-of-type),.c16 dd:not(:last-of-type) {
+  .c15 dt:not(:last-of-type),.c15 dd:not(:last-of-type) {
     margin-bottom: 3px;
   }
 
-  .c16 dt:first-of-type,
-  .c16 dd:first-of-type {
+  .c15 dt:first-of-type,
+  .c15 dd:first-of-type {
     font-size: 18px;
     line-height: 24px;
     margin-bottom: 6px;
@@ -1007,7 +975,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c19 {
+  .c18 {
     padding: 6px;
   }
 }
@@ -1086,27 +1054,10 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   </span>
                 </span>
               </span>
-              <button
-                class="c11"
-                type="button"
-              >
-                <svg
-                  aria-label="Edit"
-                  class="c15"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m14 4 6 6-6-6zm8.294 1.294c.39.39.387 1.025-.008 1.42L9 20l-7 2 2-7L17.286 1.714a1 1 0 0 1 1.42-.008l3.588 3.588zM3 19l2 2m2-4 8-8"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </button>
             </div>
           </div>
           <dl
-            class="c16"
+            class="c15"
             data-testid="account-balance-summary"
           >
             <dt>
@@ -1124,7 +1075,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   100.000001111
                 </span>
                 <span
-                  class="c17"
+                  class="c16"
                 >
                   <span
                     class="notranslate"
@@ -1144,7 +1095,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   100.0
                 </span>
                 <span
-                  class="c17"
+                  class="c16"
                 >
                   <span
                     class="notranslate"
@@ -1165,7 +1116,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   0.000001111
                 </span>
                 <span
-                  class="c17"
+                  class="c16"
                 >
                   <span
                     class="notranslate"
@@ -1185,7 +1136,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                   0.0
                 </span>
                 <span
-                  class="c17"
+                  class="c16"
                 >
                   <span
                     class="notranslate"
@@ -1201,15 +1152,15 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
       </div>
     </div>
     <nav
-      class="c18"
+      class="c17"
     >
       <a
         aria-current="page"
-        class="c19 active"
+        class="c18 active"
         href="/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk"
       >
         <button
-          class="c20"
+          class="c19"
           tabindex="-1"
           type="button"
         >
@@ -1217,17 +1168,17 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
         </button>
       </a>
       <a
-        class="c19"
+        class="c18"
         href="/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk/active-delegations"
       >
         <div
-          class="c21"
+          class="c20"
         >
           <div
-            class="c22"
+            class="c21"
           >
             <button
-              class="c20"
+              class="c19"
               tabindex="-1"
               type="button"
             >
@@ -1235,15 +1186,15 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
             </button>
           </div>
           <div
-            class="c23"
+            class="c22"
             style="top: 0px; right: 0px; transform: translate(50%, -50%); transform-origin: 100% 0%;"
           >
             <div
-              class="c24 c25"
+              class="c23 c24"
               style="min-height: 20px; min-width: 20px;"
             >
               <span
-                class="c26"
+                class="c25"
               >
                 1
               </span>
@@ -1252,11 +1203,11 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
         </div>
       </a>
       <a
-        class="c19"
+        class="c18"
         href="/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk/debonding-delegations"
       >
         <button
-          class="c20"
+          class="c19"
           tabindex="-1"
           type="button"
         >
@@ -1265,38 +1216,38 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
       </a>
     </nav>
     <div
-      class="c27"
+      class="c26"
     >
       <div
-        class="c28"
+        class="c27"
       >
         <div
           class="c6"
         >
           <form>
             <div
-              class="c29"
+              class="c28"
             >
               <div
                 class="c2 "
               >
                 <label
-                  class="c30"
+                  class="c29"
                   for="recipient-id"
                 >
                   Recipient
                 </label>
                 <div
-                  class="c31 "
+                  class="c30 "
                 >
                   <div
-                    class="c32"
+                    class="c31"
                   >
                     <input
                       aria-autocomplete="list"
                       aria-expanded="false"
                       autocomplete="off"
-                      class="c33"
+                      class="c32"
                       id="recipient-id"
                       name="recipient"
                       placeholder="Enter an address"
@@ -1308,26 +1259,26 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c34"
+                class="c33"
               />
               <div
                 class="c2 "
               >
                 <label
-                  class="c30"
+                  class="c29"
                   for="amount-id"
                 >
                   Amount
                 </label>
                 <div
-                  class="c31 "
+                  class="c30 "
                 >
                   <div
-                    class="c32"
+                    class="c31"
                   >
                     <input
                       autocomplete="off"
-                      class="c33"
+                      class="c32"
                       id="amount-id"
                       min="0"
                       name="amount"
@@ -1341,13 +1292,13 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c34"
+                class="c33"
               />
               <div
-                class="c35"
+                class="c34"
               >
                 <button
-                  class="c36"
+                  class="c35"
                   type="submit"
                 >
                   Send
@@ -1358,19 +1309,19 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="c37"
+        class="c36"
       />
       <div
-        class="c38"
+        class="c37"
       >
         <div
-          class="c39"
+          class="c38"
         >
           <div
-            class="c40"
+            class="c39"
           >
             <h3
-              class="c41"
+              class="c40"
             >
               No transactions found.
             </h3>

--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -26,6 +26,7 @@ import { profileActions } from 'app/state/profile'
 import { accountActions } from 'app/state/account'
 import { selectAccount } from 'app/state/account/selectors'
 import { selectName } from 'app/state/wallet/selectors'
+import { selectUnlockedStatus } from 'app/state/selectUnlockedStatus'
 import { BalanceDetails } from 'app/state/account/types'
 import { selectAddress, selectHasAccounts } from 'app/state/wallet/selectors'
 import { AccountSummary } from './Features/AccountSummary'
@@ -79,6 +80,8 @@ export function AccountPage(props: AccountPageProps) {
   const walletAddress = useSelector(selectAddress)
   const walletName = useSelector(selectName)
   const selectedNetwork = useSelector(selectSelectedNetwork)
+  const unlockedStatus = useSelector(selectUnlockedStatus)
+  const hasProfile = unlockedStatus === 'unlockedProfile'
   const { active } = useSelector(selectTransaction)
 
   const balanceDelegations = stake.delegations?.reduce((acc, v) => acc + BigInt(v.amount), 0n)
@@ -136,6 +139,7 @@ export function AccountPage(props: AccountPageProps) {
             address={address}
             balance={balance}
             editHandler={() => dispatch(profileActions.setProfileModalOpen(true))}
+            hasProfile={hasProfile}
             walletAddress={walletAddress}
             walletName={walletName}
             walletHasAccounts={walletHasAccounts}

--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -22,7 +22,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { NavLink, Outlet, useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { normalizeColor } from 'grommet/es6/utils'
-
+import { profileActions } from 'app/state/profile'
 import { accountActions } from 'app/state/account'
 import { selectAccount } from 'app/state/account/selectors'
 import { BalanceDetails } from 'app/state/account/types'
@@ -133,6 +133,7 @@ export function AccountPage(props: AccountPageProps) {
           <AccountSummary
             address={address}
             balance={balance}
+            editHandler={() => dispatch(profileActions.setProfileModalOpen(true))}
             walletAddress={walletAddress}
             walletHasAccounts={walletHasAccounts}
           />

--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -25,6 +25,7 @@ import { normalizeColor } from 'grommet/es6/utils'
 import { profileActions } from 'app/state/profile'
 import { accountActions } from 'app/state/account'
 import { selectAccount } from 'app/state/account/selectors'
+import { selectName } from 'app/state/wallet/selectors'
 import { BalanceDetails } from 'app/state/account/types'
 import { selectAddress, selectHasAccounts } from 'app/state/wallet/selectors'
 import { AccountSummary } from './Features/AccountSummary'
@@ -76,6 +77,7 @@ export function AccountPage(props: AccountPageProps) {
 
   const walletHasAccounts = useSelector(selectHasAccounts)
   const walletAddress = useSelector(selectAddress)
+  const walletName = useSelector(selectName)
   const selectedNetwork = useSelector(selectSelectedNetwork)
   const { active } = useSelector(selectTransaction)
 
@@ -135,6 +137,7 @@ export function AccountPage(props: AccountPageProps) {
             balance={balance}
             editHandler={() => dispatch(profileActions.setProfileModalOpen(true))}
             walletAddress={walletAddress}
+            walletName={walletName}
             walletHasAccounts={walletHasAccounts}
           />
           <Nav

--- a/src/app/pages/AccountPage/index.tsx
+++ b/src/app/pages/AccountPage/index.tsx
@@ -138,7 +138,7 @@ export function AccountPage(props: AccountPageProps) {
           <AccountSummary
             address={address}
             balance={balance}
-            editHandler={() => dispatch(profileActions.setProfileModalOpen(true))}
+            editHandler={() => dispatch(profileActions.setManageAccountModalId(address))}
             hasProfile={hasProfile}
             walletAddress={walletAddress}
             walletName={walletName}

--- a/src/app/state/profile/index.ts
+++ b/src/app/state/profile/index.ts
@@ -1,0 +1,21 @@
+import { PayloadAction } from '@reduxjs/toolkit'
+import { createSlice } from 'utils/@reduxjs/toolkit'
+import { ProfileState } from './types'
+
+export const initialState: ProfileState = {
+  profileModalOpen: false,
+}
+
+const slice = createSlice({
+  name: 'profile',
+  initialState,
+  reducers: {
+    setProfileModalOpen(state, action: PayloadAction<boolean>) {
+      state.profileModalOpen = action.payload
+    },
+  },
+})
+
+export const { actions: profileActions } = slice
+
+export default slice.reducer

--- a/src/app/state/profile/index.ts
+++ b/src/app/state/profile/index.ts
@@ -3,6 +3,9 @@ import { createSlice } from 'utils/@reduxjs/toolkit'
 import { ProfileState } from './types'
 
 export const initialState: ProfileState = {
+  // Overlay layer with manage account view
+  manageAccountModalId: '',
+  // Main profile modal
   profileModalOpen: false,
 }
 
@@ -10,6 +13,10 @@ const slice = createSlice({
   name: 'profile',
   initialState,
   reducers: {
+    setManageAccountModalId(state, action: PayloadAction<string>) {
+      state.profileModalOpen = true
+      state.manageAccountModalId = action.payload
+    },
     setProfileModalOpen(state, action: PayloadAction<boolean>) {
       state.profileModalOpen = action.payload
     },

--- a/src/app/state/profile/selectors.ts
+++ b/src/app/state/profile/selectors.ts
@@ -1,0 +1,8 @@
+import { createSelector } from '@reduxjs/toolkit'
+
+import { RootState } from 'types'
+import { initialState } from '.'
+
+const selectSlice = (state: RootState) => state.profile || initialState
+
+export const selectProfile = createSelector([selectSlice], state => state)

--- a/src/app/state/profile/types.ts
+++ b/src/app/state/profile/types.ts
@@ -1,0 +1,4 @@
+/* --- STATE --- */
+export interface ProfileState {
+  profileModalOpen: boolean
+}

--- a/src/app/state/profile/types.ts
+++ b/src/app/state/profile/types.ts
@@ -1,4 +1,5 @@
 /* --- STATE --- */
 export interface ProfileState {
+  manageAccountModalId: string
   profileModalOpen: boolean
 }

--- a/src/app/state/wallet/index.ts
+++ b/src/app/state/wallet/index.ts
@@ -50,6 +50,9 @@ const slice = createSlice({
       state.wallets[newWallet.address] = newWallet
       state.selectedWallet ??= newWallet.address
     },
+    setWalletName(state, action: PayloadAction<{ address: string; name: string }>) {
+      state.wallets[action.payload.address].name = action.payload.name
+    },
   },
 })
 

--- a/src/app/state/wallet/selectors.ts
+++ b/src/app/state/wallet/selectors.ts
@@ -14,6 +14,7 @@ export const selectActiveWallet = createSelector([selectSlice], state => {
 
 export const selectWallets = createSelector([selectSlice], state => state.wallets ?? {})
 export const selectAddress = createSelector([selectActiveWallet], wallet => wallet?.address)
+export const selectName = createSelector([selectActiveWallet], wallet => wallet?.name)
 export const selectWalletsAddresses = createSelector([selectWallets], wallets =>
   Object.values(wallets).map(w => w.address),
 )

--- a/src/app/state/wallet/selectors.ts
+++ b/src/app/state/wallet/selectors.ts
@@ -17,6 +17,7 @@ export const selectAddress = createSelector([selectActiveWallet], wallet => wall
 export const selectWalletsAddresses = createSelector([selectWallets], wallets =>
   Object.values(wallets).map(w => w.address),
 )
+
 export const selectPublicKey = createSelector([selectActiveWallet], wallet => wallet?.publicKey ?? '')
 export const selectBalance = createSelector([selectActiveWallet], wallet => wallet?.balance)
 export const selectType = createSelector([selectActiveWallet], wallet => wallet?.type)

--- a/src/app/state/wallet/types.ts
+++ b/src/app/state/wallet/types.ts
@@ -19,6 +19,7 @@ export interface Wallet {
   pathDisplay?: string
   privateKey?: string
   balance: BalanceDetails
+  name?: string
 }
 
 export interface AddWalletPayload extends Wallet {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -429,9 +429,10 @@
       "cancel": "Cancel",
       "contacts": "Contacts",
       "exportPrivateKey": "Export Private Key",
-      "lock": "Lock",
       "manageAccount": "Manage",
       "myAccountsTab": "My Accounts",
+      "nameLengthError": "No more than 16 characters",
+      "optionalName": "Name (optional)",
       "profile": "Profile",
       "settings": "Settings"
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -426,6 +426,7 @@
       }
     },
     "settings": {
+      "accountNamingNotAvailable": "To name your account create a profile while <OpenWalletButton>opening a wallet</OpenWalletButton>.",
       "cancel": "Cancel",
       "contacts": "Contacts",
       "exportPrivateKey": "Export Private Key",
@@ -433,7 +434,9 @@
       "myAccountsTab": "My Accounts",
       "nameLengthError": "No more than 16 characters",
       "optionalName": "Name (optional)",
+      "optionalNameDisabled": "Name (optional)",
       "profile": "Profile",
+      "save": "Save",
       "settings": "Settings"
     },
     "wallets": {

--- a/src/store/__tests__/reducer.test.ts
+++ b/src/store/__tests__/reducer.test.ts
@@ -17,5 +17,6 @@ describe('reducer', () => {
     expect(newState).toHaveProperty('transaction')
     expect(newState).toHaveProperty('wallet')
     expect(newState).toHaveProperty('persist')
+    expect(newState).toHaveProperty('profile')
   })
 })

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -15,6 +15,7 @@ import contactsReducer from 'app/state/contacts'
 import transactionReducer from 'app/state/transaction'
 import walletReducer from 'app/state/wallet'
 import themeReducer from 'styles/theme/slice'
+import profileReducer from 'app/state/profile'
 import persistReducer, { persistActions, receivePersistedRootState } from 'app/state/persist'
 import { RootState } from 'types'
 
@@ -33,6 +34,7 @@ function createRootReducer() {
     transaction: transactionReducer,
     wallet: walletReducer,
     persist: persistReducer,
+    profile: profileReducer,
   })
 
   return rootReducer

--- a/src/types/RootState.ts
+++ b/src/types/RootState.ts
@@ -12,6 +12,7 @@ import { ParaTimesState } from 'app/state/paratimes/types'
 import { StakingState } from 'app/state/staking/types'
 import { FatalErrorState } from 'app/state/fatalerror/types'
 import { PersistState } from 'app/state/persist/types'
+import { ProfileState } from 'app/state/profile/types'
 // [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating containers seamlessly
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -36,6 +37,7 @@ export interface RootState {
   paraTimes: ParaTimesState
   staking: StakingState
   fatalError: FatalErrorState
+  profile: ProfileState
   // [INSERT NEW REDUCER KEY ABOVE] < Needed for generating containers seamlessly
 }
 


### PR DESCRIPTION
We need to open ProfileModal from various places now and we need to open a sub layer.

options:
1) simplified impl. Remove open sub layers requirement. When user clicks edit address icon: open My Accounts modal (with accounts list) and user clicks Manage button (no need to move all stuff to redux and layerVisibilities stays as is)

2) Allow to open subviews. This requires moving all layerVisibilities to Redux (we need one sub view, but to keep it all consistent) + refactor sub views showing logic (maybe) so it does not open layer over layer to avoid height issues and multiple modals.

3) Do 1 + 2 but  in separate PRs to avoid large changeset

4) Where do we show names of Named Accounts. On mockups a name is used only in Account Summary. What about
TX list and Confirmation dialogs? Does these names have higher priority than Contact addresses?

TODO:
- layerVisibilities vs redux 
- keep original AddressBox and create NameBox 
- tests