### PR TITLE
Fix noGoogleTranslateCrashingSyntax to use shallow `:has(>...)`

### DIFF
--- a/.changelog/2029.internal.md
+++ b/.changelog/2029.internal.md
@@ -1,0 +1,1 @@
+Fix noGoogleTranslateCrashingSyntax to use shallow :has(>...)

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,7 @@ const noGoogleTranslateCrashingSyntax = [
   // Ban text nodes before or after a condition `text {condition && <span/>} text`
   {
     selector:
-      'JSXElement:has(JSXExpressionContainer.children > LogicalExpression[operator="&&"])' +
+      'JSXElement:has(> JSXExpressionContainer.children:has(> LogicalExpression[operator="&&"]))' +
       ' > JSXText[value!=/^\\s+$/]',
     message:
       '[c] Plain text nodes before or after a condition could break React if used with Google Translate. Wrap text into an element.',
@@ -29,7 +29,7 @@ const noGoogleTranslateCrashingSyntax = [
   // Ban variables before or after `{var} {condition && <span/>} {var}` (just in case they return a string)
   {
     selector:
-      'JSXElement:has(JSXExpressionContainer.children > LogicalExpression[operator="&&"])' +
+      'JSXElement:has(> JSXExpressionContainer.children:has(> LogicalExpression[operator="&&"]))' +
       ' > JSXExpressionContainer:matches([expression.type="Identifier"], [expression.type="CallExpression"])',
     message:
       '[d] Plain text nodes before or after a condition could break React if used with Google Translate. Identifier could possibly return a string, so wrap it into an element.',
@@ -54,7 +54,7 @@ const noGoogleTranslateCrashingSyntax = [
   // Ban text nodes before or after a condition `text {condition ? <span/> : <span/>} text`
   {
     selector:
-      'JSXElement:has(JSXExpressionContainer.children > ConditionalExpression)' +
+      'JSXElement:has(> JSXExpressionContainer.children:has(> ConditionalExpression))' +
       ' > JSXText[value!=/^\\s+$/]',
     message:
       '[g] Plain text nodes before or after a condition could break React if used with Google Translate. Wrap text into an element.',
@@ -62,7 +62,7 @@ const noGoogleTranslateCrashingSyntax = [
   // Ban variables before or after `{var} {condition ? <span/> : <span/>} {var}` (just in case they return a string)
   {
     selector:
-      'JSXElement:has(JSXExpressionContainer.children > ConditionalExpression)' +
+      'JSXElement:has(> JSXExpressionContainer.children:has(> ConditionalExpression))' +
       ' > JSXExpressionContainer:matches([expression.type="Identifier"], [expression.type="CallExpression"])',
     message:
       '[h] Plain text nodes before or after a condition could break React if used with Google Translate. Identifier could possibly return a string, so wrap it into an element.',
@@ -94,7 +94,7 @@ const noGoogleTranslateCrashingSyntax = [
   },
 ]
 
-/** @type { import('eslint').Linter.Config } */
+/** @type { import('eslint').Linter.LegacyConfig } */
 const config = {
   extends: [
     'eslint:recommended', // https://eslint.org/docs/rules/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ const noGoogleTranslateCrashingSyntax = [
   {
     selector:
       'JSXElement > JSXExpressionContainer > LogicalExpression[operator="&&"]' +
-      ' > JSXFragment > .children:not(JSXElement, JSXText[value=/^\\s+$/])',
+      ' > JSXFragment > .children:not(JSXElement, JSXText[value=/^\\s+$/], JSXExpressionContainer)',
     message:
       '[b] Conditional plain text nodes could break React if used with Google Translate. Wrap text into an element.',
   },
@@ -47,7 +47,7 @@ const noGoogleTranslateCrashingSyntax = [
   {
     selector:
       'JSXElement > JSXExpressionContainer > ConditionalExpression' +
-      ' > JSXFragment > .children:not(JSXElement, JSXText[value=/^\\s+$/])',
+      ' > JSXFragment > .children:not(JSXElement, JSXText[value=/^\\s+$/], JSXExpressionContainer)',
     message:
       '[f] Conditional plain text nodes could break React if used with Google Translate. Wrap text into an element.',
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ const noGoogleTranslateCrashingSyntax = [
       'JSXElement > JSXExpressionContainer > LogicalExpression[operator="&&"]' +
       '[right.type!="JSXElement"][right.type!="JSXFragment"]',
     message:
-      'Conditional plain text nodes could break React if used with Google Translate. Wrap text into an element.',
+      '[a] Conditional plain text nodes could break React if used with Google Translate. Wrap text into an element.',
   },
   // Ban `condition && <>text node</>`
   {
@@ -16,7 +16,7 @@ const noGoogleTranslateCrashingSyntax = [
       'JSXElement > JSXExpressionContainer > LogicalExpression[operator="&&"]' +
       ' > JSXFragment > .children:not(JSXElement, JSXText[value=/^\\s+$/])',
     message:
-      'Conditional plain text nodes could break React if used with Google Translate. Wrap text into an element.',
+      '[b] Conditional plain text nodes could break React if used with Google Translate. Wrap text into an element.',
   },
   // Ban text nodes before or after a condition `text {condition && <span/>} text`
   {
@@ -24,7 +24,7 @@ const noGoogleTranslateCrashingSyntax = [
       'JSXElement:has(JSXExpressionContainer.children > LogicalExpression[operator="&&"])' +
       ' > JSXText[value!=/^\\s+$/]',
     message:
-      'Plain text nodes before or after a condition could break React if used with Google Translate. Wrap text into an element.',
+      '[c] Plain text nodes before or after a condition could break React if used with Google Translate. Wrap text into an element.',
   },
   // Ban variables before or after `{var} {condition && <span/>} {var}` (just in case they return a string)
   {
@@ -32,7 +32,7 @@ const noGoogleTranslateCrashingSyntax = [
       'JSXElement:has(JSXExpressionContainer.children > LogicalExpression[operator="&&"])' +
       ' > JSXExpressionContainer:matches([expression.type="Identifier"], [expression.type="CallExpression"])',
     message:
-      'Plain text nodes before or after a condition could break React if used with Google Translate. Identifier could possibly return a string, so wrap it into an element.',
+      '[d] Plain text nodes before or after a condition could break React if used with Google Translate. Identifier could possibly return a string, so wrap it into an element.',
   },
 
   // Ban `condition ? text node : <span/>`
@@ -41,7 +41,7 @@ const noGoogleTranslateCrashingSyntax = [
       'JSXElement > JSXExpressionContainer > ConditionalExpression' +
       ' > :matches(.consequent, .alternate):not(JSXElement, JSXFragment)',
     message:
-      'Conditional plain text nodes could break React if used with Google Translate. Wrap text into an element.',
+      '[e] Conditional plain text nodes could break React if used with Google Translate. Wrap text into an element.',
   },
   // Ban `condition ? <>text node</> : <span/>`
   {
@@ -49,7 +49,7 @@ const noGoogleTranslateCrashingSyntax = [
       'JSXElement > JSXExpressionContainer > ConditionalExpression' +
       ' > JSXFragment > .children:not(JSXElement, JSXText[value=/^\\s+$/])',
     message:
-      'Conditional plain text nodes could break React if used with Google Translate. Wrap text into an element.',
+      '[f] Conditional plain text nodes could break React if used with Google Translate. Wrap text into an element.',
   },
   // Ban text nodes before or after a condition `text {condition ? <span/> : <span/>} text`
   {
@@ -57,7 +57,7 @@ const noGoogleTranslateCrashingSyntax = [
       'JSXElement:has(JSXExpressionContainer.children > ConditionalExpression)' +
       ' > JSXText[value!=/^\\s+$/]',
     message:
-      'Plain text nodes before or after a condition could break React if used with Google Translate. Wrap text into an element.',
+      '[g] Plain text nodes before or after a condition could break React if used with Google Translate. Wrap text into an element.',
   },
   // Ban variables before or after `{var} {condition ? <span/> : <span/>} {var}` (just in case they return a string)
   {
@@ -65,7 +65,7 @@ const noGoogleTranslateCrashingSyntax = [
       'JSXElement:has(JSXExpressionContainer.children > ConditionalExpression)' +
       ' > JSXExpressionContainer:matches([expression.type="Identifier"], [expression.type="CallExpression"])',
     message:
-      'Plain text nodes before or after a condition could break React if used with Google Translate. Identifier could possibly return a string, so wrap it into an element.',
+      '[h] Plain text nodes before or after a condition could break React if used with Google Translate. Identifier could possibly return a string, so wrap it into an element.',
   },
 
   // Ban components returning text or variables inside fragments `return <>{t('text')}</>` (just in case vars return a string and parent components are conditionally inserted)
@@ -80,17 +80,17 @@ const noGoogleTranslateCrashingSyntax = [
       '  MemberExpression[property.name="children"]' + // Allow `<>{someProps.children}</>`
       ')',
     message:
-      'Text nodes inside React fragments could break React if used with Google Translate. Identifier could possibly return a string, and parent components could be conditionally inserted, so wrap it into an element.',
+      '[i] Text nodes inside React fragments could break React if used with Google Translate. Identifier could possibly return a string, and parent components could be conditionally inserted, so wrap it into an element.',
   },
 
   // TODO: Nesting is not supported. Detect it as error for now
   {
     selector: 'JSXElement > JSXExpressionContainer > ConditionalExpression > ConditionalExpression',
-    message: 'noGoogleTranslateCrashingSyntax can not check nested conditions.',
+    message: '[j] noGoogleTranslateCrashingSyntax can not check nested conditions.',
   },
   {
     selector: 'JSXElement > JSXExpressionContainer > ConditionalExpression > LogicalExpression',
-    message: 'noGoogleTranslateCrashingSyntax can not check nested conditions.',
+    message: '[k] noGoogleTranslateCrashingSyntax can not check nested conditions.',
   },
 ]
 

--- a/src/app/pages/AccountPage/Features/TransactionHistory/index.tsx
+++ b/src/app/pages/AccountPage/Features/TransactionHistory/index.tsx
@@ -63,7 +63,6 @@ export function TransactionHistory() {
           <ErrorFormatter code={transactionsError.code} message={transactionsError.message} />
         </p>
       )}
-      {/* eslint-disable no-restricted-syntax */}
       {!isInitialLoading && (!!pendingTransactionComponents.length || hasUnknownPendingTransactions) && (
         <>
           <Heading level="2">{t('account.summary.pendingTransactions', 'Pending transactions')}</Heading>
@@ -97,15 +96,16 @@ export function TransactionHistory() {
               'Some transactions are currently in a pending state.',
             )}
           </AlertBox>
+          {/* eslint-disable no-restricted-syntax */}
           {!!pendingTransactionComponents.length && (
             <Box gap="medium" data-testid="pending-txs" margin={{ top: 'small' }}>
               {pendingTransactionComponents}
             </Box>
           )}
+          {/* eslint-enable no-restricted-syntax */}
         </>
       )}
       <Heading level="2">{t('account.summary.activity', 'Activity')}</Heading>
-      {/* eslint-enable no-restricted-syntax */}
       {allTransactions.length ? (
         <Box gap="medium" margin="none" data-testid="completed-txs">
           {transactionComponents}

--- a/src/app/pages/AccountPage/Features/TransactionHistory/index.tsx
+++ b/src/app/pages/AccountPage/Features/TransactionHistory/index.tsx
@@ -96,13 +96,11 @@ export function TransactionHistory() {
               'Some transactions are currently in a pending state.',
             )}
           </AlertBox>
-          {/* eslint-disable no-restricted-syntax */}
           {!!pendingTransactionComponents.length && (
             <Box gap="medium" data-testid="pending-txs" margin={{ top: 'small' }}>
               {pendingTransactionComponents}
             </Box>
           )}
-          {/* eslint-enable no-restricted-syntax */}
         </>
       )}
       <Heading level="2">{t('account.summary.activity', 'Activity')}</Heading>

--- a/src/utils/eslint-test-noGoogleTranslateCrashingSyntax.tsx
+++ b/src/utils/eslint-test-noGoogleTranslateCrashingSyntax.tsx
@@ -77,6 +77,9 @@ const textAfterAndOperator = (
       {!condition && <span>good</span>}
       bad
     </span>
+    good
+    {good}
+    {/* good */}
     <span>
       {!condition && <span>good</span>}
       {/* eslint-disable-next-line no-restricted-syntax */}
@@ -99,6 +102,9 @@ const textBeforeTernaryOperator = (
       bad
       {!condition ? <span>good</span> : <span>good</span>}
     </span>
+    good
+    {good}
+    {/* good */}
     <span>
       {/* eslint-disable-next-line no-restricted-syntax */}
       {bad}
@@ -176,10 +182,14 @@ const textInTernaryOperator = (
 const textAfterTernaryOperator = (
   <div>
     <span>
+      bad
       {/* eslint-disable-next-line no-restricted-syntax */}
       {!condition ? <span>good</span> : <span>good</span>}
       bad
     </span>
+    good
+    {good}
+    {/* good */}
     <span>
       {!condition ? <span>good</span> : <span>good</span>}
       {/* eslint-disable-next-line no-restricted-syntax */}

--- a/src/utils/eslint-test-noGoogleTranslateCrashingSyntax.tsx
+++ b/src/utils/eslint-test-noGoogleTranslateCrashingSyntax.tsx
@@ -181,6 +181,7 @@ const textInTernaryOperator = (
 )
 const textAfterTernaryOperator = (
   <div>
+    {/* eslint-disable-next-line no-restricted-syntax */}
     <span>
       bad
       {/* eslint-disable-next-line no-restricted-syntax */}

--- a/src/utils/eslint-test-noGoogleTranslateCrashingSyntax.tsx
+++ b/src/utils/eslint-test-noGoogleTranslateCrashingSyntax.tsx
@@ -40,6 +40,8 @@ const textBeforeAndOperator = (
       {!condition && <span>good</span>}
       {!condition && (
         <>
+          {/* good */}
+          {!condition && <span>good</span>}
           <span>good</span>
           <span>good</span>
         </>
@@ -167,6 +169,8 @@ const textInTernaryOperator = (
       {!condition ? <span>{good}</span> : <span>{good}</span>}
       {!condition ? (
         <>
+          {/* good */}
+          {!condition && <span>good</span>}
           <span>good</span>
           <span>good</span>
         </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5455,9 +5455,9 @@ esprima@^4.0.0, esprima@^4.0.1:
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esquery@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.2.tgz#c6d3fee05dd665808e2ad870631f221f5617b1d1"
-  integrity sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.6.0.tgz#91419234f804d852a82dceec3e16cdc22cf9dae7"
+  integrity sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==
   dependencies:
     estraverse "^5.1.0"
 


### PR DESCRIPTION
https://github.com/oasisprotocol/oasis-wallet-web/pull/1954#discussion_r1646806112