### PR TITLE
Bring back padding to language and theme dropdowns

### DIFF
--- a/.changelog/2016.trivial.md
+++ b/.changelog/2016.trivial.md
@@ -1,0 +1,1 @@
+Bring back padding to language and theme dropdowns

--- a/src/styles/theme/ThemeProvider.tsx
+++ b/src/styles/theme/ThemeProvider.tsx
@@ -63,11 +63,14 @@ const grommetCustomTheme: ThemeType = {
     },
   },
   select: {
-    options: {
-      container: {
-        // Remove padding to match ParaTimeOption when displayed as value and as option
-        pad: 'none',
-      },
+    container: {
+      // Remove padding from selects with custom elements inside options.
+      // Needed to match ParaTimeOption when displayed as value and as option
+      extend: css`
+        button > div:has(span *) {
+          padding: 0;
+        }
+      `,
     },
   },
   global: {


### PR DESCRIPTION
Reimplements #1426

| Before | After |
| --- | --- |
| ![localhost_3000_account_oasis1qz78ap0456g2rk7j6rmtvasc9v2kjhz2s58qgj90_paratimes](https://github.com/user-attachments/assets/c779ac31-7e50-4aed-b1a7-c778f68f12d3) | ![localhost_3000_account_oasis1qz78ap0456g2rk7j6rmtvasc9v2kjhz2s58qgj90](https://github.com/user-attachments/assets/a0875e06-7564-4df8-bb1b-8a662215db81) |
| ![localhost_3000_account_oasis1qz78ap0456g2rk7j6rmtvasc9v2kjhz2s58qgj90_paratimes (2)](https://github.com/user-attachments/assets/37eda4c8-9a61-4d4f-850f-b06a858c755f) | ![localhost_3000_account_oasis1qz78ap0456g2rk7j6rmtvasc9v2kjhz2s58qgj90 (1)](https://github.com/user-attachments/assets/fe2c67a4-2292-4866-8c23-febb42724c32) |
