### PR TITLE
Prevent throwing unknown error in transactions list

### DIFF
--- a/.changelog/2216.bugfix.md
+++ b/.changelog/2216.bugfix.md
@@ -1,0 +1,1 @@
+Prevent throwing unknown error in transactions list

--- a/src/vendors/nexus.ts
+++ b/src/vendors/nexus.ts
@@ -267,7 +267,7 @@ function parseTransactionsList(list: (NexusTransaction | ExtendedRuntimeTransact
             ? TransactionStatus.Successful
             : TransactionStatus.Failed,
         timestamp: transactionDate.getTime(),
-        to: t.to_eth ?? t.to ?? (t.body as { to?: string }).to ?? undefined,
+        to: t.to_eth ?? t.to ?? (t.body as { to?: string })?.to ?? undefined,
         type: getTransactionType(t.method),
         runtimeName: t.runtimeName,
         runtimeId: t.runtimeId,


### PR DESCRIPTION
When I was testing https://github.com/oasisprotocol/wallet/pull/2215 I grabbed random test account addr from CLI and ended up with `Couldn't load transactions. Unknown error: Cannot read properties of undefined (reading 'to')` 

https://pr-2216.oasis-wallet.pages.dev/account/oasis1qzgc7dvlls36q47z5y6dvu6ylaa78rkrduqtxgdr
vs https://wallet.oasis.io/account/oasis1qzgc7dvlls36q47z5y6dvu6ylaa78rkrduqtxgdr

As we are not filtering txs in Wallet and fetch all layers we may hit edge case: 
- encrypted tx (with envelope)
- any other tx with missing body




