### PR TITLE
Allow to use any of validator field to expand details

### DIFF
--- a/.changelog/2034.trivial.md
+++ b/.changelog/2034.trivial.md
@@ -1,0 +1,1 @@
+Allow to use any of validator field to expand details

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/ActiveDelegationList.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
   stroke: none;
 }
 
-.c18 {
+.c19 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -46,25 +46,25 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
   stroke: #2ad5ab;
 }
 
-.c18 g {
+.c19 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill='none'] {
+.c19 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*='#'],
-.c18 *[STROKE*='#'] {
+.c19 *[stroke*='#'],
+.c19 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*='#'],
-.c18 *[FILL*='#'] {
+.c19 *[fill-rule],
+.c19 *[FILL-RULE],
+.c19 *[fill*='#'],
+.c19 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -100,10 +100,19 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
   padding: 24px;
 }
 
-.c19 {
-  font-size: 16px;
-  line-height: 20px;
-  color: #0500e2;
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  cursor: pointer;
 }
 
 .c4 {
@@ -391,6 +400,12 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
   display: table;
 }
 
+.c20 {
+  font-size: 16px;
+  line-height: 20px;
+  color: #0500e2;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -560,18 +575,24 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
                 id="cell-status-test-validator"
                 role="gridcell"
               >
-                <svg
-                  aria-label="Status is okay"
+                <div
                   class="c18"
-                  viewBox="0 0 24 24"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
                 >
-                  <path
-                    d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zM7 12l4 3 5-7"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
+                  <svg
+                    aria-label="Status is okay"
+                    class="c19"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zM7 12l4 3 5-7"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
               </div>
               <div
                 class="c16 c9 c17 rdt_TableCell"
@@ -587,24 +608,30 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
                 id="cell-amount-test-validator"
                 role="gridcell"
               >
-                <span>
-                  <div
-                    class="c0"
-                    style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
-                  >
-                    0.00
-                  </div>
-                  <span
-                    class="c19"
-                  >
-                    <span
-                      class="notranslate"
-                      translate="no"
+                <div
+                  class="c18"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
+                >
+                  <span>
+                    <div
+                      class="c0"
+                      style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
                     >
-                       
+                      0.00
+                    </div>
+                    <span
+                      class="c20"
+                    >
+                      <span
+                        class="notranslate"
+                        translate="no"
+                      >
+                         
+                      </span>
                     </span>
                   </span>
-                </span>
+                </div>
               </div>
               <div
                 class="c16 c13 c17 rdt_TableCell"
@@ -612,7 +639,15 @@ exports[`<ActiveDelegationList  /> should match snapshot 1`] = `
                 id="cell-fee-test-validator"
                 role="gridcell"
               >
-                7%
+                <div
+                  class="c18"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
+                >
+                  <span>
+                    7%
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/DelegationList/__tests__/__snapshots__/DebondingDelegationList.test.tsx.snap
@@ -67,9 +67,18 @@ exports[`<DebondingDelegationList  /> should match snapshot 1`] = `
 }
 
 .c19 {
-  font-size: 16px;
-  line-height: 20px;
-  color: #0500e2;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  cursor: pointer;
 }
 
 .c4 {
@@ -407,6 +416,12 @@ exports[`<DebondingDelegationList  /> should match snapshot 1`] = `
   display: table;
 }
 
+.c20 {
+  font-size: 16px;
+  line-height: 20px;
+  color: #0500e2;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -575,24 +590,30 @@ exports[`<DebondingDelegationList  /> should match snapshot 1`] = `
                 id="cell-amount-test-validator+100"
                 role="gridcell"
               >
-                <span>
-                  <div
-                    class="c0"
-                    style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
-                  >
-                    0.00
-                  </div>
-                  <span
-                    class="c19"
-                  >
-                    <span
-                      class="notranslate"
-                      translate="no"
+                <div
+                  class="c19"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
+                >
+                  <span>
+                    <div
+                      class="c0"
+                      style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
                     >
-                       
+                      0.00
+                    </div>
+                    <span
+                      class="c20"
+                    >
+                      <span
+                        class="notranslate"
+                        translate="no"
+                      >
+                         
+                      </span>
                     </span>
                   </span>
-                </span>
+                </div>
               </div>
               <div
                 class="c17 c13 c18 rdt_TableCell"
@@ -600,9 +621,15 @@ exports[`<DebondingDelegationList  /> should match snapshot 1`] = `
                 id="cell-debondingTimeEnd-test-validator+100"
                 role="gridcell"
               >
-                <span>
-                  in 4 days
-                </span>
+                <div
+                  class="c19"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
+                >
+                  <span>
+                    in 4 days
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/pages/StakingPage/Features/DelegationList/index.tsx
+++ b/src/app/pages/StakingPage/Features/DelegationList/index.tsx
@@ -3,25 +3,19 @@
  * DelegationList
  *
  */
-import { AmountFormatter } from 'app/components/AmountFormatter'
-import { ShortAddress } from 'app/components/ShortAddress'
-import { TimeToEpoch } from 'app/components/TimeToEpoch'
-import { formatCommissionPercent } from 'app/lib/helpers'
-import { ValidatorStatus } from 'app/pages/StakingPage/Features/ValidatorList/ValidatorStatus'
 import { selectIsAddressInWallet } from 'app/state/selectIsAddressInWallet'
 import { stakingActions } from 'app/state/staking'
 import { selectSelectedAddress, selectValidatorDetails } from 'app/state/staking/selectors'
 import { DebondingDelegation, Delegation } from 'app/state/staking/types'
-import { Text } from 'grommet/es6/components/Text'
 import { Down } from 'grommet-icons/es6/icons/Down'
-import React, { memo } from 'react'
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { dataTableCustomStyles } from 'styles/theme/dataTableTheme'
 import { TypeSafeDataTable, ITypeSafeDataTableColumn } from 'types/TypeSafeDataTable'
 import { isWebUri } from 'valid-url'
-
 import { DelegationItem } from './DelegationItem'
+import { AmountCell, FeeCell, IconCell, NameCell, StatusCell, TimeEndCell } from '../TableCell'
 
 type Props =
   | {
@@ -75,7 +69,7 @@ export const DelegationList = memo((props: Props) => {
       cell: datum =>
         datum.validator?.media?.logotype &&
         isWebUri(datum.validator?.media.logotype) && (
-          <img src={datum.validator?.media.logotype} loading="lazy" className={'logotype-small'} alt="" />
+          <IconCell onClick={() => rowClicked(datum)} src={datum.validator?.media.logotype} />
         ),
       width: '34px',
     },
@@ -83,9 +77,7 @@ export const DelegationList = memo((props: Props) => {
       name: '',
       id: 'status',
       cell: datum =>
-        datum.validator && (
-          <ValidatorStatus status={datum.validator.status} showLabel={false}></ValidatorStatus>
-        ),
+        datum.validator && <StatusCell onClick={() => rowClicked(datum)} status={datum.validator.status} />,
       width: '34px',
     },
     name: {
@@ -96,9 +88,7 @@ export const DelegationList = memo((props: Props) => {
       minWidth: '15ex',
       cell: datum =>
         datum.validator?.name ?? (
-          <Text data-tag="allowRowEvents">
-            <ShortAddress address={datum.validatorAddress} />
-          </Text>
+          <NameCell address={datum.validatorAddress} onClick={() => rowClicked(datum)} />
         ),
       sortable: true,
       sortFunction: (row1, row2) =>
@@ -117,7 +107,12 @@ export const DelegationList = memo((props: Props) => {
       right: true,
       cell: datum =>
         datum.amount && (
-          <AmountFormatter amount={datum.amount} maximumFractionDigits={2} minimumFractionDigits={2} />
+          <AmountCell
+            amount={datum.amount}
+            onClick={() => rowClicked(datum)}
+            maximumFractionDigits={2}
+            minimumFractionDigits={2}
+          />
         ),
       sortable: true,
       sortFunction: (row1, row2) => Number(BigInt(row1.amount) - BigInt(row2.amount)),
@@ -129,10 +124,8 @@ export const DelegationList = memo((props: Props) => {
       width: '100px',
       right: true,
       hide: 'sm',
-      cell: datum =>
-        datum.validator?.current_rate !== undefined
-          ? `${formatCommissionPercent(datum.validator.current_rate)}%`
-          : 'Unknown',
+      cell: datum => <FeeCell fee={datum.validator?.current_rate} onClick={() => rowClicked(datum)} />,
+
       sortable: true,
       sortFunction: (row1, row2) => (row1.validator?.current_rate ?? 0) - (row2.validator?.current_rate ?? 0),
     },
@@ -141,7 +134,9 @@ export const DelegationList = memo((props: Props) => {
       id: 'debondingTimeEnd',
       selector: 'epoch',
       sortable: true,
-      cell: datum => <TimeToEpoch epoch={(datum as DebondingDelegation).epoch} />,
+      cell: datum => (
+        <TimeEndCell epoch={(datum as DebondingDelegation).epoch} onClick={() => rowClicked(datum)} />
+      ),
     },
   }
 

--- a/src/app/pages/StakingPage/Features/TableCell.tsx
+++ b/src/app/pages/StakingPage/Features/TableCell.tsx
@@ -6,6 +6,7 @@ import { formatCommissionPercent } from '../../../lib/helpers'
 import { ShortAddress } from '../../../components/ShortAddress'
 import { AmountFormatter } from '../../..//components/AmountFormatter'
 import { ValidatorStatus } from './ValidatorList/ValidatorStatus'
+import { TimeToEpoch } from 'app/components/TimeToEpoch'
 
 interface ExpandableCellProps {
   children: ReactNode
@@ -70,12 +71,23 @@ export const NameCell: FC<NameCellProps> = ({ address, onClick }) => {
 interface AmountCellProps {
   amount: StringifiedBigInt
   onClick: () => void
+  minimumFractionDigits?: number
+  maximumFractionDigits?: number
 }
 
-export const AmountCell: FC<AmountCellProps> = ({ amount, onClick }) => {
+export const AmountCell: FC<AmountCellProps> = ({
+  amount,
+  onClick,
+  minimumFractionDigits,
+  maximumFractionDigits,
+}) => {
   return (
     <ExpandableCell onClick={onClick}>
-      <AmountFormatter amount={amount} minimumFractionDigits={0} maximumFractionDigits={0} />
+      <AmountFormatter
+        amount={amount}
+        minimumFractionDigits={minimumFractionDigits}
+        maximumFractionDigits={maximumFractionDigits}
+      />
     </ExpandableCell>
   )
 }
@@ -89,6 +101,19 @@ export const FeeCell: FC<FeeCellProps> = ({ fee, onClick }) => {
   return (
     <ExpandableCell onClick={onClick}>
       {fee !== undefined ? <span>{`${formatCommissionPercent(fee)}%`}</span> : <span>Unknown</span>}
+    </ExpandableCell>
+  )
+}
+
+interface TimeEndCellProps {
+  epoch: number
+  onClick: () => void
+}
+
+export const TimeEndCell: FC<TimeEndCellProps> = ({ epoch, onClick }) => {
+  return (
+    <ExpandableCell onClick={onClick}>
+      <TimeToEpoch epoch={epoch} />
     </ExpandableCell>
   )
 }

--- a/src/app/pages/StakingPage/Features/TableCell.tsx
+++ b/src/app/pages/StakingPage/Features/TableCell.tsx
@@ -1,25 +1,94 @@
-/**
- *
- * ExpandableRow
- *
- * Helper component for react-data-table-component custom cells
- *
- * react-data-table-component handles expandableRows correctly only for text nodes
- * or it requires to apply data-tag="allowRowEvents" to the innermost element which is hard to control
- */
-
-import { Box } from 'grommet/es6/components/Box'
 import { FC, ReactNode } from 'react'
+import { Box } from 'grommet/es6/components/Box'
+import { Text } from 'grommet/es6/components/Text'
+import { StringifiedBigInt } from '../../../../types/StringifiedBigInt'
+import { formatCommissionPercent } from '../../../lib/helpers'
+import { ShortAddress } from '../../../components/ShortAddress'
+import { AmountFormatter } from '../../..//components/AmountFormatter'
+import { ValidatorStatus } from './ValidatorList/ValidatorStatus'
 
 interface ExpandableCellProps {
   children: ReactNode
   onClick: () => void
 }
 
+/**
+ * Helper component for react-data-table-component custom cells
+ *
+ * react-data-table-component handles expandableRows correctly only for text nodes
+ * or it requires to apply data-tag="allowRowEvents" to the innermost element which is hard to control
+ */
 export const ExpandableCell: FC<ExpandableCellProps> = ({ children, onClick }) => {
   return (
     <Box onClick={onClick} style={{ display: 'inline', boxShadow: 'none' }}>
       {children}
     </Box>
+  )
+}
+
+interface IconCellProps {
+  onClick: () => void
+  src: string
+}
+
+export const IconCell: FC<IconCellProps> = ({ onClick, src }) => {
+  return (
+    <ExpandableCell onClick={onClick}>
+      <img src={src} loading="lazy" className={'logotype-small'} alt="" />
+    </ExpandableCell>
+  )
+}
+
+interface StatusCellProps {
+  onClick: () => void
+  status: 'active' | 'inactive' | 'unknown'
+}
+
+export const StatusCell: FC<StatusCellProps> = ({ onClick, status }) => {
+  return (
+    <ExpandableCell onClick={onClick}>
+      <ValidatorStatus status={status} showLabel={false}></ValidatorStatus>
+    </ExpandableCell>
+  )
+}
+
+interface NameCellProps {
+  address: string
+  onClick: () => void
+}
+
+export const NameCell: FC<NameCellProps> = ({ address, onClick }) => {
+  return (
+    <ExpandableCell onClick={onClick}>
+      <Text>
+        <ShortAddress address={address} />
+      </Text>
+    </ExpandableCell>
+  )
+}
+
+interface AmountCellProps {
+  amount: StringifiedBigInt
+  onClick: () => void
+}
+
+export const AmountCell: FC<AmountCellProps> = ({ amount, onClick }) => {
+  return (
+    <ExpandableCell onClick={onClick}>
+      <AmountFormatter amount={amount} minimumFractionDigits={0} maximumFractionDigits={0} />
+    </ExpandableCell>
+  )
+}
+
+interface FeeCellProps {
+  fee: number | undefined
+  onClick: () => void
+}
+
+export const FeeCell: FC<FeeCellProps> = ({ fee, onClick }) => {
+  return (
+    <ExpandableCell onClick={onClick}>
+      {fee !== undefined ? <span>{`${formatCommissionPercent(fee)}%`}</span> : <span>Unknown</span>}
+    </ExpandableCell>
   )
 }

--- a/src/app/pages/StakingPage/Features/TableCell.tsx
+++ b/src/app/pages/StakingPage/Features/TableCell.tsx
@@ -1,0 +1,25 @@
+/**
+ *
+ * ExpandableRow
+ *
+ * Helper component for react-data-table-component custom cells
+ *
+ * react-data-table-component handles expandableRows correctly only for text nodes
+ * or it requires to apply data-tag="allowRowEvents" to the innermost element which is hard to control
+ */
+
+import { Box } from 'grommet/es6/components/Box'
+import { FC, ReactNode } from 'react'
+
+interface ExpandableCellProps {
+  children: ReactNode
+  onClick: () => void
+}
+
+export const ExpandableCell: FC<ExpandableCellProps> = ({ children, onClick }) => {
+  return (
+    <Box onClick={onClick} style={{ display: 'inline', boxShadow: 'none' }}>
+      {children}
+    </Box>
+  )
+}

--- a/src/app/pages/StakingPage/Features/ValidatorList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/StakingPage/Features/ValidatorList/__tests__/__snapshots__/index.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   stroke: none;
 }
 
-.c18 {
+.c19 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -181,30 +181,30 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   stroke: #2ad5ab;
 }
 
-.c18 g {
+.c19 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill='none'] {
+.c19 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*='#'],
-.c18 *[STROKE*='#'] {
+.c19 *[stroke*='#'],
+.c19 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*='#'],
-.c18 *[FILL*='#'] {
+.c19 *[fill-rule],
+.c19 *[FILL-RULE],
+.c19 *[fill*='#'],
+.c19 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c20 {
+.c21 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -215,25 +215,25 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   stroke: #d24c00;
 }
 
-.c20 g {
+.c21 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c20 *:not([stroke])[fill='none'] {
+.c21 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c20 *[stroke*='#'],
-.c20 *[STROKE*='#'] {
+.c21 *[stroke*='#'],
+.c21 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c20 *[fill-rule],
-.c20 *[FILL-RULE],
-.c20 *[fill*='#'],
-.c20 *[FILL*='#'] {
+.c21 *[fill-rule],
+.c21 *[FILL-RULE],
+.c21 *[fill*='#'],
+.c21 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -269,10 +269,19 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   padding: 24px;
 }
 
-.c19 {
-  font-size: 16px;
-  line-height: 20px;
-  color: #0500e2;
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  cursor: pointer;
 }
 
 .c4 {
@@ -560,6 +569,12 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
   display: table;
 }
 
+.c20 {
+  font-size: 16px;
+  line-height: 20px;
+  color: #0500e2;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -735,18 +750,24 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 id="cell-status-oasis1qpc4ze5zzq3aa5mu5ttu4ku4ctp5t6x0asemymfz"
                 role="gridcell"
               >
-                <svg
-                  aria-label="Status is okay"
+                <div
                   class="c18"
-                  viewBox="0 0 24 24"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
                 >
-                  <path
-                    d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zM7 12l4 3 5-7"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
+                  <svg
+                    aria-label="Status is okay"
+                    class="c19"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zM7 12l4 3 5-7"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
               </div>
               <div
                 class="c16 c9 c17 rdt_TableCell"
@@ -762,24 +783,30 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 id="cell-escrow-oasis1qpc4ze5zzq3aa5mu5ttu4ku4ctp5t6x0asemymfz"
                 role="gridcell"
               >
-                <span>
-                  <div
-                    class="c0"
-                    style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
-                  >
-                    0
-                  </div>
-                  <span
-                    class="c19"
-                  >
-                    <span
-                      class="notranslate"
-                      translate="no"
+                <div
+                  class="c18"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
+                >
+                  <span>
+                    <div
+                      class="c0"
+                      style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
                     >
-                       ROSE
+                      0
+                    </div>
+                    <span
+                      class="c20"
+                    >
+                      <span
+                        class="notranslate"
+                        translate="no"
+                      >
+                         ROSE
+                      </span>
                     </span>
                   </span>
-                </span>
+                </div>
               </div>
               <div
                 class="c16 c13 c17 rdt_TableCell"
@@ -787,7 +814,15 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 id="cell-fee-oasis1qpc4ze5zzq3aa5mu5ttu4ku4ctp5t6x0asemymfz"
                 role="gridcell"
               >
-                10%
+                <div
+                  class="c18"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
+                >
+                  <span>
+                    10%
+                  </span>
+                </div>
               </div>
             </div>
             <div
@@ -807,18 +842,24 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 id="cell-status-oasis1qrfe9n26nq3t6vc9hlu9gnupwf4rm6wr0uglh3r7"
                 role="gridcell"
               >
-                <svg
-                  aria-label="Status is unknown"
-                  class="c20"
-                  viewBox="0 0 24 24"
+                <div
+                  class="c18"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
                 >
-                  <path
-                    d="M2 3.99C2 2.892 2.898 2 3.99 2h16.02C21.108 2 22 2.898 22 3.99v16.02c0 1.099-.898 1.99-1.99 1.99H3.99A1.995 1.995 0 0 1 2 20.01V3.99zM12 15v-1c0-1 0-1.5 1-2s2-1 2-2.5c0-1-1-2.5-3-2.5s-3 1.264-3 3m3 6v2"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
+                  <svg
+                    aria-label="Status is unknown"
+                    class="c21"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M2 3.99C2 2.892 2.898 2 3.99 2h16.02C21.108 2 22 2.898 22 3.99v16.02c0 1.099-.898 1.99-1.99 1.99H3.99A1.995 1.995 0 0 1 2 20.01V3.99zM12 15v-1c0-1 0-1.5 1-2s2-1 2-2.5c0-1-1-2.5-3-2.5s-3 1.264-3 3m3 6v2"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
               </div>
               <div
                 class="c16 c9 c17 rdt_TableCell"
@@ -834,24 +875,30 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 id="cell-escrow-oasis1qrfe9n26nq3t6vc9hlu9gnupwf4rm6wr0uglh3r7"
                 role="gridcell"
               >
-                <span>
-                  <div
-                    class="c0"
-                    style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
-                  >
-                    0
-                  </div>
-                  <span
-                    class="c19"
-                  >
-                    <span
-                      class="notranslate"
-                      translate="no"
+                <div
+                  class="c18"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
+                >
+                  <span>
+                    <div
+                      class="c0"
+                      style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
                     >
-                       ROSE
+                      0
+                    </div>
+                    <span
+                      class="c20"
+                    >
+                      <span
+                        class="notranslate"
+                        translate="no"
+                      >
+                         ROSE
+                      </span>
                     </span>
                   </span>
-                </span>
+                </div>
               </div>
               <div
                 class="c16 c13 c17 rdt_TableCell"
@@ -859,7 +906,15 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 id="cell-fee-oasis1qrfe9n26nq3t6vc9hlu9gnupwf4rm6wr0uglh3r7"
                 role="gridcell"
               >
-                20%
+                <div
+                  class="c18"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
+                >
+                  <span>
+                    20%
+                  </span>
+                </div>
               </div>
             </div>
             <div
@@ -879,18 +934,24 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 id="cell-status-oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe"
                 role="gridcell"
               >
-                <svg
-                  aria-label="Status is critical"
-                  class="c20"
-                  viewBox="0 0 24 24"
+                <div
+                  class="c18"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
                 >
-                  <path
-                    d="M12.703 2.703a.99.99 0 0 0-1.406 0l-8.594 8.594a.99.99 0 0 0 0 1.406l8.594 8.594a.99.99 0 0 0 1.406 0l8.594-8.594a.99.99 0 0 0 0-1.406l-8.594-8.594zM8.983 14.7 14.7 8.983m-5.717 0L14.7 14.7"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
+                  <svg
+                    aria-label="Status is critical"
+                    class="c21"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12.703 2.703a.99.99 0 0 0-1.406 0l-8.594 8.594a.99.99 0 0 0 0 1.406l8.594 8.594a.99.99 0 0 0 1.406 0l8.594-8.594a.99.99 0 0 0 0-1.406l-8.594-8.594zM8.983 14.7 14.7 8.983m-5.717 0L14.7 14.7"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
               </div>
               <div
                 class="c16 c9 c17 rdt_TableCell"
@@ -906,24 +967,30 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 id="cell-escrow-oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe"
                 role="gridcell"
               >
-                <span>
-                  <div
-                    class="c0"
-                    style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
-                  >
-                    0
-                  </div>
-                  <span
-                    class="c19"
-                  >
-                    <span
-                      class="notranslate"
-                      translate="no"
+                <div
+                  class="c18"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
+                >
+                  <span>
+                    <div
+                      class="c0"
+                      style="display: inline-flex; white-space: nowrap; font-family: "Roboto mono", monospace; letter-spacing: 0;"
                     >
-                       ROSE
+                      0
+                    </div>
+                    <span
+                      class="c20"
+                    >
+                      <span
+                        class="notranslate"
+                        translate="no"
+                      >
+                         ROSE
+                      </span>
                     </span>
                   </span>
-                </span>
+                </div>
               </div>
               <div
                 class="c16 c13 c17 rdt_TableCell"
@@ -931,7 +998,15 @@ exports[`<ValidatorList  /> list should match snapshot 1`] = `
                 id="cell-fee-oasis1qzyqaxestzlum26e2vdgvkerm6d9qgdp7gh2pxqe"
                 role="gridcell"
               >
-                20%
+                <div
+                  class="c18"
+                  style="display: inline; box-shadow: none;"
+                  tabindex="0"
+                >
+                  <span>
+                    20%
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
@@ -20,7 +20,7 @@ import { selectIsAddressInWallet } from 'app/state/selectIsAddressInWallet'
 import { Box } from 'grommet/es6/components/Box'
 import { Text } from 'grommet/es6/components/Text'
 import { Down } from 'grommet-icons/es6/icons/Down'
-import React, { memo } from 'react'
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { dataTableCustomStyles } from 'styles/theme/dataTableTheme'
@@ -32,6 +32,7 @@ import { formatCommissionPercent } from 'app/lib/helpers'
 import { intlDateTimeFormat } from 'app/components/DateFormatter/intlDateTimeFormat'
 import { StakeSubnavigation } from '../../../AccountPage/Features/StakeSubnavigation'
 import { selectAccountAvailableBalance } from '../../../../state/account/selectors'
+import { ExpandableCell } from '../TableCell'
 
 interface Props {}
 
@@ -61,14 +62,20 @@ export const ValidatorList = memo((props: Props) => {
       cell: datum =>
         datum.media?.logotype &&
         isWebUri(datum.media.logotype) && (
-          <img src={datum.media.logotype} loading="lazy" className={'logotype-small'} alt="" />
+          <ExpandableCell onClick={() => rowClicked(datum)}>
+            <img src={datum.media.logotype} loading="lazy" className={'logotype-small'} alt="" />
+          </ExpandableCell>
         ),
       width: '34px',
     },
     {
       name: '',
       id: 'status',
-      cell: datum => <ValidatorStatus status={datum.status} showLabel={false}></ValidatorStatus>,
+      cell: datum => (
+        <ExpandableCell onClick={() => rowClicked(datum)}>
+          <ValidatorStatus status={datum.status} showLabel={false}></ValidatorStatus>
+        </ExpandableCell>
+      ),
       width: '34px',
     },
     {
@@ -79,9 +86,11 @@ export const ValidatorList = memo((props: Props) => {
       minWidth: '15ex',
       cell: datum =>
         datum.name ?? (
-          <Text data-tag="allowRowEvents">
-            <ShortAddress address={datum.address} />
-          </Text>
+          <ExpandableCell onClick={() => rowClicked(datum)}>
+            <Text>
+              <ShortAddress address={datum.address} />
+            </Text>
+          </ExpandableCell>
         ),
       sortable: true,
       sortFunction: (row1, row2) => (row1.name ?? row1.address).localeCompare(row2.name ?? row2.address),
@@ -94,7 +103,9 @@ export const ValidatorList = memo((props: Props) => {
       right: true,
       hide: 'sm',
       cell: datum => (
-        <AmountFormatter amount={datum.escrow} minimumFractionDigits={0} maximumFractionDigits={0} />
+        <ExpandableCell onClick={() => rowClicked(datum)}>
+          <AmountFormatter amount={datum.escrow} minimumFractionDigits={0} maximumFractionDigits={0} />
+        </ExpandableCell>
       ),
       sortable: true,
       sortFunction: (row1, row2) => Number(BigInt(row1.escrow ?? 0) - BigInt(row2.escrow ?? 0)),

--- a/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
@@ -3,10 +3,7 @@
  * ValidatorList
  *
  */
-import { AmountFormatter } from 'app/components/AmountFormatter'
 import { ErrorFormatter } from 'app/components/ErrorFormatter'
-import { ShortAddress } from 'app/components/ShortAddress'
-import { ValidatorStatus } from 'app/pages/StakingPage/Features/ValidatorList/ValidatorStatus'
 import { stakingActions } from 'app/state/staking'
 import {
   selectSelectedAddress,
@@ -18,7 +15,6 @@ import {
 import { Validator } from 'app/state/staking/types'
 import { selectIsAddressInWallet } from 'app/state/selectIsAddressInWallet'
 import { Box } from 'grommet/es6/components/Box'
-import { Text } from 'grommet/es6/components/Text'
 import { Down } from 'grommet-icons/es6/icons/Down'
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -28,11 +24,10 @@ import { TypeSafeDataTable, ITypeSafeDataTableColumn } from 'types/TypeSafeDataT
 import { isWebUri } from 'valid-url'
 
 import { ValidatorItem } from './ValidatorItem'
-import { formatCommissionPercent } from 'app/lib/helpers'
 import { intlDateTimeFormat } from 'app/components/DateFormatter/intlDateTimeFormat'
 import { StakeSubnavigation } from '../../../AccountPage/Features/StakeSubnavigation'
 import { selectAccountAvailableBalance } from '../../../../state/account/selectors'
-import { ExpandableCell } from '../TableCell'
+import { AmountCell, FeeCell, IconCell, NameCell, StatusCell } from '../TableCell'
 
 interface Props {}
 
@@ -62,20 +57,14 @@ export const ValidatorList = memo((props: Props) => {
       cell: datum =>
         datum.media?.logotype &&
         isWebUri(datum.media.logotype) && (
-          <ExpandableCell onClick={() => rowClicked(datum)}>
-            <img src={datum.media.logotype} loading="lazy" className={'logotype-small'} alt="" />
-          </ExpandableCell>
+          <IconCell onClick={() => rowClicked(datum)} src={datum.media.logotype} />
         ),
       width: '34px',
     },
     {
       name: '',
       id: 'status',
-      cell: datum => (
-        <ExpandableCell onClick={() => rowClicked(datum)}>
-          <ValidatorStatus status={datum.status} showLabel={false}></ValidatorStatus>
-        </ExpandableCell>
-      ),
+      cell: datum => <StatusCell onClick={() => rowClicked(datum)} status={datum.status} />,
       width: '34px',
     },
     {
@@ -84,14 +73,7 @@ export const ValidatorList = memo((props: Props) => {
       selector: 'name',
       maxWidth: '40ex',
       minWidth: '15ex',
-      cell: datum =>
-        datum.name ?? (
-          <ExpandableCell onClick={() => rowClicked(datum)}>
-            <Text>
-              <ShortAddress address={datum.address} />
-            </Text>
-          </ExpandableCell>
-        ),
+      cell: datum => datum.name ?? <NameCell address={datum.address} onClick={() => rowClicked(datum)} />,
       sortable: true,
       sortFunction: (row1, row2) => (row1.name ?? row1.address).localeCompare(row2.name ?? row2.address),
     },
@@ -102,11 +84,7 @@ export const ValidatorList = memo((props: Props) => {
       width: '28ex',
       right: true,
       hide: 'sm',
-      cell: datum => (
-        <ExpandableCell onClick={() => rowClicked(datum)}>
-          <AmountFormatter amount={datum.escrow} minimumFractionDigits={0} maximumFractionDigits={0} />
-        </ExpandableCell>
-      ),
+      cell: datum => <AmountCell amount={datum.escrow} onClick={() => rowClicked(datum)} />,
       sortable: true,
       sortFunction: (row1, row2) => Number(BigInt(row1.escrow ?? 0) - BigInt(row2.escrow ?? 0)),
     },
@@ -117,8 +95,7 @@ export const ValidatorList = memo((props: Props) => {
       sortable: true,
       width: '110px',
       right: true,
-      cell: datum =>
-        datum.current_rate !== undefined ? `${formatCommissionPercent(datum.current_rate)}%` : 'Unknown',
+      cell: datum => <FeeCell fee={datum.current_rate} onClick={() => rowClicked(datum)} />,
       sortFunction: (row1, row2) => (row1.current_rate ?? 0) - (row2.current_rate ?? 0),
       hide: 'sm',
     },

--- a/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
+++ b/src/app/pages/StakingPage/Features/ValidatorList/index.tsx
@@ -84,7 +84,14 @@ export const ValidatorList = memo((props: Props) => {
       width: '28ex',
       right: true,
       hide: 'sm',
-      cell: datum => <AmountCell amount={datum.escrow} onClick={() => rowClicked(datum)} />,
+      cell: datum => (
+        <AmountCell
+          amount={datum.escrow}
+          onClick={() => rowClicked(datum)}
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+        />
+      ),
       sortable: true,
       sortFunction: (row1, row2) => Number(BigInt(row1.escrow ?? 0) - BigInt(row2.escrow ?? 0)),
     },


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/oasis-wallet-web/issues/1858

note: there is special `data-tag="allowRowEvents"` attribute in react-data-table-component that we could add to last nodes. For me, it wasn't reliable with svgs (clicking paths when attr is set in svg) and it would require to pass a prop via multiple generic components to get to NoTranslate for example. It is also weird to bind events with data attrs in react. I am going with `onClick` handler here. 
