### PR TITLE
Make buttons to manage accounts more prominent

### DIFF
--- a/.changelog/1909.bugfix.md
+++ b/.changelog/1909.bugfix.md
@@ -1,0 +1,1 @@
+Make buttons to manage accounts more prominent

--- a/src/app/components/Toolbar/Features/Account/Account.tsx
+++ b/src/app/components/Toolbar/Features/Account/Account.tsx
@@ -13,15 +13,13 @@ import { Button } from 'grommet/es6/components/Button'
 import { DerivationFormatter, DerivationFormatterProps } from './DerivationFormatter'
 import styled from 'styled-components'
 
-// Larger area for hoverIndicator
 const StyledManageButton = styled(Button)`
-  padding: 0.5ex 0.7ch;
-  margin: -0.5ex -0.7ch;
   border-radius: ${({ theme }) => theme.button?.border?.radius};
 `
 StyledManageButton.defaultProps = {
-  plain: true,
   color: { light: 'brand', dark: 'white' },
+  size: 'small',
+  primary: true,
   hoverIndicator: true,
 }
 

--- a/src/app/components/Toolbar/Features/AccountSelector/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Toolbar/Features/AccountSelector/__tests__/__snapshots__/index.test.tsx.snap
@@ -293,16 +293,28 @@ exports[`<AccountSelector  /> should match snapshot 1`] = `
   background: transparent;
   overflow: visible;
   text-transform: none;
-  color: #0500e2;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
+  border: 2px solid #0500e2;
+  border-radius: 18px;
+  color: #16213E;
+  padding: 4px 20px;
+  font-size: 14px;
+  line-height: 20px;
+  background-color: #0500e2;
+  color: #F8F8F8;
+  border-radius: 18px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  font-weight: bold;
 }
 
 .c9:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
+  box-shadow: 0px 0px 0px 2px #0500e2;
 }
 
 .c9:focus {
@@ -489,8 +501,6 @@ exports[`<AccountSelector  /> should match snapshot 1`] = `
 }
 
 .c10 {
-  padding: 0.5ex 0.7ch;
-  margin: -0.5ex -0.7ch;
   border-radius: 4px;
 }
 

--- a/src/app/components/Toolbar/Features/Contacts/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Toolbar/Features/Contacts/__tests__/__snapshots__/index.test.tsx.snap
@@ -186,16 +186,28 @@ exports[`<Contacts  /> should match snapshot 1`] = `
   background: transparent;
   overflow: visible;
   text-transform: none;
-  color: #0500e2;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
+  border: 2px solid #0500e2;
+  border-radius: 18px;
+  color: #16213E;
+  padding: 4px 20px;
+  font-size: 14px;
+  line-height: 20px;
+  background-color: #0500e2;
+  color: #F8F8F8;
+  border-radius: 18px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  font-weight: bold;
 }
 
 .c9:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
+  box-shadow: 0px 0px 0px 2px #0500e2;
 }
 
 .c9:focus {
@@ -312,8 +324,6 @@ exports[`<Contacts  /> should match snapshot 1`] = `
 }
 
 .c10 {
-  padding: 0.5ex 0.7ch;
-  margin: -0.5ex -0.7ch;
   border-radius: 4px;
 }
 


### PR DESCRIPTION
Fixes:
> @lubej: Manage wallet(settings) is a bit hidden if you only have 1 wallet, as it is the same color as the account name and account address text.

| Before | After |
| --- | --- |
| ![image](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/dfc4ef0e-9972-4cae-b211-005f239bf117) | ![image](https://github.com/oasisprotocol/oasis-wallet-web/assets/3758846/6a213898-065c-48c4-9644-217ae5b741f8)  | 


