### PR TITLE
Migrate from grpc.oasis.dev to grpc.oasis.io

### DIFF
--- a/.changelog/1965.bugfix.md
+++ b/.changelog/1965.bugfix.md
@@ -1,0 +1,1 @@
+Migrate from grpc.oasis.dev to grpc.oasis.io

--- a/internals/getSecurityHeaders.js
+++ b/internals/getSecurityHeaders.js
@@ -45,8 +45,8 @@ const getCsp = ({ isExtension, isDev }) =>
       'self';
     connect-src
       'self'
-      https://grpc.oasis.dev
-      https://testnet.grpc.oasis.dev
+      https://grpc.oasis.io
+      https://testnet.grpc.oasis.io
       https://api.oasisscan.com
       ${isDev ? localnet : ''}
       ${isDev ? hmr : ''}

--- a/internals/getSecurityHeaders.js
+++ b/internals/getSecurityHeaders.js
@@ -48,7 +48,6 @@ const getCsp = ({ isExtension, isDev }) =>
       https://grpc.oasis.dev
       https://testnet.grpc.oasis.dev
       https://api.oasisscan.com
-      https://monitor.oasis.dev
       ${isDev ? localnet : ''}
       ${isDev ? hmr : ''}
       ;

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,7 @@ type BackendConfig = {
 
 export const config: BackendConfig = {
   mainnet: {
-    grpc: 'https://grpc.oasis.dev',
+    grpc: 'https://grpc.oasis.io',
     ticker: 'ROSE',
     min_delegation: 100,
     [BackendAPIs.OasisMonitor]: {
@@ -42,7 +42,7 @@ export const config: BackendConfig = {
     },
   },
   testnet: {
-    grpc: 'https://testnet.grpc.oasis.dev',
+    grpc: 'https://testnet.grpc.oasis.io',
     ticker: 'TEST',
     min_delegation: 100,
     [BackendAPIs.OasisMonitor]: {


### PR DESCRIPTION
Heads up: this changes security headers