### PR TITLE
Adjust mobile version code value with Google Play versioning boundaries

### DIFF
--- a/.changelog/2231.internal.md
+++ b/.changelog/2231.internal.md
@@ -1,0 +1,1 @@
+Update internal mobile build versions

--- a/internals/scripts/changelog.js
+++ b/internals/scripts/changelog.js
@@ -57,9 +57,12 @@ execSync(`towncrier build --version ${version}`, { stdio: 'inherit' })
 const gitCommitCount = execSync('git rev-list --count HEAD', { encoding: 'utf8' }).trim()
 const versionPrefix = version
   .split('.')
-  .map((n, i) => (i > 0 ? n.padStart(3, '0') : n))
+  .map((n, i) => (i > 0 ? n.padStart(2, '0') : n))
   .join('')
-const newVersionCode = `${versionPrefix}${gitCommitCount}`
+
+// The greatest value Google Play allows for versionCode is 2100000000
+// https://developer.android.com/studio/publish/versioning
+const newVersionCode = `${versionPrefix}${gitCommitCount.padStart(4, '0')}`
 
 // Android app needs to bump versionName in build.gradle
 const gradleFilePath = './android/app/build.gradle'


### PR DESCRIPTION
Related https://github.com/oasisprotocol/wallet/issues/2227 and https://github.com/oasisprotocol/wallet/pull/2229

```
// 2.5.0
versionCode 20050004163 // master
versionCode 205004164 // branch  
            2100000000 // max 
```