### PR TITLE
Add transaction detail API cache

### DIFF
--- a/.changelog/1979.internal.md
+++ b/.changelog/1979.internal.md
@@ -1,0 +1,1 @@
+Add transaction detail API cache


### PR DESCRIPTION
Adds cache for the following 2 endpoints:
- getTransaction (`/chain/transaction/{hash}`)
- getRuntimeTransactionInfo (`/runtime/transaction/info?id={paraTimeId}&hash={hash}`)

As those responses won't change, once indexed, they are cached through the app session(until user closes the wallet).