### PR TITLE
Fix extracting translations from MuiWalletIcon

### DIFF
--- a/.changelog/1987.trivial.md
+++ b/.changelog/1987.trivial.md
@@ -1,0 +1,1 @@
+Fix extracting translations from MuiWalletIcon

--- a/internals/extractMessages/i18next-scanner.config.js
+++ b/internals/extractMessages/i18next-scanner.config.js
@@ -1,7 +1,7 @@
 const typescriptTransform = require('i18next-scanner-typescript')
 
 module.exports = {
-  input: ['src/app/**/**.{js,jsx,ts,tsx}', '!**/node_modules/**', '!src/app/**/*.test.{ts,tsx}'],
+  input: ['src/**/**.{js,jsx,ts,tsx}', '!**/node_modules/**', '!src/**/*.test.{ts,tsx}'],
   output: './',
   options: {
     debug: false,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -212,13 +212,13 @@
       "header": "Access existing wallet"
     }
   },
-  "infoBox": {
-    "valueCopied": "{{label}} copied."
-  },
   "icons": {
     "wallet": {
       "label": "Wallet"
     }
+  },
+  "infoBox": {
+    "valueCopied": "{{label}} copied."
   },
   "language": "Language",
   "ledger": {


### PR DESCRIPTION
src/styles/theme/icons/mui-icons/MuiWalletIcon.tsx didn't match `src/app/**/**.{js,jsx,ts,tsx}`