### PR TITLE
Allow quotes when typing 'delete'

### DIFF
--- a/.changelog/1951.trivial.md
+++ b/.changelog/1951.trivial.md
@@ -1,0 +1,1 @@
+Allow quotes when typing 'delete'

--- a/src/app/components/DeleteInputForm/index.tsx
+++ b/src/app/components/DeleteInputForm/index.tsx
@@ -21,7 +21,9 @@ export function DeleteInputForm({ children, onCancel, onConfirm }: DeleteInputFo
       <FormField
         name="type_delete"
         validate={(value: string | undefined) =>
-          !value || value.toLowerCase() !== t('deleteForm.confirmationKeyword', 'delete').toLowerCase()
+          !value ||
+          value.toLowerCase().replace(/['"“”]/g, '') !==
+            t('deleteForm.confirmationKeyword', 'delete').toLowerCase()
             ? t('deleteForm.hint', `Type '{{confirmationKeyword}}'`, {
                 confirmationKeyword: t('deleteForm.confirmationKeyword', 'delete'),
               })


### PR DESCRIPTION
since our instructions are `To confirm and proceed, please type 'delete' below.` 