### PR TITLE
Update react-error-overlay CSP hash

### DIFF
--- a/.changelog/1792.internal.md
+++ b/.changelog/1792.internal.md
@@ -1,0 +1,1 @@
+Update react-error-overlay CSP hash

--- a/internals/getSecurityHeaders.js
+++ b/internals/getSecurityHeaders.js
@@ -17,6 +17,7 @@ const localnet = `
 const hmrWebsocket = `
   ws://localhost:2222
 `
+// If this changes csp-react-error-overlay.spec.ts will print a new sha in an error in csp-react-error-overlay.spec.ts.
 const reactErrorOverlay = `'sha256-yt+SNVxRkIi6H6yb7ndFuZM1esMX9esg3UpRHaTsyVk='`
 const hmrScripts = `
   'unsafe-eval'

--- a/internals/getSecurityHeaders.js
+++ b/internals/getSecurityHeaders.js
@@ -17,7 +17,7 @@ const localnet = `
 const hmrWebsocket = `
   ws://localhost:2222
 `
-const reactErrorOverlay = `'sha256-RV6I4HWPb71LvA27WVD3cEz8GsJrHlfcM/2X2Q5gV00='`
+const reactErrorOverlay = `'sha256-yt+SNVxRkIi6H6yb7ndFuZM1esMX9esg3UpRHaTsyVk='`
 const hmrScripts = `
   'unsafe-eval'
 `

--- a/playwright/tests/csp-react-error-overlay.spec.ts
+++ b/playwright/tests/csp-react-error-overlay.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { reactErrorOverlay } from '../../internals/getSecurityHeaders.js'
+import { expectNoErrorsInConsole } from '../utils/expectNoErrorsInConsole'
 
 test('Dev Content-Security-Policy should allow react-error-overlay', async ({ page, baseURL }) => {
   if (baseURL !== 'http://localhost:3000') test.skip()
@@ -7,6 +8,7 @@ test('Dev Content-Security-Policy should allow react-error-overlay', async ({ pa
   expect((await page.request.head('/')).headers()['content-security-policy']).toContain(reactErrorOverlay)
   await page.goto('/e2e')
   await page.getByRole('button', { name: 'Trigger uncaught error' }).click()
+  await expectNoErrorsInConsole(page)
   await expect(page.locator('iframe')).toBeVisible()
   await expect(page.frameLocator('iframe').getByText('ReferenceError')).toBeVisible()
 })


### PR DESCRIPTION
Broken since 9c7da1ac4954089abee86f3a4900fb36f0d7401b

Note: react-error-overlay only appears during development, and csp-react-error-overlay.spec.ts doesn't test it on CI. Running it locally detects it as broken tho.