### PR TITLE
Increase desktop profile modal width to match pre #1796 width

### DIFF
--- a/.changelog/1805.bugfix.md
+++ b/.changelog/1805.bugfix.md
@@ -1,0 +1,1 @@
+Prevent showing horizontal scrollbar in desktop profile modal

--- a/src/app/components/Toolbar/Features/LayerContainer/index.tsx
+++ b/src/app/components/Toolbar/Features/LayerContainer/index.tsx
@@ -25,7 +25,7 @@ export const LayerContainer = ({ animation, children, hideLayer }: LayerContaine
       position="center"
       style={{
         width: '100%',
-        maxWidth: isMobile ? 'none' : '700px',
+        maxWidth: isMobile ? 'none' : '760px',
         minHeight: `min(${layerOverlayMinHeight}, 90dvh)`,
       }}
     >


### PR DESCRIPTION
The difference on Ubuntu with scrollbars is: optional scrollbar (15px) + margin (24px + 24px) = 63px
Without scrollbars the whole account address would still fit in one line.

| Before https://github.com/oasisprotocol/oasis-wallet-web/pull/1796 | Now | After |
| --- | --- | --- |
| ![localhost_3000_account_oasis1qrtyn2q78jv6plrmexrsrv4dh89wv4n49udtg2km](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/49e4fd68-c2c2-4534-a3bb-eac9470cb165) | ![localhost_3000_account_oasis1qrtyn2q78jv6plrmexrsrv4dh89wv4n49udtg2km (1)](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/ca776953-4b11-48de-9fd7-0d7400d4db69) | ![localhost_3000_account_oasis1qrtyn2q78jv6plrmexrsrv4dh89wv4n49udtg2km (2)](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/b54e2052-f372-4109-aafb-edb020d75a70) |