### PR TITLE
Rename runtime transaction wrapper variable

### DIFF
--- a/.changelog/2000.trivial.md
+++ b/.changelog/2000.trivial.md
@@ -1,0 +1,1 @@
+Rename runtime transaction wrapper variable


### PR DESCRIPTION
`consensusRuntimeId` name was misleading
`txWrapper` name was slightly misleading, and we already use `rtw` in other code