### PR TITLE
Fix hiding body scrollbar in extension again for Chrome 121 and newer

### DIFF
--- a/.changelog/1902.bugfix.md
+++ b/.changelog/1902.bugfix.md
@@ -1,0 +1,1 @@
+Fix hiding body scrollbar in extension again for Chrome 121 and newer

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -64,9 +64,6 @@ body:has(.fix-responsive-layer) {
  * so main scrollbar is still displayed after modal tries to hide it. Workaround:
  * change scrollbar width to 0 when any responsive layer exists.
  */
-body:has(.fix-responsive-layer) {
-  scrollbar-width: none;
-}
 body:has(.fix-responsive-layer)::-webkit-scrollbar {
   display: none;
 }


### PR DESCRIPTION
Re-fixes https://github.com/oasisprotocol/oasis-wallet-web/pull/1811. That worked in Chrome 120, but is broken again in Chrome 124. It most likely broke in 121 when Chrome "fully supported" the css statement that does not work anymore now. https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width
![image](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/f28b6c72-17f3-4855-ae12-437dcbab2045)

| Before | After |
| --- | --- |
| ![Screenshot from 2024-04-24 05-53-01](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/d3a93240-0a48-4991-bcac-3b0e34a2279b)  | ![Screenshot from 2024-04-24 05-53-10](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/e7b98109-3481-4e73-bf2b-98e7bab71ee4)  |