### PR TITLE
Don't cleanup E2E page globals

### DIFF
--- a/.changelog/1779.internal.md
+++ b/.changelog/1779.internal.md
@@ -1,0 +1,1 @@
+Don't cleanup E2E page globals

--- a/src/app/pages/E2EPage/index.tsx
+++ b/src/app/pages/E2EPage/index.tsx
@@ -45,10 +45,7 @@ function ExposeInternals() {
     window.oasis = oasis
     window.store = store
     return () => {
-      window.monitor = undefined
-      window.oasisscan = undefined
-      window.oasis = undefined
-      window.store = undefined
+      // Keep globals even after redirecting away
     }
   }, [store])
   return <></>


### PR DESCRIPTION
migrating-persisted-state.spec.ts didn't have much time after `goto('/e2e')` to use the globals before useRouteRedirects navigates away and cleans up.