### PR TITLE
Fix crash when expanding delegation translated by Google

### DIFF
--- a/.changelog/1983.bugfix.md
+++ b/.changelog/1983.bugfix.md
@@ -1,0 +1,1 @@
+Fix crash when expanding delegation translated by Google

--- a/src/app/pages/StakingPage/Features/CommissionBounds/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/CommissionBounds/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,9 @@
 exports[`<CommissionBounds  /> should match snapshot when empty 1`] = `
 <body>
   <div>
-    No bounds set (0% - 100%)
+    <span>
+      No bounds set (0% - 100%)
+    </span>
   </div>
 </body>
 `;

--- a/src/app/pages/StakingPage/Features/CommissionBounds/index.tsx
+++ b/src/app/pages/StakingPage/Features/CommissionBounds/index.tsx
@@ -68,6 +68,6 @@ export const CommissionBounds = memo((props: Props) => {
       </Box>
     )
   } else {
-    return <>{t('validator.boundsNotSet', 'No bounds set (0% - 100%)')}</>
+    return <span>{t('validator.boundsNotSet', 'No bounds set (0% - 100%)')}</span>
   }
 })


### PR DESCRIPTION
Closes #1982 

seems related to async data rendering