### PR TITLE
Fix footer to work with existing translations

### DIFF
--- a/.changelog/2026.bugfix.md
+++ b/.changelog/2026.bugfix.md
@@ -1,0 +1,1 @@
+Fix footer to work with existing translations

--- a/src/app/components/Footer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Footer/__tests__/__snapshots__/index.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`<Footer /> should render mobile version of footer 1`] = `
         </a>
         <br />
         <span>
-          (commit: 
+           (commit: 
         </span>
         <a
           class="c3"

--- a/src/app/components/Footer/index.tsx
+++ b/src/app/components/Footer/index.tsx
@@ -147,26 +147,18 @@ const Version = () => {
         t={t}
         components={{
           ReleaseLink: process.env.REACT_APP_BUILD_VERSION ? (
-            <Anchor
-              href={githubReleaseLink(process.env.REACT_APP_BUILD_VERSION)}
-              label={process.env.REACT_APP_BUILD_VERSION.replace('v', '')}
-              target="_blank"
-              rel="noopener noreferrer"
-            />
+            <>
+              <Anchor
+                href={githubReleaseLink(process.env.REACT_APP_BUILD_VERSION)}
+                label={process.env.REACT_APP_BUILD_VERSION.replace('v', '')}
+                target="_blank"
+                rel="noopener noreferrer"
+              />
+              {isMobileOrTablet ? <br /> : <span>&nbsp;</span>}
+            </>
           ) : (
             <NoReleaseLink />
           ),
-        }}
-        values={{
-          buildTime: intlDateTimeFormat(Number(process.env.REACT_APP_BUILD_DATETIME)),
-        }}
-        defaults="Version: <ReleaseLink/>"
-      />
-      {isMobileOrTablet ? <br /> : <span> </span>}
-      <Trans
-        i18nKey="footer.buildDetails"
-        t={t}
-        components={{
           CommitLink: (
             <Anchor
               href={`${githubLink}commit/${process.env.REACT_APP_BUILD_SHA}`}
@@ -179,7 +171,7 @@ const Version = () => {
         values={{
           buildTime: intlDateTimeFormat(Number(process.env.REACT_APP_BUILD_DATETIME)),
         }}
-        defaults="(commit: <CommitLink/>) built at {{buildTime}}"
+        defaults="Version: <ReleaseLink/> (commit: <CommitLink/>) built at {{buildTime}}"
       />
     </span>
   )

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -194,7 +194,6 @@
     "thirdPartyDisclaimer": "This service is provided by Transak - an external party. Oasis* does not carry any responsibility. All fees charged by Transak."
   },
   "footer": {
-    "buildDetails": "(commit: <CommitLink/>) built at {{buildTime}}",
     "feedback": "We’d love your feedback at <EmailLink>wallet@oasisprotocol.org</EmailLink>",
     "github": "ROSE Wallet is <GithubLink>open source</GithubLink> and powered by",
     "poweredBy": {
@@ -202,7 +201,7 @@
       "oasisscan": "Oasis Scan API & Oasis gRPC"
     },
     "terms": "<TermsLink>Terms and Conditions</TermsLink>",
-    "version": "Version: <ReleaseLink/>"
+    "version": "Version: <ReleaseLink/> (commit: <CommitLink/>) built at {{buildTime}}"
   },
   "home": {
     "create": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -126,7 +126,7 @@
       "oasisscan": "Alimenté par Oasis Scan API & Oasis gRPC"
     },
     "terms": "<TermsLink>Termes et Conditions</TermsLink>",
-    "version": "Version: <CommitLink/> construit à {{buildTime}}"
+    "version": "Version: <ReleaseLink/> (<CommitLink/>) construit à {{buildTime}}"
   },
   "home": {
     "create": {


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-wallet-web/issues/2023

Example of existing translation that was broken:
`"version": "Različica <ReleaseLink/> (<CommitLink/>) zgrajena {{buildTime}}"`

Reverts part of #1941 and #1961.