### PR TITLE
Show sidebar behind login modal

### DIFF
--- a/.changelog/1778.trivial.md
+++ b/.changelog/1778.trivial.md
@@ -1,0 +1,1 @@
+Show sidebar behind login modal

--- a/src/app/components/Persist/DeleteProfileButton.tsx
+++ b/src/app/components/Persist/DeleteProfileButton.tsx
@@ -5,8 +5,10 @@ import { useDispatch } from 'react-redux'
 import { Trans, useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Paragraph } from 'grommet/es6/components/Paragraph'
-import { LoginModalLayout } from './LoginModalLayout'
 import { DeleteInputForm } from '../../components/DeleteInputForm'
+import { Box } from 'grommet/es6/components/Box'
+import { Layer } from 'grommet/es6/components/Layer'
+import { Header } from 'app/components/Header'
 
 interface DeleteProfileButtonProps {
   prominent?: boolean
@@ -37,7 +39,7 @@ export function DeleteProfileButton({ prominent }: DeleteProfileButtonProps) {
         plain={!prominent}
       />
       {layerVisibility && (
-        <LoginModalLayout
+        <ModalLayout
           title={t('persist.loginToProfile.deleteProfile.title', 'Delete Profile')}
           onClickOutside={onCancel}
           onEsc={onCancel}
@@ -56,8 +58,27 @@ export function DeleteProfileButton({ prominent }: DeleteProfileButtonProps) {
               </label>
             </Paragraph>
           </DeleteInputForm>
-        </LoginModalLayout>
+        </ModalLayout>
       )}
     </>
+  )
+}
+
+export function ModalLayout(props: {
+  title: string
+  children: React.ReactNode
+  onClickOutside?: () => void
+  onEsc?: () => void
+}) {
+  return (
+    <Layer modal background="background-front" onClickOutside={props.onClickOutside} onEsc={props.onEsc}>
+      <Box pad="medium">
+        <Header level={2} textAlign="center" margin={{ top: 'medium' }}>
+          {props.title}
+        </Header>
+
+        {props.children}
+      </Box>
+    </Layer>
   )
 }

--- a/src/app/components/Persist/LoginModalLayout.tsx
+++ b/src/app/components/Persist/LoginModalLayout.tsx
@@ -2,6 +2,7 @@ import { Box } from 'grommet/es6/components/Box'
 import { Layer } from 'grommet/es6/components/Layer'
 import React from 'react'
 import { Header } from 'app/components/Header'
+import { Navigation } from '../Sidebar'
 
 export function LoginModalLayout(props: {
   title: string
@@ -10,14 +11,17 @@ export function LoginModalLayout(props: {
   onEsc?: () => void
 }) {
   return (
-    <Layer modal background="background-front" onClickOutside={props.onClickOutside} onEsc={props.onEsc}>
-      <Box pad="medium">
-        <Header level={2} textAlign="center" margin={{ top: 'medium' }}>
-          {props.title}
-        </Header>
+    <Box direction="row-responsive" background="background-back" fill style={{ minHeight: '100dvh' }}>
+      <Navigation />
+      <Layer modal background="background-front" onClickOutside={props.onClickOutside} onEsc={props.onEsc}>
+        <Box pad="medium">
+          <Header level={2} textAlign="center" margin={{ top: 'medium' }}>
+            {props.title}
+          </Header>
 
-        {props.children}
-      </Box>
-    </Layer>
+          {props.children}
+        </Box>
+      </Layer>
+    </Box>
   )
 }


### PR DESCRIPTION
| Before | After |
| --- | --- |
|  ![image](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/d84886b1-3bec-4f6c-b173-cddbd08e4c9b) |  ![image](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/f738178f-9129-46be-8196-e8ee61ab3770) |

Better matches the migration mocks without much effort
![image](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/fc23779f-2fae-400d-ad90-8a4df559dffb)

cc @donouwens