### PR TITLE
Check account nonce when continuously refreshing balance

### DIFF
--- a/.changelog/2002.trivial.md
+++ b/.changelog/2002.trivial.md
@@ -1,0 +1,1 @@
+Check account nonce when continuously refreshing balance

--- a/src/app/state/account/saga.ts
+++ b/src/app/state/account/saga.ts
@@ -132,6 +132,7 @@ export function* fetchingOnAccountPage() {
           const staleBalances = yield* select(selectAccount)
           const hasPendingTxs = yield* select(hasAccountUnknownPendingTransactions)
           if (
+            staleBalances.nonce !== refreshedAccount.nonce || // If a new transaction fails it won't change balances
             staleBalances.available !== refreshedAccount.available ||
             staleBalances.delegations !== refreshedAccount.delegations ||
             staleBalances.debonding !== refreshedAccount.debonding ||


### PR DESCRIPTION
https://github.com/oasisprotocol/oasis-wallet-web/pull/1954 added nonce field to account and we can use it as another source for updating balance/transactions. This also fixes https://github.com/oasisprotocol/oasis-wallet-web/pull/1954#discussion_r1657332239 and updating transactions list if tx fails and doesn't update balance