### PR TITLE
Add Android bundle to GitHub Action build artifacts

### DIFF
--- a/.changelog/1944.internal.md
+++ b/.changelog/1944.internal.md
@@ -1,0 +1,1 @@
+Add Android bundle to GitHub Action build artifacts

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -66,14 +66,14 @@ jobs:
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > android/release.jks
       - name: Sign AAB using jarsigner
         run: |
-          jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEY_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
+          jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEY_SIGNER_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
       # Targeting version 30 and above we need to align the APK so that all uncompressed data starts on a 4-byte boundary
       - name: Zipalign APK
         run: |
           $ANDROID_SDK_ROOT/build-tools/31.0.0/zipalign -v 4 android/app/build/outputs/apk/release/app-release-unsigned.apk android/app/build/outputs/apk/release/app-release-aligned.apk
       - name: Sign APK using apksigner
         run: |
-          $ANDROID_SDK_ROOT/build-tools/31.0.0/apksigner sign --ks android/release.jks --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} --key-pass pass:${{ secrets.KEY_PASSWORD }} --ks-key-alias ${{ secrets.KEY_ALIAS }} android/app/build/outputs/apk/release/app-release-aligned.apk
+          $ANDROID_SDK_ROOT/build-tools/31.0.0/apksigner sign --ks android/release.jks --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} --key-pass pass:${{ secrets.KEY_SIGNER_PASSWORD }} --ks-key-alias ${{ secrets.KEY_ALIAS }} android/app/build/outputs/apk/release/app-release-aligned.apk
       - name: Upload Android AAB build artifacts
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
       - name: Build Android App Bundle (AAB)
+        if: github.event_name == 'push'
         run: ./gradlew bundleRelease
         working-directory: android
       - name: Build Android Package (APK)
@@ -65,6 +66,7 @@ jobs:
         run: |
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > android/release.jks
       - name: Sign AAB using jarsigner
+        if: github.event_name == 'push'
         run: |
           jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
       # Targeting version 30 and above we need to align the APK so that all uncompressed data starts on a 4-byte boundary

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,6 +26,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up OpenJDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '17'
       - name: Set up Node.js 18
         uses: actions/setup-node@v4
         with:
@@ -42,6 +47,22 @@ jobs:
         run: yarn build
       - name: Build extension ROSE Wallet
         run: yarn build:ext
+      - name: Sync Capacitor for Android
+        run: yarn cap sync android
+      - name: Accept SDK licenses
+        run: yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses
+      - name: Install SDK components
+        run: |
+          $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-31" "build-tools;31.0.0"
+      - name: Build Android ROSE Wallet
+        run: ./gradlew bundleRelease
+        working-directory: android
+      - name: Upload Android ROSE Wallet build artifacts
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rose-wallet-android-${{ steps.vars.outputs.SHORT_SHA }}.aab
+          path: android/app/build/outputs/bundle/release/app-release.aab
       - name: Upload web ROSE Wallet build artifacts
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,21 +54,37 @@ jobs:
       - name: Install SDK components
         run: |
           $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-31" "build-tools;31.0.0"
-      - name: Build Android ROSE Wallet
+      - name: Build Android App Bundle (AAB)
         run: ./gradlew bundleRelease
+        working-directory: android
+      - name: Build Android Package (APK)
+        run: ./gradlew assembleRelease
         working-directory: android
       - name: Decode and Save Keystore File
         run: |
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > android/release.jks
-      - name: Sign Android bundle
+      - name: Sign AAB using jarsigner
         run: |
           jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEY_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
-      - name: Upload Android ROSE Wallet build artifacts
+      # Targeting version 30 and above we need to align the APK so that all uncompressed data starts on a 4-byte boundary
+      - name: Zipalign APK
+        run: |
+          $ANDROID_SDK_ROOT/build-tools/31.0.0/zipalign -v 4 android/app/build/outputs/apk/release/app-release-unsigned.apk android/app/build/outputs/apk/release/app-release-aligned.apk
+      - name: Sign APK using apksigner
+        run: |
+          $ANDROID_SDK_ROOT/build-tools/31.0.0/apksigner sign --ks android/release.jks --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} --key-pass pass:${{ secrets.KEY_PASSWORD }} --ks-key-alias ${{ secrets.KEY_ALIAS }} android/app/build/outputs/apk/release/app-release-aligned.apk
+      - name: Upload Android AAB build artifacts
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: rose-wallet-android-${{ steps.vars.outputs.SHORT_SHA }}.aab
           path: android/app/build/outputs/bundle/release/app-release-signed.aab
