### PR TITLE
Prevent app content from being captured in screenshots or apps view

### DIFF
--- a/.changelog/1940.feature.md
+++ b/.changelog/1940.feature.md
@@ -1,0 +1,1 @@
+Prevent app content from being captured in screenshots or apps view

--- a/android/app/src/main/java/com/oasisprotocol/wallet/MainActivity.java
+++ b/android/app/src/main/java/com/oasisprotocol/wallet/MainActivity.java
@@ -1,5 +1,16 @@
 package com.oasisprotocol.wallet;
 
+import android.os.Bundle;
+import android.view.WindowManager; 
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Set secure flag to prevent app content from being captured in screenshots or recent apps view
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                             WindowManager.LayoutParams.FLAG_SECURE);
+    }
+}


### PR DESCRIPTION
https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE

switching apps
![Screenshot_20240516-101313](https://github.com/oasisprotocol/oasis-wallet-web/assets/891392/691db590-9688-4104-a421-4621b1b93292)

screenshot taken
![Screenshot_20240516-101325](https://github.com/oasisprotocol/oasis-wallet-web/assets/891392/aea97692-e802-4f64-9b96-48fdb385ca99)
