### PR TITLE
Don't throw on failed debonding transaction

### DIFF
--- a/.changelog/2187.bugfix.md
+++ b/.changelog/2187.bugfix.md
@@ -1,0 +1,1 @@
+Don't throw on failed debonding transaction

--- a/src/vendors/nexus.ts
+++ b/src/vendors/nexus.ts
@@ -112,13 +112,13 @@ export function getNexusAPIs(url: string | 'https://nexus.oasis.io/v1/') {
       // Temporary workaround for missing amount in staking.ReclaimEscrow
       const transactionsWithFixedAmount = await Promise.all(
         mergedTransactions.map(async transaction => {
-          if (transaction.method === ConsensusTxMethod.StakingReclaimEscrow) {
+          if (transaction.method === ConsensusTxMethod.StakingReclaimEscrow && transaction.success) {
             const eventsResponse = await api.consensusEventsGet({
               limit: 1,
               txHash: transaction.hash,
               type: ConsensusEventType.StakingEscrowDebondingStart,
             })
-            const amount = (eventsResponse.events[0].body as { amount?: number })?.amount
+            const amount = (eventsResponse.events[0]?.body as { amount?: number })?.amount
             return {
               ...transaction,
               body: {


### PR DESCRIPTION
e.g. https://wallet.oasis.io/account/oasis1qqazrhk6l3v23nzk098p0dq9xlv5rfkpn50mjxdd
![image](https://github.com/user-attachments/assets/f27b890f-14d9-49ce-be98-dbdf8a2c10f9)