+      - name: Upload Android APK build artifacts
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rose-wallet-android-${{ steps.vars.outputs.SHORT_SHA }}.apk
+          path: android/app/build/outputs/apk/release/app-release-aligned.apk
       - name: Upload web ROSE Wallet build artifacts
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -66,14 +66,14 @@ jobs:
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > android/release.jks
       - name: Sign AAB using jarsigner
         run: |
-          jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEY_SIGNER_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
+          jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
       # Targeting version 30 and above we need to align the APK so that all uncompressed data starts on a 4-byte boundary
       - name: Zipalign APK
         run: |
           $ANDROID_SDK_ROOT/build-tools/31.0.0/zipalign -v 4 android/app/build/outputs/apk/release/app-release-unsigned.apk android/app/build/outputs/apk/release/app-release-aligned.apk
       - name: Sign APK using apksigner
         run: |
-          $ANDROID_SDK_ROOT/build-tools/31.0.0/apksigner sign --ks android/release.jks --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} --key-pass pass:${{ secrets.KEY_SIGNER_PASSWORD }} --ks-key-alias ${{ secrets.KEY_ALIAS }} android/app/build/outputs/apk/release/app-release-aligned.apk
+          $ANDROID_SDK_ROOT/build-tools/31.0.0/apksigner sign --ks android/release.jks --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} --key-pass pass:${{ secrets.KEYSTORE_PASSWORD }} --ks-key-alias ${{ secrets.KEY_ALIAS }} android/app/build/outputs/apk/release/app-release-aligned.apk
       - name: Upload Android AAB build artifacts
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -51,9 +51,10 @@ jobs:
         run: yarn cap sync android
       - name: Accept SDK licenses
         run: yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses
+      # Capacitor v6 sets a deployment target of Android 14 (SDK 34)
       - name: Install SDK components
         run: |
-          $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-31" "build-tools;31.0.0"
+          $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
       - name: Build Android App Bundle (AAB)
         run: ./gradlew bundleRelease
         working-directory: android

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up OpenJDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
       - name: Set up Node.js 18
         uses: actions/setup-node@v4

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -57,12 +57,18 @@ jobs:
       - name: Build Android ROSE Wallet
         run: ./gradlew bundleRelease
         working-directory: android
+      - name: Decode and Save Keystore File
+        run: |
+          echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > android/release.jks
+      - name: Sign Android bundle
+        run: |
+          jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEY_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
       - name: Upload Android ROSE Wallet build artifacts
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: rose-wallet-android-${{ steps.vars.outputs.SHORT_SHA }}.aab
-          path: android/app/build/outputs/bundle/release/app-release.aab
+          path: android/app/build/outputs/bundle/release/app-release-signed.aab
       - name: Upload web ROSE Wallet build artifacts
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up OpenJDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
       - name: Set up Node.js 18
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,10 @@ jobs:
         run: yarn cap sync android
       - name: Accept SDK licenses
         run: yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses
+      # Capacitor v6 sets a deployment target of Android 14 (SDK 34)
       - name: Install SDK components
         run: |
-          $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-31" "build-tools;31.0.0"
+          $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
       - name: Build Android ROSE Wallet
         run: ./gradlew bundleRelease
         working-directory: android

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > android/release.jks
       - name: Sign Android bundle
         run: |
-          jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEY_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
+          jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEY_SIGNER_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
       - name: Set workflow variables
         # Id is needed to access output in a next step.
         id: vars

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > android/release.jks
       - name: Sign Android bundle
         run: |
-          jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEY_SIGNER_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
+          jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
       - name: Set workflow variables
         # Id is needed to access output in a next step.
         id: vars

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up OpenJDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '17'
       - name: Set up Node.js 18
         uses: actions/setup-node@v4
         with:
@@ -35,6 +40,22 @@ jobs:
         run: yarn build
       - name: Build extension ROSE Wallet
         run: yarn build:ext
