### PR TITLE
Lock profile when user leaves app on Ionic platform

### DIFF
--- a/.changelog/1933.feature.md
+++ b/.changelog/1933.feature.md
@@ -1,0 +1,1 @@
+Lock profile when user leaves app on Ionic platform

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "extract-messages": "rm src/locales/en/translation.json && i18next-scanner --config=internals/extractMessages/i18next-scanner.config.js && node ./internals/scripts/normalize-translations.js ./src/locales/*/translation.json",
     "fix-grommet-icons-types": "node ./internals/scripts/fix-grommet-icons-types.js",
     "print-extension-dev-csp": "node ./internals/scripts/print-extension-dev-csp.js",
-    "android": "yarn build && yarn cap run android -l --external",
-    "ios": "yarn build && yarn cap run ios -l --external"
+    "android": "yarn build && yarn cap sync android && yarn cap run android -l --external",
+    "ios": "yarn build && yarn cap sync ios && yarn cap run ios -l --external"
   },
   "browserslist": {
     "production": [

--- a/src/app/components/Ionic/IonicProvider.tsx
+++ b/src/app/components/Ionic/IonicProvider.tsx
@@ -1,37 +1,13 @@
-import { createContext, FC, PropsWithChildren, useEffect, useRef } from 'react'
+import { createContext, FC, PropsWithChildren } from 'react'
 import { Capacitor } from '@capacitor/core'
-import { App } from '@capacitor/app'
-import { useDispatch } from 'react-redux'
-import { persistActions } from '../../state/persist'
-import { deltaMsToLockProfile } from '../../../ionicConfig'
 import { useIonicBackButtonListener } from './hooks/useIonicBackButtonListener'
+import { useIonicAppStateChangeListener } from './hooks/useIonicAppStateChangeListener'
 
 const IonicContext = createContext<undefined>(undefined)
 
 const IonicContextProvider: FC<PropsWithChildren> = ({ children }) => {
-  const dispatch = useDispatch()
-  const lockTimestamp = useRef<number>()
-
   useIonicBackButtonListener()
-
-  useEffect(() => {
-    const appStateChangeListenerHandle = App.addListener('appStateChange', ({ isActive }) => {
-      const shouldLock = lockTimestamp.current && Date.now() - lockTimestamp.current > deltaMsToLockProfile
-      if (isActive && shouldLock) {
-        dispatch(persistActions.lockAsync())
-      } else if (isActive && !shouldLock) {
-        lockTimestamp.current = undefined
-      }
-
-      if (!isActive) {
-        lockTimestamp.current = Date.now()
-      }
-    })
-
-    return () => {
-      appStateChangeListenerHandle.remove()
-    }
-  }, [dispatch])
+  useIonicAppStateChangeListener()
 
   return <IonicContext.Provider value={undefined}>{children}</IonicContext.Provider>
 }

--- a/src/app/components/Ionic/IonicProvider.tsx
+++ b/src/app/components/Ionic/IonicProvider.tsx
@@ -1,32 +1,20 @@
 import { createContext, FC, PropsWithChildren, useEffect, useRef } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { Capacitor } from '@capacitor/core'
 import { App } from '@capacitor/app'
 import { useDispatch } from 'react-redux'
 import { persistActions } from '../../state/persist'
 import { deltaMsToLockProfile } from '../../../ionicConfig'
+import { useIonicBackButtonListener } from './hooks/useIonicBackButtonListener'
 
 const IonicContext = createContext<undefined>(undefined)
 
 const IonicContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const dispatch = useDispatch()
-  const navigate = useNavigate()
   const lockTimestamp = useRef<number>()
 
-  useEffect(() => {
-    /**
-     * The back button refers to the physical back button on an Android device and should not be confused
-     * with either the browser back button or ion-back-button.
-     */
-    const backButtonListenerHandle = App.addListener('backButton', ({ canGoBack }) => {
-      if (!canGoBack) {
-        App.exitApp()
-      } else {
-        navigate(-1)
-      }
-    })
+  useIonicBackButtonListener()
 
-    // TODO: appStateChange triggers on the web platform as well, using visibilitychange listener, consider reusing the code(downside @capacitor/app dependency on web & extension)
+  useEffect(() => {
     const appStateChangeListenerHandle = App.addListener('appStateChange', ({ isActive }) => {
       const shouldLock = lockTimestamp.current && Date.now() - lockTimestamp.current > deltaMsToLockProfile
       if (isActive && shouldLock) {
@@ -41,10 +29,9 @@ const IonicContextProvider: FC<PropsWithChildren> = ({ children }) => {
     })
 
     return () => {
-      backButtonListenerHandle.remove()
       appStateChangeListenerHandle.remove()
     }
-  }, [dispatch, navigate])
+  }, [dispatch])
 
   return <IonicContext.Provider value={undefined}>{children}</IonicContext.Provider>
 }

--- a/src/app/components/Ionic/hooks/useIonicAppStateChangeListener.tsx
+++ b/src/app/components/Ionic/hooks/useIonicAppStateChangeListener.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react'
+import { App } from '@capacitor/app'
+import { deltaMsToLockProfile } from '../../../../ionicConfig'
+import { persistActions } from '../../../state/persist'
+import { useDispatch } from 'react-redux'
+
+export const useIonicAppStateChangeListener = () => {
+  const dispatch = useDispatch()
+  const lockTimestamp = useRef<number>()
+
+  useEffect(() => {
+    const appStateChangeListenerHandle = App.addListener('appStateChange', ({ isActive }) => {
+      const shouldLock = lockTimestamp.current && Date.now() - lockTimestamp.current > deltaMsToLockProfile
+      if (isActive && shouldLock) {
+        dispatch(persistActions.lockAsync())
+      } else if (isActive && !shouldLock) {
+        lockTimestamp.current = undefined
+      }
+
+      if (!isActive) {
+        lockTimestamp.current = Date.now()
+      }
+    })
+
+    return () => {
+      appStateChangeListenerHandle.then(pluginListenerHandle => pluginListenerHandle.remove())
+    }
+  }, [dispatch])
+}

--- a/src/app/components/Ionic/hooks/useIonicBackButtonListener.ts
+++ b/src/app/components/Ionic/hooks/useIonicBackButtonListener.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { App } from '@capacitor/app'
+import { useNavigate } from 'react-router-dom'
+
+export const useIonicBackButtonListener = () => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    /**
+     * The back button refers to the physical back button on an Android device and should not be confused
+     * with either the browser back button or ion-back-button.
+     */
+    const backButtonListenerHandle = App.addListener('backButton', ({ canGoBack }) => {
+      if (!canGoBack) {
+        App.exitApp()
+      } else {
+        navigate(-1)
+      }
+    })
+
+    return () => {
+      backButtonListenerHandle.then(pluginListenerHandle => pluginListenerHandle.remove())
+    }
+  }, [navigate])
+}

--- a/src/ionicConfig.ts
+++ b/src/ionicConfig.ts
@@ -1,0 +1,6 @@
+/**
+ * Represents the duration in milliseconds to lock a profile.
+ *
+ * @type {number}
+ */
+export const deltaMsToLockProfile = 30 * 1000


### PR DESCRIPTION
## Solution

Current behavior of mobile platform(for that matter also web/extensions) does not lock the user profile, when leaving the app. Meaning the app would stay indefinitely unlocked, if user does not explicitly lock the wallet. This PR locks the wallet in 30sec of inactivity - but the implementation is not ideal. As timers get "frozen" when put in background, it uses a check upon activating the app, by comparing the timestamps before it went to sleep. Ideal solution would have a background service, with timer implemented - but would add an overhead of additional capacitor plugin.

In combination with hiding app information upon switching between apps(mobile), should be good enough solution.

## Resources

For demo purposes, this used 5sec timer(instead of 30sec):
https://github.com/oasisprotocol/oasis-wallet-web/assets/9722540/ef1cb6d9-3cf0-4dac-8345-8fddd1bbdbdf