### PR TITLE
Keep mobile versions in sync

### DIFF
--- a/.changelog/2228.internal.md
+++ b/.changelog/2228.internal.md
@@ -1,0 +1,1 @@
+Keep mobile versions in sync

--- a/internals/scripts/changelog.js
+++ b/internals/scripts/changelog.js
@@ -52,3 +52,18 @@ prettier
   })
 
 execSync(`towncrier build --version ${version}`, { stdio: 'inherit' })
+
+// Android app needs to bump versionName in build.gradle
+const gradleFilePath = './android/app/build.gradle'
+const gradleContent = fs.readFileSync(gradleFilePath, 'utf8')
+const updatedGradleContent = gradleContent.replace(/versionName\s+"[\d.]+"/, `versionName "${version}"`)
+fs.writeFileSync(gradleFilePath, updatedGradleContent, 'utf8')
+
+// iOS app needs to bump MARKETING_VERSION in project.pbxproj
+const pbxprojFilePath = './ios/App/App.xcodeproj/project.pbxproj'
+const pbxprojContent = fs.readFileSync(pbxprojFilePath, 'utf8')
+const updatedPbxprojContent = pbxprojContent.replace(
+  /MARKETING_VERSION = [\d.]+;/g,
+  `MARKETING_VERSION = ${version};`,
+)
+fs.writeFileSync(pbxprojFilePath, updatedPbxprojContent, 'utf8')


### PR DESCRIPTION
`yarn changelog`
```
-        versionName "2.4.0"
+        versionName "2.5.0"
```
```
-                               MARKETING_VERSION = 2.4.0;
+                               MARKETING_VERSION = 2.5.0;
```