+      - name: Sync Capacitor for Android
+        run: yarn cap sync android
+      - name: Accept SDK licenses
+        run: yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses
+      - name: Install SDK components
+        run: |
+          $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-31" "build-tools;31.0.0"
+      - name: Build Android ROSE Wallet
+        run: ./gradlew bundleRelease
+        working-directory: android
+      - name: Decode and Save Keystore File
+        run: |
+          echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > android/release.jks
+      - name: Sign Android bundle
+        run: |
+          jarsigner -verbose -keystore android/release.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEY_PASSWORD }} -signedjar android/app/build/outputs/bundle/release/app-release-signed.aab android/app/build/outputs/bundle/release/app-release.aab ${{ secrets.KEY_ALIAS }}
       - name: Set workflow variables
         # Id is needed to access output in a next step.
         id: vars
@@ -42,6 +63,9 @@ jobs:
         # and use short SHA of the commit for file name.
         run: |
           echo "VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')" >> "$GITHUB_OUTPUT"
+      - name: Copy and rename Android bundle
+        run: |
+          cp android/app/build/outputs/bundle/release/app-release-signed.aab rose-wallet-android-${{ steps.vars.outputs.VERSION }}.aab
       - name: Create web ROSE Wallet zip file
         run: |
           cd build/
