### PR TITLE
Update internal mobile build versions

### DIFF
--- a/.changelog/2229.internal.md
+++ b/.changelog/2229.internal.md
@@ -1,0 +1,1 @@
+Update internal mobile build versions


### PR DESCRIPTION
Built on top of https://github.com/oasisprotocol/wallet/pull/2228 
Closes https://github.com/oasisprotocol/wallet/issues/2227

`yarn changelog`

```
-        versionCode 2
-        versionName "2.4.0"
+        versionCode 20050004161
+        versionName "2.5.0"
```

```
-                              CURRENT_PROJECT_VERSION = 2;
+                              CURRENT_PROJECT_VERSION = 20050004161;
-                              MARKETING_VERSION = 2.4.0;
+                              MARKETING_VERSION = 2.5.0;
```