### PR TITLE
Adjust margins for mobile edge to edge layout

### DIFF
--- a/.changelog/2223.bugfix.md
+++ b/.changelog/2223.bugfix.md
@@ -1,0 +1,1 @@
+Adjust margins for mobile edge to edge layout

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,6 +4,9 @@ const config: CapacitorConfig = {
   appId: 'org.oasisprotocol.wallet',
   appName: 'ROSE Wallet',
   webDir: 'build',
+  android: {
+    adjustMarginsForEdgeToEdge: 'force',
+  },
   server: {
     androidScheme: 'https',
   },


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/wallet/issues/2221 

- the fastest solution https://capacitorjs.com/docs/config -> `adjustMarginsForEdgeToEdge`

alternatives:
- maybe https://capawesome.io/plugins/android-edge-to-edge-support/
- or
```
android: {
  adjustMarginsForEdgeToEdge: 'auto', 
},
plugins: {
  StatusBar: {
    setOverlaysWebView: true,
  },
},
```
and controlling padding in app just for mobile builds (header/footer/check dialogs overflow etc)