### PR TITLE
Sync extension manifest version during version bump

### DIFF
--- a/.changelog/1921.bugfix.md
+++ b/.changelog/1921.bugfix.md
@@ -1,0 +1,1 @@
+Sync extension manifest version during version bump


### PR DESCRIPTION
![Screenshot from 2024-05-06 11-42-03](https://github.com/oasisprotocol/oasis-wallet-web/assets/891392/7dfe5e00-c505-4fac-a643-f03e09119867)


The only other idea I had was to use env replacement strings, but valid manifest version has to be in `<number><dot>` format during build time.