### PR TITLE
Revert TODOs from "Avoid playwright's buggy test.fail() skipping tests"

### DIFF
--- a/.changelog/1775.internal.md
+++ b/.changelog/1775.internal.md
@@ -1,0 +1,1 @@
+Revert TODOs from "Avoid playwright's buggy test.fail() skipping tests"

--- a/playwright/tests/fiat.spec.ts
+++ b/playwright/tests/fiat.spec.ts
@@ -60,7 +60,7 @@ test.describe('Fiat on-ramp', () => {
   test('Content-Security-Policy should block unknown iframe and fail', async ({ page }) => {
     test.fail()
     expect((await page.request.head('/')).headers()).toHaveProperty('content-security-policy')
-    // await expectNoErrorsInConsole(page) // TODO: revert when playwright doesn't skip other tests because of this
+    await expectNoErrorsInConsole(page)
     await setup(page)
     await page.route('https://*.transak.com/*', route =>
       route.fulfill({ status: 301, headers: { Location: 'https://phishing-transak.com/' } }),
@@ -79,7 +79,7 @@ test.describe('Fiat on-ramp', () => {
 
   test('Sandbox should block top-navigation from iframe and fail', async ({ page }) => {
     test.fail()
-    // await expectNoErrorsInConsole(page) // TODO: revert when playwright doesn't skip other tests because of this
+    await expectNoErrorsInConsole(page)
     await setup(page)
     await page.route('https://*.transak.com/*', route =>
       route.fulfill({


### PR DESCRIPTION
Playwright doesn't skip tests anymore (since https://github.com/oasisprotocol/oasis-wallet-web/pull/1664) so this reverts part of commit 14f52305643d7ab01169a265b9ac7c0c88353de3.