### PR TITLE
Use bold text instead of quotes around "delete" confirmation keyword

### DIFF
--- a/.changelog/1953.trivial.md
+++ b/.changelog/1953.trivial.md
@@ -1,0 +1,1 @@
+Use bold text instead of quotes around "delete" confirmation keyword

--- a/playwright/tests/toolbar.spec.ts
+++ b/playwright/tests/toolbar.spec.ts
@@ -127,7 +127,7 @@ test.describe('My Accounts tab', () => {
     await page.getByText('Delete Account').click()
     await page.getByTestId('account-delete-confirmation-input').fill('foo')
     await page.getByRole('button', { name: 'Yes, delete' }).click()
-    expect(page.getByText("Type 'delete'", { exact: true })).toBeVisible()
+    await expect(page.getByText('Type delete', { exact: true })).toBeVisible()
     await page.getByTestId('account-delete-confirmation-input').fill('delete')
     await page.getByRole('button', { name: 'Yes, delete' }).click()
     await expect(page).not.toHaveURL(new RegExp(`/account/${mnemonicAddress0}`))

--- a/src/app/components/DeleteInputForm/index.tsx
+++ b/src/app/components/DeleteInputForm/index.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 import { Box } from 'grommet/es6/components/Box'
 import { Button } from 'grommet/es6/components/Button'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { TextInput } from 'grommet/es6/components/TextInput'
 import { Form } from 'grommet/es6/components/Form'
 import { FormField } from 'grommet/es6/components/FormField'
@@ -21,11 +21,16 @@ export function DeleteInputForm({ children, onCancel, onConfirm }: DeleteInputFo
       <FormField
         name="type_delete"
         validate={(value: string | undefined) =>
-          !value || value.toLowerCase() !== t('deleteForm.confirmationKeyword', 'delete').toLowerCase()
-            ? t('deleteForm.hint', `Type '{{confirmationKeyword}}'`, {
+          !value || value.toLowerCase() !== t('deleteForm.confirmationKeyword', 'delete').toLowerCase() ? (
+            <Trans
+              i18nKey="deleteForm.hint"
+              t={t}
+              defaults="Type <strong>{{confirmationKeyword}}</strong>"
+              values={{
                 confirmationKeyword: t('deleteForm.confirmationKeyword', 'delete'),
-              })
-            : undefined
+              }}
+            />
+          ) : undefined
         }
       >
         <TextInput data-testid="account-delete-confirmation-input" id="type_delete" name="type_delete" />

--- a/src/app/components/Persist/DeleteProfileButton.tsx
+++ b/src/app/components/Persist/DeleteProfileButton.tsx
@@ -66,7 +66,7 @@ export function DeleteProfileButton({ prominent, variant }: DeleteProfileButtonP
                 <Trans
                   t={t}
                   i18nKey="persist.loginToProfile.deleteProfile.description"
-                  defaults="This will <strong>permanently remove your private keys from this device.</strong><br/><br/>To confirm and proceed, please type '{{confirmationKeyword}}' below."
+                  defaults="This will <strong>permanently remove your private keys from this device.</strong><br/><br/>To confirm and proceed, please type <strong>{{confirmationKeyword}}</strong> below."
                   values={{
                     confirmationKeyword: t('deleteForm.confirmationKeyword', 'delete'),
                   }}

--- a/src/app/components/Toolbar/Features/Account/DeleteAccount.tsx
+++ b/src/app/components/Toolbar/Features/Account/DeleteAccount.tsx
@@ -52,7 +52,7 @@ export const DeleteAccount = ({ onCancel, onDelete, wallet }: DeleteAccountProps
               <Paragraph fill textAlign="center">
                 {t(
                   'toolbar.settings.delete.inputHelp',
-                  `This action cannot be undone. To continue please type '{{confirmationKeyword}}' below.`,
+                  `This action cannot be undone. To continue please type <strong>{{confirmationKeyword}}</strong> below.`,
                   {
                     confirmationKeyword: t('deleteForm.confirmationKeyword', 'delete'),
                   },

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -95,7 +95,7 @@
   "deleteForm": {
     "confirm": "Ja, löschen",
     "confirmationKeyword": "löschen",
-    "hint": "Typ '{{confirmationKeyword}}'"
+    "hint": "Eingeben <strong>{{confirmationKeyword}}</strong>"
   },
   "errors": {
     "LedgerDerivedDifferentAccount": "Dieses Konto gehört nicht zu dem aktuell verbundenen Ledger.",
@@ -312,7 +312,7 @@
       "contacts": "Kontakte",
       "delete": {
         "description": "Bist du sicher, dass du das folgende Konto löschen möchtest?",
-        "inputHelp": "Diese Aktion kann nicht rückgängig gemacht werden. Um fortzufahren, gib bitte '{{confirmationKeyword}}' unten ein.",
+        "inputHelp": "Diese Aktion kann nicht rückgängig gemacht werden. Um fortzufahren, gib bitte <strong>{{confirmationKeyword}}</strong> unten ein.",
         "title": "Konto löschen",
         "tooltip": "Du musst immer mindestens ein Konto haben."
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -140,7 +140,7 @@
   "deleteForm": {
     "confirm": "Yes, delete",
     "confirmationKeyword": "delete",
-    "hint": "Type '{{confirmationKeyword}}'"
+    "hint": "Type <strong>{{confirmationKeyword}}</strong>"
   },
   "errors": {
     "LedgerDerivedDifferentAccount": "This account does not belong to the currently connected Ledger.",
@@ -415,7 +415,7 @@
     "loginToProfile": {
       "deleteProfile": {
         "button": "Delete profile",
-        "description": "This will <strong>permanently remove your private keys from this device.</strong><br/><br/>To confirm and proceed, please type '{{confirmationKeyword}}' below.",
+        "description": "This will <strong>permanently remove your private keys from this device.</strong><br/><br/>To confirm and proceed, please type <strong>{{confirmationKeyword}}</strong> below.",
         "forgotPasswordButton": "Forgot password?",
         "forgotPasswordDescription": "ROSE Wallet does not store your password and cannot help you retrieve it. If you forgot your password, you can delete your locked profile here. After that, you can create a new one using your mnemonic phrase or private keys, and use your ROSE tokens again.",
         "title": "Delete Profile"
@@ -483,7 +483,7 @@
       "contacts": "Contacts",
       "delete": {
         "description": "Are you sure you want to delete the following account?",
-        "inputHelp": "This action cannot be undone. To continue please type '{{confirmationKeyword}}' below.",
+        "inputHelp": "This action cannot be undone. To continue please type <strong>{{confirmationKeyword}}</strong> below.",
         "title": "Delete Account",
         "tooltip": "You must have at least one account at all times."
       },

--- a/src/locales/sl/translation.json
+++ b/src/locales/sl/translation.json
@@ -135,7 +135,7 @@
   "deleteForm": {
     "confirm": "Da, izbriši",
     "confirmationKeyword": "izbriši",
-    "hint": "Vtipkajte '{{confirmationKeyword}}'"
+    "hint": "Vtipkajte <strong>{{confirmationKeyword}}</strong>"
   },
   "errors": {
     "LedgerDerivedDifferentAccount": "Račun ne pripada trenutno povezanemu Ledgerju",
@@ -460,7 +460,7 @@
       "contacts": "Stiki",
       "delete": {
         "description": "Ali ste prepričani, da želite izbrisati ta račun?",
-        "inputHelp": "Tega ne bo mogoče razveljaviti. Če želite nadaljevati vnesite '{{confirmationKeyword}}'.",
+        "inputHelp": "Tega ne bo mogoče razveljaviti. Če želite nadaljevati vnesite <strong>{{confirmationKeyword}}</strong>.",
         "title": "Izbriši Račun",
         "tooltip": "V denarnici morate imeti vsaj en račun."
       },

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -135,7 +135,7 @@
   "deleteForm": {
     "confirm": "Evet, Sil",
     "confirmationKeyword": "Sil",
-    "hint": "'{{confirmationKeyword}}' yazın"
+    "hint": "<strong>{{confirmationKeyword}}</strong> yazın"
   },
   "errors": {
     "LedgerDerivedDifferentAccount": "Bu hesap şu anda bağlı olan Ledger'a ait değil.",
@@ -446,7 +446,7 @@
       "contacts": "Kontaklar",
       "delete": {
         "description": "Aşağıdaki hesabı silmek istediğinizden emin misiniz?",
-        "inputHelp": "Bu eylem geri alınamaz. Devam etmek için lütfen aşağıya {{confirmationKeyword}} girin.",
+        "inputHelp": "Bu eylem geri alınamaz. Devam etmek için lütfen aşağıya <strong>{{confirmationKeyword}}</strong> girin.",
         "title": "Hesabı sil",
         "tooltip": "Her zaman en az bir hesabınızın olması gerekir."
       },


### PR DESCRIPTION
Supersedes https://github.com/oasisprotocol/oasis-wallet-web/pull/1951
(didn't update chinese translation https://devblogs.microsoft.com/oldnewthing/20060914-02/?p=29743)