### PR TITLE
Fix display of delegations to non-validators

### DIFF
--- a/.changelog/2031.bugfix.md
+++ b/.changelog/2031.bugfix.md
@@ -1,0 +1,1 @@
+Fix display of delegations to non-validators

--- a/src/app/components/AmountFormatter/index.tsx
+++ b/src/app/components/AmountFormatter/index.tsx
@@ -45,8 +45,7 @@ export const AmountFormatter = memo(
     const formatter = isUsingBaseUnits ? formatBaseUnitsAsRose : formatWeiAsWrose
     const amountString = formatter(amount, {
       minimumFractionDigits: minimumFractionDigits ?? 1,
-      maximumFractionDigits:
-        typeof maximumFractionDigits !== 'undefined' ? maximumFractionDigits : isUsingBaseUnits ? 15 : 18,
+      maximumFractionDigits: maximumFractionDigits ?? (isUsingBaseUnits ? 15 : 18),
     })
 
     const tickerProps = smallTicker

--- a/src/app/pages/StakingPage/Features/DelegationList/DelegationItem.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/DelegationItem.tsx
@@ -11,6 +11,7 @@ interface DelegationProps {
   data: Delegation | DebondingDelegation
   validatorDetails: ValidatorDetails | null
   canReclaim: boolean
+  type: 'active' | 'debonding'
 }
 
 export const DelegationItem = memo((props: DelegationProps) => {
@@ -23,7 +24,14 @@ export const DelegationItem = memo((props: DelegationProps) => {
   return (
     <Box pad={{ vertical: 'medium' }} data-testid="validator-item">
       <Box style={{ maxWidth: '85vw' }}>
-        {validator && <ValidatorInformations validator={validator} details={details} />}
+        {validator && (
+          <ValidatorInformations
+            validator={validator}
+            details={details}
+            delegation={props.type === 'active' ? delegation.amount : null}
+            debonding={props.type === 'debonding' ? delegation.amount : null}
+          />
+        )}
         {!validator && (
           <div>
             <AddressBox address={delegation.validatorAddress} trimMobile />

--- a/src/app/pages/StakingPage/Features/DelegationList/DelegationItem.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/DelegationItem.tsx
@@ -5,6 +5,7 @@ import React, { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ValidatorInformations } from '../ValidatorList/ValidatorInformations'
+import { AddressBox } from '../../../../components/AddressBox'
 
 interface DelegationProps {
   data: Delegation | DebondingDelegation
@@ -23,7 +24,12 @@ export const DelegationItem = memo((props: DelegationProps) => {
     <Box pad={{ vertical: 'medium' }} data-testid="validator-item">
       <Box style={{ maxWidth: '85vw' }}>
         {validator && <ValidatorInformations validator={validator} details={details} />}
-        {!validator && <span>{t('validator.unknownValidator', 'Unknown validator')}</span>}
+        {!validator && (
+          <div>
+            <AddressBox address={delegation.validatorAddress} trimMobile />
+            {t('validator.unknownValidator', 'Unknown validator')}
+          </div>
+        )}
         {canReclaim && (
           <ReclaimEscrowForm
             address={delegation.validatorAddress}

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
@@ -592,7 +592,7 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
                     class="c0"
                     style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
                   >
-                    0.0000001
+                    0.00
                   </div>
                   <span
                     class="c19"

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
@@ -580,7 +580,7 @@ exports[`<DebondingDelegationList  /> should match snapshot 1`] = `
                     class="c0"
                     style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
                   >
-                    0.0000001
+                    0.00
                   </div>
                   <span
                     class="c19"

--- a/src/app/pages/StakingPage/Features/DelegationList/index.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/index.tsx
@@ -115,7 +115,10 @@ export const DelegationList = memo((props: Props) => {
       selector: 'amount',
       width: '28ex',
       right: true,
-      cell: datum => datum.amount && <AmountFormatter amount={datum.amount} />,
+      cell: datum =>
+        datum.amount && (
+          <AmountFormatter amount={datum.amount} maximumFractionDigits={2} minimumFractionDigits={2} />
+        ),
       sortable: true,
       sortFunction: (row1, row2) => Number(BigInt(row1.amount) - BigInt(row2.amount)),
     },

--- a/src/app/pages/StakingPage/Features/DelegationList/index.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/index.tsx
@@ -172,7 +172,12 @@ export const DelegationList = memo((props: Props) => {
       expandableRowsHideExpander
       expandableRows={true}
       expandableRowsComponent={
-        <DelegationItem data={{} as any} validatorDetails={validatorDetails} canReclaim={canReclaim} />
+        <DelegationItem
+          data={{} as any}
+          validatorDetails={validatorDetails}
+          canReclaim={canReclaim}
+          type={type}
+        />
       }
       expandableRowExpanded={row => row.validatorAddress === selectedAddress}
       sortIcon={<Down />}

--- a/src/app/pages/StakingPage/Features/ValidatorList/ValidatorInformations.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/ValidatorInformations.tsx
@@ -12,6 +12,7 @@ import { Spinner } from 'grommet/es6/components/Spinner'
 import { Text } from 'grommet/es6/components/Text'
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
+import { StringifiedBigInt } from '../../../../../types/StringifiedBigInt'
 
 import { CommissionBounds } from '../CommissionBounds'
 import { ValidatorMediaInfo } from '../ValidatorMediaInfo'
@@ -19,6 +20,8 @@ import { ValidatorMediaInfo } from '../ValidatorMediaInfo'
 interface ValidatorProps {
   validator: Validator
   details: ValidatorDetails | null
+  delegation: StringifiedBigInt | null
+  debonding: StringifiedBigInt | null
 }
 
 export const ValidatorInformations = (props: ValidatorProps) => {
@@ -74,6 +77,19 @@ export const ValidatorInformations = (props: ValidatorProps) => {
           label={t('validator.status', 'Status')}
           value={<ValidatorStatus status={validator.status} showLabel={true}></ValidatorStatus>}
         />
+
+        {props.delegation && (
+          <ResponsiveGridRow
+            label={t('delegations.delegatedAmount', 'Delegated amount')}
+            value={<AmountFormatter amount={props.delegation} size="inherit" />}
+          />
+        )}
+        {props.debonding && (
+          <ResponsiveGridRow
+            label={t('delegations.reclaimedAmount', 'Amount to reclaim')}
+            value={<AmountFormatter amount={props.debonding} size="inherit" />}
+          />
+        )}
       </Grid>
     </>
   )

--- a/src/app/pages/StakingPage/Features/ValidatorList/ValidatorItem.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/ValidatorItem.tsx
@@ -20,7 +20,7 @@ export const ValidatorItem = (props: ValidatorProps) => {
   return (
     <Box pad={{ vertical: 'medium' }} data-testid="validator-item">
       <Box style={{ maxWidth: '85vw' }}>
-        <ValidatorInformations validator={validator} details={details} />
+        <ValidatorInformations validator={validator} details={details} delegation={null} debonding={null} />
         {isAddressInWallet && (
           <AddEscrowForm
             validatorAddress={validator.address}

--- a/src/vendors/oasisscan.ts
+++ b/src/vendors/oasisscan.ts
@@ -260,7 +260,7 @@ export function parseDelegations(delegations: DelegationRow[]): Delegation[] {
     const parsed: Delegation = {
       amount: parseRoseStringToBaseUnitString(delegation.amount),
       shares: parseRoseStringToBaseUnitString(delegation.shares),
-      validatorAddress: delegation.validatorAddress,
+      validatorAddress: delegation.validatorAddress ?? delegation.entityAddress,
     }
     return parsed
   })


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-wallet-web/issues/2030

https://wallet.dev.oasis.io/account/oasis1qprtzrg97jk0wxnqkhxwyzy5qys47r7alvfl3fcg/stake/active-delegations

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/5c3b5a04-f560-4fd6-8714-d6c948bd3953) | ![image](https://github.com/user-attachments/assets/e6e90bb0-fa03-404f-b1ce-17911bcfd2f8) |

- Fixes selecting non-validators. Previously all "undefined" validators were pre-expanded and crashed when collapsing + re-expanding their details
- Prints delegation's address
- Round delegation amounts in the table. Accurate delegation amount is still displayed when expanding
- (we currently don't have a rounding indicator like https://github.com/oasisprotocol/explorer/blob/1651e1a64a4ae9a7743b3fdc78e1e98aa5d1f5b4/src/app/components/RoundedBalance/__tests__/index.test.tsx#L11-L12)