### PR TITLE
Exclude manifest.json from towncrier check

### DIFF
--- a/.changelog/2021.internal.md
+++ b/.changelog/2021.internal.md
@@ -1,0 +1,1 @@
+Exclude manifest.json from towncrier check

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -9,6 +9,7 @@ directory = ".changelog"
 check_ignore_files = [
   # File where we store app version.
   "package.json",
+  "public/manifest.json",
 ]
 issue_format = "[#{issue}](https://github.com/oasisprotocol/oasis-wallet-web/issues/{issue})"
 start_string = "<!-- TOWNCRIER -->\n"


### PR DESCRIPTION
Assemble changes PRs (https://github.com/oasisprotocol/oasis-wallet-web/pull/2020) should not be blocked by `ci-lint`. Relates to https://github.com/oasisprotocol/oasis-wallet-web/pull/1921