### PR TITLE
Add yaml schema to markdownlint configs

### DIFF
--- a/.changelog/.markdownlint.yml
+++ b/.changelog/.markdownlint.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json
+
 # markdownlint configuration for Change Log fragments.
 
 # For more information, see:

--- a/.changelog/1828.internal.md
+++ b/.changelog/1828.internal.md
@@ -1,0 +1,1 @@
+Add yaml schema to markdownlint configs

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json
+
 # markdownlint configuration.
 
 # For more information, see:


### PR DESCRIPTION
Adds code-completion, at least in vscode. Should this be propagated to everywhere?