### PR TITLE
Prevent AddressBox in expanded row from resizing whole validators table

### DIFF
--- a/.changelog/2035.bugfix.md
+++ b/.changelog/2035.bugfix.md
@@ -1,0 +1,1 @@
+Prevent AddressBox in expanded row from resizing whole validators table

--- a/src/app/components/AddressBox/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/AddressBox/__tests__/__snapshots__/index.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`<AddressBox /> should render address properly 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  width: 690px;
+  width: min(690px,100%);
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
@@ -336,7 +336,7 @@ exports[`<EditableNameBox /> should render name properly 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  width: 690px;
+  width: min(690px,100%);
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;

--- a/src/app/components/AddressBox/index.tsx
+++ b/src/app/components/AddressBox/index.tsx
@@ -82,7 +82,7 @@ const Container = ({ address, border, children, copyToClipboard, separator }: Co
           flex
           pad={{ bottom: isMobile ? 'small' : separator ? 'xsmall' : undefined }}
           margin={{ right: isMobile ? undefined : 'large' }}
-          width="690px" // keep the same width for address and name variants
+          width="min(690px, 100%)" // keep the same width for address and name variants
         >
           {copyToClipboard === 'icon' && <CopyAddressButton address={address} />}
           <Box flex>{children}</Box>

--- a/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/pages/AccountPage/__tests__/__snapshots__/index.test.tsx.snap
@@ -343,7 +343,7 @@ exports[`<AccountPage  /> should match snapshot 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  width: 690px;
+  width: min(690px,100%);
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/32346cb5-ade5-4df4-8ee8-edd298f3e025 

After

https://github.com/user-attachments/assets/73f81a49-84eb-4595-abdc-cc21a5bac8c8

