### PR TITLE
Fix playwright tests finding duplicate elements in closing modals

### DIFF
--- a/.changelog/1852.trivial.md
+++ b/.changelog/1852.trivial.md
@@ -1,0 +1,1 @@
+Fix playwright tests finding duplicate elements in closing modals

--- a/playwright/tests/toolbar.spec.ts
+++ b/playwright/tests/toolbar.spec.ts
@@ -46,6 +46,7 @@ test.describe('Profile tab', () => {
     await expect(page.getByText('Password updated.')).toBeVisible()
 
     await page.getByTestId('close-settings-modal').click()
+    await expect(page.getByTestId('close-settings-modal')).not.toBeVisible()
     await page.getByRole('button', { name: /Lock profile/ }).click()
     await page.getByPlaceholder('Enter your password here').fill(tempPassword)
     await page.getByRole('button', { name: /Unlock/ }).click()
@@ -63,6 +64,7 @@ test.describe('Profile tab', () => {
 
     // validate default password
     await page.getByTestId('close-settings-modal').click()
+    await expect(page.getByTestId('close-settings-modal')).not.toBeVisible()
     await page.getByRole('button', { name: /Lock profile/ }).click()
     await page.getByPlaceholder('Enter your password here').fill(password)
     await page.getByRole('button', { name: /Unlock/ }).click()


### PR DESCRIPTION
https://github.com/oasisprotocol/oasis-wallet-web/pull/1850 broke master

Somewhat related to 66cde90085a3b585034077ccaa710c8ca55843b5