### PR TITLE
Display unhandled transaction methods as generic not unrecognized

### DIFF
--- a/.changelog/2215.bugfix.md
+++ b/.changelog/2215.bugfix.md
@@ -1,0 +1,1 @@
+Display unhandled transaction methods as generic not unrecognized

--- a/src/app/components/Transaction/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Transaction/__tests__/__snapshots__/index.test.tsx.snap
@@ -496,12 +496,12 @@ exports[`<Transaction  /> should handle unknown transaction types gracefully 1`]
     class="c1"
   >
     <svg
-      aria-label="Alert"
+      aria-label="New"
       class="c2"
       viewBox="0 0 24 24"
     >
       <path
-        d="M12 17v2m0-9v6m0-13L2 22h20L12 3z"
+        d="M12 1v22M2 6l20 12m0-12L2 18"
         fill="none"
         stroke="#000"
         stroke-width="2"
@@ -513,7 +513,7 @@ exports[`<Transaction  /> should handle unknown transaction types gracefully 1`]
     <span
       class="c4"
     >
-      account.transaction.unrecognizedTransaction.header
+      account.transaction.genericTransaction.header
     </span>
   </header>
   <div
@@ -558,7 +558,7 @@ exports[`<Transaction  /> should handle unknown transaction types gracefully 1`]
                 class="c14"
                 style="opacity: 0.5;"
               >
-                account.transaction.unrecognizedTransaction.destination
+                account.transaction.genericTransaction.destination
               </span>
               <div
                 class="c7 c15"

--- a/src/app/components/Transaction/index.tsx
+++ b/src/app/components/Transaction/index.tsx
@@ -25,7 +25,6 @@ import { New } from 'grommet-icons/es6/icons/New'
 import { LinkPrevious } from 'grommet-icons/es6/icons/LinkPrevious'
 import { LinkNext } from 'grommet-icons/es6/icons/LinkNext'
 import { Atm } from 'grommet-icons/es6/icons/Atm'
-import { Alert } from 'grommet-icons/es6/icons/Alert'
 import { MuiLocalFireDepartmentIcon } from '../../../styles/theme/icons/mui-icons/MuiLocalFireDepartmentIcon'
 // eslint-disable-next-line no-restricted-imports
 import type { Icon } from 'grommet-icons/es6/icons'
@@ -114,18 +113,18 @@ export function Transaction(props: TransactionProps) {
     ),
   }
 
-  const unrecognizedTransaction: TransactionDictionary[transactionTypes.TransactionType][TransactionSide] = {
-    destination: t('account.transaction.unrecognizedTransaction.destination', 'Other address'),
-    icon: Alert,
-    header: () => (
-      <Trans
-        i18nKey="account.transaction.unrecognizedTransaction.header"
-        t={t}
-        values={{ method: transaction.type }}
-        defaults="Unrecognized transaction, method '{{method}}'"
-      />
-    ),
-  }
+  const unrecognizedTransaction: TransactionDictionary[transactionTypes.TransactionType][TransactionSide] =
+    genericTransaction
+  // destination: t('account.transaction.unrecognizedTransaction.destination', 'Other address'),
+  // icon: Alert,
+  // header: () => (
+  //   <Trans
+  //     i18nKey="account.transaction.unrecognizedTransaction.header"
+  //     t={t}
+  //     values={{ method: transaction.type }}
+  //     defaults="Unrecognized transaction, method '{{method}}'"
+  //   />
+  // ),
 
   // @TODO: This could probably cleverly be moved outside of the component
   //for better readability and marginal performance gain, but for now


### PR DESCRIPTION
Makes https://github.com/oasisprotocol/wallet/issues/2175 less scary