@@ -59,6 +83,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
+            rose-wallet-android-${{ steps.vars.outputs.VERSION }}.aab
             rose-wallet-web-${{ steps.vars.outputs.VERSION }}.zip
             rose-wallet-ext-${{ steps.vars.outputs.VERSION }}.zip
             build/Content-Security-Policy.txt

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.application'
 
 android {
-    namespace "com.oasisprotocol.wallet"
+    namespace "org.oasisprotocol.wallet"
     compileSdk rootProject.ext.compileSdkVersion
     defaultConfig {
-        applicationId "com.oasisprotocol.wallet"
+        applicationId "org.oasisprotocol.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/android/app/src/main/java/org/oasisprotocol/wallet/MainActivity.java
+++ b/android/app/src/main/java/org/oasisprotocol/wallet/MainActivity.java
@@ -1,4 +1,4 @@
-package com.oasisprotocol.wallet;
+package org.oasisprotocol.wallet;
 
 import android.os.Bundle;
 import android.view.WindowManager; 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,6 @@
 <resources>
     <string name="app_name">ROSE Wallet</string>
     <string name="title_activity_main">ROSE Wallet</string>
-    <string name="package_name">com.oasisprotocol.wallet</string>
-    <string name="custom_url_scheme">com.oasisprotocol.wallet</string>
+    <string name="package_name">org.oasisprotocol.wallet</string>
+    <string name="custom_url_scheme">org.oasisprotocol.wallet</string>
 </resources>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,7 +1,7 @@
 import { CapacitorConfig } from '@capacitor/cli'
 
 const config: CapacitorConfig = {
-  appId: 'com.oasisprotocol.wallet',
+  appId: 'org.oasisprotocol.wallet',
   appName: 'ROSE Wallet',
   webDir: 'build',
   server: {

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -1,5 +1,34 @@
 # Mobile app development
 
+## Convert Android App Bundle (AAB) to Android Package (APK)
+
+Our GitHub workflows create signed AAB and APK files.
+We use AAB to upload to Google Play Store and APK for testing.
+In case of testing AAB locally follow steps below to convert bundle to APK:
+
+- Download [bundletool] from the official GitHub repository
+- Generate APK files
+
+<!-- markdownlint-disable MD013 -->
+
+```
+java -jar bundletool-all-<VERSION>.jar build-apks --bundle=app-release-signed.aab --output=app-release-signed.apks --mode=universal
+```
+
+<!-- markdownlint-enable MD013 -->
+
+- Extract the APK
+
+```
+  unzip app-release-signed.apks -d extracted-apks
+```
+
+- Install the APK on your device
+
+```
+adb -s <DEVICE_SERIAL_NUMBER> install extracted-apks/universal.apk
+```
+
 ## Capacitor assets
 
 - Create `assets` folder with source images
@@ -26,3 +55,4 @@ npx @capacitor/assets generate --ios
 - Additional information are available in [Capacitor Assets docs]
 
 [Capacitor Assets docs]: https://github.com/ionic-team/capacitor-assets#usage---custom-mode
+[bundletool]: https://github.com/google/bundletool/releases

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
-				PRODUCT_BUNDLE_IDENTIFIER = com.oasisprotocol.wallet;
+				PRODUCT_BUNDLE_IDENTIFIER = org.oasisprotocol.wallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
@@ -371,7 +371,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.oasisprotocol.wallet;
+				PRODUCT_BUNDLE_IDENTIFIER = org.oasisprotocol.wallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Release task has only AAB to avoid confusion what goes to Google app store. Build workflow has both AAB and APK (for testing). Sample fork output  https://github.com/buberdds/oasis-wallet-web/actions/runs/9283327194

Alternative builds samples for future reference:
1. using `android-actions/setup-android@v3` action. Has hardcoded command line tools versions (may be outdated). 
2. manual instalation of Android command line tools. more ugly wokrflow, with hardoded url, but we control everything.

```
      - name: Download Command Line Tools
        # Expected location for sdkmanager is: <sdk>/cmdline-tools/latest/
        # CLI tools package https://developer.android.com/studio#command-line-tools-only
        run: |
          curl -o commandlinetools.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
          mkdir -p $HOME/android-sdk/cmdline-tools/latest
          unzip commandlinetools.zip -d $HOME/android-sdk/cmdline-tools
          mv $HOME/android-sdk/cmdline-tools/cmdline-tools/* $HOME/android-sdk/cmdline-tools/latest/
          rm -rf $HOME/android-sdk/cmdline-tools/cmdline-tools
      - name: Set up environment variables
        run: |
          echo "ANDROID_HOME=$HOME/android-sdk" >> $GITHUB_ENV
          echo "ANDROID_SDK_ROOT=$HOME/android-sdk" >> $GITHUB_ENV
          echo "PATH=$HOME/android-sdk/cmdline-tools/latest/bin:$PATH" >> $GITHUB_ENV
      - name: Accept SDK licenses
        run: yes | sdkmanager --licenses

      - name: Install SDK components
        run: |
          sdkmanager "platform-tools" "platforms;android-33" "build-tools;33.0.0"
      - name: Build Android ROSE Wallet
        run: ./gradlew bundleRelease
        working-directory: android
```

APK artifact alternative:
 - download bundletool jar end extract APK from AAB

TODO:
 - [x] build AAB file rather thank APK using `gradlew bundleRelease` instead of `assembleRelease` (actually we want both to speed up testing)
 - [x] confirm Java version used by workflow https://github.com/actions/setup-java?tab=readme-ov-file#supported-distributions. Should we use `temurin` distribution? 
 - [x] confirm Android platform and build tools versions https://github.com/oasisprotocol/oasis-wallet-web/blob/master/android/app/src/main/AndroidManifest.xml#L40, so it's 31 ? It's 34 now after switching to Capacitor v6
 - [x] choose bundle build flow
 - [x]  jarsigner
 - [x] confirm appId `com.oasisprotocol.wallet` - switch to `org.`
 - [x] update release workflow (fork sample: https://github.com/buberdds/oasis-wallet-web/releases/tag/v1.11.0)
 - [x] add GitHub secrets to repo
 - [x] add apk for testing 
 
 ### GH secrets
- generate keystore password with a password manager (e.g. `pass generate rose-wallet/android-keystore-password`)
- generate keystore file:
 ```
keytool -genkeypair -v -keystore rose-wallet-android.jks -keyalg RSA -keysize 4096 -validity 100 -alias rose-wallet-android -storepass $(pass rose-wallet/android-keystore-password)
```
when asked, enter something like below:
```
Enter the distinguished name. Provide a single dot (.) to leave a sub-component empty or press ENTER to use the default value in braces.
What is your first and last name?
  [Unknown]:  Oasis
What is the name of your organizational unit?
  [Unknown]:  Engineering
What is the name of your organization?
  [Unknown]:  Oasis Protocol Foundation
What is the name of your City or Locality?
  [Unknown]:  
What is the name of your State or Province?
  [Unknown]:  
What is the two-letter country code for this unit?
  [Unknown]:  
Is CN=Oasis, OU=Engineering, O=Oasis Protocol Foundation, L=Unknown, ST=Unknown, C=Unknown correct?
  [no]:  yes
```

- encode keystore file in base64 format so it can be added as GitHub secret
```
base64 rose-wallet-android.jks > rose-wallet-android.jks.base64
```
- provide all secrets in repo settings https://github.com/oasisprotocol/oasis-wallet-web/settings/secrets/actions -> New repository secret: `KEYSTORE_FILE` , `KEYSTORE_PASSWORD` and `KEY_ALIAS`.

### Dev after package name update (Android Studio)
- File -> Sync Project with Gradle Files
- Build -> Clean Project
- Build -> Rebuild Project.