### PR TITLE
Fix e2e extension test for getting state

### DIFF
--- a/.changelog/1812.trivial.md
+++ b/.changelog/1812.trivial.md
@@ -1,0 +1,1 @@
+Fix e2e extension test for getting state

--- a/playwright/tests/extension.spec.ts
+++ b/playwright/tests/extension.spec.ts
@@ -26,7 +26,8 @@ test.describe('The extension popup should load', () => {
     await page.getByRole('link', { name: /Home/i }).click()
 
     await page.getByRole('link', { name: /Create wallet/i }).click()
-    await expect(page.getByTestId('mnemonic-grid').locator('> *')).toHaveCount(24)
+    await page.getByRole('button', { name: /Generate a new mnemonic/i }).click()
+    await expect(page.getByTestId('generated-mnemonic')).toHaveText(/\w+(\s\w+){23}/)
   })
 
   test('ask for USB permissions in ledger popup', async ({ page, context, extensionPopupURL }) => {


### PR DESCRIPTION
It hasn't been testing that mnemonic arrives from state since f2f2c44.