### PR TITLE
Fix hiding body scrollbar in Chrome extension and nested layers

### DIFF
--- a/.changelog/1811.bugfix.md
+++ b/.changelog/1811.bugfix.md
@@ -1,0 +1,1 @@
+Fix hiding body scrollbar in Chrome extension and nested layers

--- a/src/app/components/ResponsiveLayer/index.tsx
+++ b/src/app/components/ResponsiveLayer/index.tsx
@@ -35,7 +35,12 @@ export function ResponsiveLayer(props: LayerExtendedProps) {
   )
 
   return (
-    <Layer {...props} ref={layerRef} style={{ overflowY: 'auto', ...props.style }}>
+    <Layer
+      {...props}
+      ref={layerRef}
+      className="fix-responsive-layer"
+      style={{ overflowY: 'auto', ...props.style }}
+    >
       <Box
         // Prevents Grommet flex overlap issue in smaller viewport
         flex={{ shrink: 0, grow: 1 }}

--- a/src/app/components/Toolbar/Features/Contacts/__tests__/__snapshots__/AddContact.test.tsx.snap
+++ b/src/app/components/Toolbar/Features/Contacts/__tests__/__snapshots__/AddContact.test.tsx.snap
@@ -838,7 +838,7 @@ exports[`<AddContact  /> should match snapshot 1`] = `
           class="c2"
         />
         <div
-          class="c3"
+          class="c3 fix-responsive-layer"
           data-g-portal-id="0"
           style="overflow-y: auto; width: 100%; max-width: none; min-height: min(550px, 90dvh);"
         >

--- a/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/OpenWalletPage/Features/ImportAccountsSelectionModal/__tests__/__snapshots__/index.test.tsx.snap
@@ -635,7 +635,7 @@ exports[`<ImportAccountsSelectionModal  /> should match snapshot 1`] = `
           class="c2"
         />
         <div
-          class="c3"
+          class="c3 fix-responsive-layer"
           data-g-portal-id="0"
           style="overflow-y: auto;"
         >

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -42,6 +42,27 @@ html {
   max-height: 16px;
 }
 
+/*
+ * Grommet and ResponsiveLayer do not handle nesting layers well:
+ * If user opens settings, clicks manage account (nested layer), and cancels:
+ * settings modal is still open, but `overflow: hidden` is removed from body.
+ * Workaround: set overflow hidden when any responsive layer exists.
+ */
+body:has(.fix-responsive-layer) {
+  overflow: hidden;
+}
+/*
+ * In chrome extension popup: `overflow: hidden` does not work on document.body,
+ * so main scrollbar is still displayed after modal tries to hide it. Workaround:
+ * change scrollbar width to 0 when any responsive layer exists.
+ */
+body:has(.fix-responsive-layer) {
+  scrollbar-width: none;
+}
+body:has(.fix-responsive-layer)::-webkit-scrollbar {
+  display: none;
+}
+
 /* Visually warn developers about sensitive input fields missing preventSavingInputsToUserData */
 :is(input, textarea):is(
 [type="password"], [name="password"], [name="privatekey"], [name="mnemonic"], #privatekey, #mnemonic


### PR DESCRIPTION
Part of it is related to https://github.com/oasisprotocol/oasis-wallet-web/issues/863 issue with nested layers

| Before | After |
| --- | --- |
|  ![Screenshot from 2023-12-19 04-42-24](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/db4f1f84-30c4-4a42-ab43-b72d178b5d60) | ![Screenshot from 2023-12-19 04-41-58](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/bbe63dc7-0482-4e97-80f6-53f66ca12068)  |
| ![localhost_3000_account_oasis1qrtyn2q78jv6plrmexrsrv4dh89wv4n49udtg2km(extension360x600)](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/30c92308-ae0c-41e5-bf16-ccc13c1c37c0) | ![localhost_3000_account_oasis1qrtyn2q78jv6plrmexrsrv4dh89wv4n49udtg2km(extension360x600) (1)](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/aff61eb3-bd6c-4f59-bb27-77cf949d33a8) |
