### PR TITLE
Move staked and debonding count badge into text parentheses

### DIFF
--- a/.changelog/2014.bugfix.md
+++ b/.changelog/2014.bugfix.md
@@ -1,0 +1,1 @@
+Move staked and debonding count badge into text parentheses

--- a/src/app/pages/AccountPage/Features/StakeSubnavigation/index.tsx
+++ b/src/app/pages/AccountPage/Features/StakeSubnavigation/index.tsx
@@ -9,9 +9,9 @@ import styled from 'styled-components'
 import { normalizeColor } from 'grommet/es6/utils'
 
 import { AccountPageParams } from '../../validateAccountPageRoute'
-import { Button } from 'grommet/es6/components/Button'
 
 const StyledNavItem = styled(NavLink)`
+  letter-spacing: 0;
   padding: ${({ theme }) => theme.global?.edgeSize?.small};
 
   :hover {
@@ -23,7 +23,8 @@ const StyledNavItem = styled(NavLink)`
   }
 
   @media only screen and (max-width: ${({ theme }) => `${theme.global?.breakpoints?.small?.value}px`}) {
-    padding: ${({ theme }) => theme.global?.edgeSize?.xsmall};
+    padding-top: ${({ theme }) => theme.global?.edgeSize?.xsmall};
+    padding-bottom: ${({ theme }) => theme.global?.edgeSize?.xsmall};
   }
 `
 
@@ -36,9 +37,13 @@ interface NavItemProps {
 const NavItem = ({ counter, label, route }: NavItemProps) => {
   return (
     <StyledNavItem end to={route}>
-      <Button badge={counter} tabIndex={-1}>
-        {label}
-      </Button>
+      {counter ? (
+        <span>
+          {label} ({counter})
+        </span>
+      ) : (
+        <span>{label}</span>
+      )}
     </StyledNavItem>
   )
 }

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
@@ -405,10 +405,6 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
 
 }
 
-@media only screen and (max-width:768px) {
-
-}
-
 @media screen and (max-width:599px) {
   .c13 {
     display: none;

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
@@ -425,10 +425,6 @@ exports[`<DebondingDelegationList  /> should match snapshot 1`] = `
 
 }
 
-@media only screen and (max-width:768px) {
-
-}
-
 <section
   class="c0"
   data-testid="debonding-delegations"


### PR DESCRIPTION
Suggested by @tjanez 

Partially reverts https://github.com/oasisprotocol/oasis-wallet-web/pull/937
| Before | After |
| --- | --- |
| ![Screenshot from 2024-07-18 04-40-22](https://github.com/user-attachments/assets/0ff8ea12-de84-4fed-bba3-8a988ec31854) | ![Screenshot from 2024-07-18 04-40-13](https://github.com/user-attachments/assets/2346f864-6ee1-4826-8d85-2e2dbbe8fcab) |


cc @donouwens